### PR TITLE
fix the one more char bug in maxlength

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -116,8 +116,6 @@ define([
                 var editor = ckEditor.replace($container.find('.text-container')[0], ckeOptions);
                 // store the instance inside data on the container
                 $container.data('editor', editor);
-
-
             }
             else {
                 $el.bind('keyup change', function(e) {
@@ -156,6 +154,10 @@ define([
                             evt.cancel();
                         }else {
                             evt.preventDefault();
+                        }
+                        if(maxLength){
+                            var value = _getTextareaValue(interaction);
+                            setText(interaction,value);
                         }
                     }
                     updateCounter();
@@ -555,13 +557,7 @@ define([
 
         if ( _getFormat(interaction) === 'xhtml') {
             var editor = _ckEditor(interaction);
-            editor.setData(text,{
-                callback : function(){
-                    var range = editor.createRange();
-                    range.moveToElementEditEnd( range.root );
-                    editor.getSelection().selectRanges( [ range ] );
-                }
-            });
+            editor.setData(text);
         }
         else {
             $container.find('textarea').val(text);


### PR DESCRIPTION
The idea is to combine the previous technique for preventing inserting too much characters with the new one to get rid of the final char : 

The new technique prevent the `keydown` event to be propagated so there's is no risk to continue typing after the text was replace by the maximum allowed ( old technique )