### PR TITLE
Capability to disable the tool

### DIFF
--- a/views/js/qtiCreator/editor/customElementRegistryFactory.js
+++ b/views/js/qtiCreator/editor/customElementRegistryFactory.js
@@ -45,7 +45,9 @@ define([
             var paths = {};
 
             _(hooks).values().each(function(hook){
-
+                if (hook.manifest && hook.manifest.disabled) {
+                    return;
+                }
                 if(isValidHook(hook)){
 
                     var id = hook.typeIdentifier;


### PR DESCRIPTION
Implementation capability to disable the tool:
Set parameter `disabled` in the `pciCreator.json` (manifest) to true to disable the tool.
Example: 
https://github.com/oat-sa/extension-parcc-student-tools/blob/TAO-655_Student_Tools_placeholders/views/js/picCreator/dev/parccWritingTools/picCreator.json#L21