### PR TITLE
Fixes http://forge.taotesting.com/issues/3402.

### DIFF
--- a/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
+++ b/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
@@ -1,3 +1,26 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+/**
+ *
+ * @author dieter <dieter@taotesting.com>
+ */
 define([
     'jquery',
     'lodash',
@@ -5,76 +28,93 @@ define([
 ], function ($, _, styleEditor) {
     'use strict';
 
-    var fontSizeChanger = function () {
-        var fontSizeChanger = $('#item-editor-font-size-changer'),
-            target = fontSizeChanger.data('target'),
-            headSelector = target + ' .item-title',
-            bodySelector = target + ' .qti-itemBody *',
-            headFontSize = parseInt($(headSelector).css('font-size'), 10),
-            bodyFontSize = parseInt($(bodySelector).css('font-size'), 10),
-            headBodyDiff = headFontSize - bodyFontSize,
-            resetButton =  fontSizeChanger.parents('.reset-group').find('[data-role="font-size-reset"]'),
-            input = $('#item-editor-font-size-text');
 
+    /**
+     * Changes the font size in the Style Editor
+     */
+    var fontSizeChanger = function () {
+        var $fontSizeChanger = $('#item-editor-font-size-changer'),
+            itemSelector = $fontSizeChanger.data('target'),
+            $item = $(itemSelector),
+            itemFontSize = parseInt($item.css('font-size'), 10),
+            $resetBtn =  $fontSizeChanger.parents('.reset-group').find('[data-role="font-size-reset"]'),
+            $input = $('#item-editor-font-size-text');
+
+        /**
+         * Writes new font size to virtual style sheet
+         */
         var resizeFont = function() {
-            var headFontSize = bodyFontSize + headBodyDiff;
-            styleEditor.apply(headSelector, 'font-size', headFontSize.toString() + 'px');
-            styleEditor.apply(bodySelector, 'font-size', bodyFontSize.toString() + 'px');
+            styleEditor.apply(itemSelector + ' *', 'font-size', itemFontSize.toString() + 'px');
         };
 
-        fontSizeChanger.find('a').on('click', function(e) {
+        /**
+         * Handle input field
+         */
+        $fontSizeChanger.find('a').on('click', function(e) {
             e.preventDefault();
             if($(this).data('action') === 'reduce') {
-                if(bodyFontSize <= 10) {
+                if(itemFontSize <= 10) {
                     return;
                 }
-                bodyFontSize--;
+                itemFontSize--;
             }
             else {
-                bodyFontSize++;
+                itemFontSize++;
             }
             resizeFont();
-            input.val(bodyFontSize);
+            $input.val(itemFontSize);
             $(this).parent().blur();
         });
 
-        input.on('keydown', function(e) {
+        /**
+         * Disallows invalid characters
+         */
+        $input.on('keydown', function(e) {
             var c = e.keyCode;
-            return (_.contains([8, 37, 39, 46], c)
-                || (c >= 48 && c <= 57)
-                || (c >= 96 && c <= 105));
+            return (_.contains([8, 37, 39, 46], c) ||
+                (c >= 48 && c <= 57) ||
+                (c >= 96 && c <= 105));
         });
 
-        input.on('blur', function() {
-            bodyFontSize = parseInt(this.value, 10);
+        /**
+         * Apply font size on blur
+         */
+        $input.on('blur', function() {
+            itemFontSize = parseInt(this.value, 10);
             resizeFont();
         });
 
-        input.on('keydown', function(e) {
+        /**
+         * Apply font size on enter
+         */
+        $input.on('keydown', function(e) {
             var c = e.keyCode;
             if(c === 13) {
-                input.trigger('blur');
+                $input.trigger('blur');
             }
         });
 
-        resetButton.on('click', function () {
-            input.val('');
-            styleEditor.apply(headSelector, 'font-size');
-            styleEditor.apply(bodySelector, 'font-size');
+        /**
+         * Remove font size from virtual style sheet
+         */
+        $resetBtn.on('click', function () {
+            $input.val('');
+            styleEditor.apply(itemSelector + ' *', 'font-size');
         });
 
-        // style loaded from style sheet
+        /**
+         * style loaded from style sheet
+         */
         $(document).on('customcssloaded.styleeditor', function(e, style) {
-            if(style[bodySelector] && style[bodySelector]['font-size']) {
-                input.val(parseInt(style[bodySelector]['font-size'], 10));
-                input.trigger('blur');
+            if(style[itemSelector] && style[itemSelector]['font-size']) {
+                $input.val(parseInt(style[itemSelector]['font-size'], 10));
+                $input.trigger('blur');
             }
             else {
-                input.val(parseInt($(bodySelector).css('font-size'), 10));
+                $input.val(parseInt($item.css('font-size'), 10));
             }
         });
     };
 
     return fontSizeChanger;
 });
-

--- a/views/js/qtiCreator/editor/styleEditor/styleEditor.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleEditor.js
@@ -1,3 +1,27 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+/**
+ *
+ * @author dieter <dieter@taotesting.com>
+ */
+
 define([
     'jquery',
     'lodash',
@@ -14,7 +38,7 @@ define([
     UrlParser,
     cssTpl
     ) {
-   // 'use strict'
+    'use strict';
 
     var itemConfig;
 

--- a/views/templates/QtiCreator/index.tpl
+++ b/views/templates/QtiCreator/index.tpl
@@ -117,28 +117,28 @@ use oat\tao\helpers\Template;
                             <span class="icon-eraser reset-button" data-value="background-color"
                                   title="<?= __('Remove custom background color') ?>"></span>
                             <span class="color-trigger" id="initial-bg" data-value="background-color"
-                                  data-target="body div.qti-item.tao-scope, body div.qti-item.tao-scope .qti-associateInteraction .result-area > li > .target"></span>
+                                  data-target="body div.qti-item, body div.qti-item .qti-associateInteraction .result-area > li > .target"></span>
                     </div>
                     <div class="clearfix">
                         <label for="initial-color" class="truncate"><?= __('Text color') ?></label>
                             <span class="icon-eraser reset-button" data-value="color"
                                   title="<?= __('Remove custom text color') ?>"></span>
                             <span class="color-trigger" id="initial-color" data-value="color"
-                                  data-target="body div.qti-item.tao-scope"></span>
+                                  data-target="body div.qti-item"></span>
                     </div>
                     <div class="clearfix">
                         <label for="initial-color" class="truncate"><?= __('Border color') ?></label>
                             <span class="icon-eraser reset-button" data-value="color"
                                   title="<?= __('Remove custom border color') ?>"></span>
                             <span class="color-trigger" id="initial-color" data-value="border-color"
-                                  data-target="body div.qti-item.tao-scope .solid,body div.qti-item.tao-scope .matrix, body div.qti-item.tao-scope table.matrix th, body div.qti-item.tao-scope table.matrix td"></span>
+                                  data-target="body div.qti-item .solid,body div.qti-item .matrix, body div.qti-item table.matrix th, body div.qti-item table.matrix td"></span>
                     </div>
                     <div class="clearfix">
                         <label for="initial-color" class="truncate"><?= __('Table headings') ?></label>
                             <span class="icon-eraser reset-button" data-value="color"
                                   title="<?= __('Remove custom background color') ?>"></span>
                             <span class="color-trigger" id="initial-color" data-value="background-color"
-                                  data-target="body div.qti-item.tao-scope .matrix th"></span>
+                                  data-target="body div.qti-item .matrix th"></span>
                     </div>
                 </div>
             </div>
@@ -150,7 +150,7 @@ use oat\tao\helpers\Template;
 
             <div class="reset-group">
                 <select
-                    data-target="body div.qti-item.tao-scope"
+                    data-target="body div.qti-item"
                     id="item-editor-font-selector"
                     data-has-search="false"
                     data-placeholder="<?= __('Default') ?>"
@@ -164,7 +164,7 @@ use oat\tao\helpers\Template;
         <div class="panel">
             <div><?= __('Font size') ?></div>
             <div class="reset-group">
-                            <span id="item-editor-font-size-changer" data-target="body div.qti-item.tao-scope">
+                            <span id="item-editor-font-size-changer" data-target="body div.qti-item">
                                 <a href="#" data-action="reduce" title="<?= __('Reduce font size') ?>"
                                    class="icon-smaller"></a>
                                 <a href="#" data-action="enlarge" title="<?= __('Enlarge font size') ?>"
@@ -192,7 +192,7 @@ use oat\tao\helpers\Template;
                     'Change the width of the item. By default the item has a width of 100% and adapts to the size of any screen. The maximal width is by default 1024px - this will also change when you set a custom with.'
                 ) ?>
             </div>
-            <div id="item-editor-item-resizer" data-target="body div.qti-item.tao-scope">
+            <div id="item-editor-item-resizer" data-target="body div.qti-item">
                 <label class="smaller-prompt">
                     <input type="radio" name="item-width-prompt" checked value="no-slider">
                     <span class="icon-radio"></span>


### PR DESCRIPTION
Since I had to touch styleEditor.js anyway I added the missing license as well as a 'use strict'. Inside the template I removed the legacy class .tao-scope for the target selector. This was originally required because it had been use as a wrapper in .qti-css.
The fontSizeChanger originally supported an automatic change of the font-size of the item title. The item title has since been removed which led to many lines of legacy code. They are now gone and the distinction between headFontSize and bodyFontSize is no longer required