### PR TITLE
take spaces into account

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -186,7 +186,7 @@ define([
                  */
                 var getCharsCount = function(){
                     var value = _getTextareaValue(interaction);
-                    return value.trim().length;
+                    return value.length;
                 };
 
                 /**


### PR DESCRIPTION
Spaces at the beginning and end of a string was not taken into account when calculating the length of string.