### PR TITLE
Fix state erasing after change (deffered call of change event).

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -45,7 +45,7 @@ define([
 
         //test when some data is entering in the input field
         //@todo plug the validator + tooltip
-        $element.on('keyup', function(){
+        $element.on('keyup.commonRenderer', function(){
             $element.removeClass('field-error');
             if(!patt.test($element.val())){
                 $element.addClass('field-error');
@@ -115,10 +115,10 @@ define([
                 // replace the textarea with ckEditor
                 var editor = ckEditor.replace($container.find('.text-container')[0], ckeOptions);
                 // store the instance inside data on the container
-                $container.data('editor', editor);
+                _setCKEditor(interaction, editor);
             }
             else {
-                $el.bind('keyup change', function(e) {
+                $el.on('keyup.commonRenderer change.commonRenderer', function(e) {
                     containerHelper.triggerResponseChangeEvent(interaction, {});
                 });
             }
@@ -203,7 +203,7 @@ define([
                 ];
 
                 if (_getFormat(interaction) === "xhtml") {
-                    _ckEditor(interaction).on('key',function(e){
+                    _getCKEditor(interaction).on('key',function(e){
                         if (_.contains(keycodes,e.data.keyCode)){
                             updateCounter();
                         }else{
@@ -211,7 +211,7 @@ define([
                         }
                     });
                 }else{
-                    $textarea.on('keydown',function(e){
+                    $textarea.on('keydown.commonRenderer',function(e){
                        if (_.contains(keycodes,e.which)){
                             updateCounter();
                         }else{
@@ -246,7 +246,7 @@ define([
 
                 if (minStrings > 0) {
 
-                    $el.on('blur', function() {
+                    $el.on('blur.commonRenderer', function() {
                         setTimeout(function() {
                             //checking if the user was clicked outside of the input fields
 
@@ -271,14 +271,14 @@ define([
                 }
             }
 
-            //set the fileds pattern mask
+            //set the fields pattern mask
             if (attributes.patternMask) {
                 $el.each(function() {
                     _setPattern($(this), attributes.patternMask);
                 });
             }
 
-            //set the fileds placeholder
+            //set the fields placeholder
             if (attributes.placeholderText) {
                 /**
                  * The type of the fileds placeholder:
@@ -306,7 +306,7 @@ define([
      */
     var resetResponse = function(interaction) {
         if (_getFormat(interaction) === 'xhtml') {
-            _ckEditor(interaction).setData('');
+            _getCKEditor(interaction).setData('');
         }else{
             containerHelper.get(interaction).find('input, textarea').val('');
         }
@@ -330,14 +330,10 @@ define([
             interaction.getContainer().find('#'+identifier).val(value);
         };
 
-        var _setVal = function(value) {
-            interaction.getContainer().find('textarea').val(value);
-        };
-
         var baseType = interaction.getResponseDeclaration().attr('baseType');
 
         if (response.base && response.base[baseType] !== undefined) {
-            _setVal(response.base[baseType]);
+            setText(interaction, response.base[baseType]);
         }
         else if (response.list && response.list[baseType]) {
 
@@ -443,12 +439,31 @@ define([
     };
 
     /**
-     * return the ckEditor instance
-     * @param  {object} interaction the interaction
-     * @return {object}             ckeditor instance
+     * Sets the CKEditor instance
+     * @param  {Object} interaction The interaction
+     * @param {Object} [editor] CKEditor instance
      */
-    var _ckEditor = function(interaction){
-        return containerHelper.get(interaction).data('editor');
+    var _setCKEditor = function(interaction, editor) {
+        var name = editor && editor.name;
+        var $container = containerHelper.get(interaction);
+
+        if (name) {
+            $container.data('editor', name);
+        } else {
+            $container.removeData('editor');
+        }
+    };
+
+    /**
+     * Gets the CKEditor instance
+     * @param  {Object} interaction The interaction
+     * @return {Object}             CKEditor instance
+     */
+    var _getCKEditor = function(interaction){
+        var $container = containerHelper.get(interaction);
+        var name = $container.data('editor');
+
+        return ckEditor.instances[name];
     };
 
     /**
@@ -458,7 +473,10 @@ define([
      */
     var _ckEditorData = function(interaction) {
         var tempNode = document.createElement('div');
-        tempNode.innerHTML = _ckEditor(interaction).getData();
+        var editor = _getCKEditor(interaction);
+        if (editor) {
+            tempNode.innerHTML = editor.getData();
+        }
         return  tempNode.textContent;
     };
 
@@ -514,12 +532,12 @@ define([
 
         if ( _getFormat(interaction) === 'xhtml') {
             var editor = ckEditor.replace($container.find('.text-container')[0], ckeOptions);
-            $container.data('editor', editor);
+            _setCKEditor(interaction, editor);
         }
         else {
             // preFormatted or plain
             if (from === 'xhtml') {
-                _ckEditor(interaction).destroy();
+                _getCKEditor(interaction).destroy();
             }
             if ( _getFormat(interaction) === 'preformatted'){
                 $container.find('textarea').addClass('text-preformatted');
@@ -531,26 +549,36 @@ define([
 
     var enable = function(interaction) {
         var $container = containerHelper.get(interaction);
+        var editor;
+
         $container.find('input, textarea').removeAttr('disabled');
 
-        if ( _getFormat(interaction) === 'xhtml') {
-            if (_ckEditor(interaction).status === 'ready') {
-                _ckEditor(interaction).setReadOnly(false);
-            } else {
-                _ckEditor(interaction).readOnly = false;
+        if (_getFormat(interaction) === 'xhtml') {
+            editor = _getCKEditor(interaction);
+            if (editor) {
+                if (editor.status === 'ready') {
+                    editor.setReadOnly(false);
+                } else {
+                    editor.readOnly = false;
+                }
             }
         }
     };
 
     var disable = function(interaction) {
         var $container = containerHelper.get(interaction);
+        var editor;
+
         $container.find('input, textarea').attr('disabled', 'disabled');
 
-        if ( _getFormat(interaction) === 'xhtml' && $container.data('editor')) {
-            if (_ckEditor(interaction).status === 'ready') {
-                _ckEditor(interaction).setReadOnly(true);
-            } else {
-                _ckEditor(interaction).readOnly = true;
+        if (_getFormat(interaction) === 'xhtml') {
+            editor = _getCKEditor(interaction);
+            if (editor) {
+                if (editor.status === 'ready') {
+                    editor.setReadOnly(true);
+                } else {
+                    editor.readOnly = true;
+                }
             }
         }
     };
@@ -560,14 +588,11 @@ define([
     };
 
     var setText = function(interaction, text) {
-        var $container = containerHelper.get(interaction);
-
         if ( _getFormat(interaction) === 'xhtml') {
-            var editor = _ckEditor(interaction);
-            editor.setData(text);
+            _getCKEditor(interaction).setData(text);
         }
         else {
-            $container.find('textarea').val(text);
+            containerHelper.get(interaction).find('textarea').val(text);
         }
     };
 
@@ -578,8 +603,12 @@ define([
     var destroy = function(interaction){
 
         var $container = containerHelper.get(interaction);
+        var $el = $container.find('input, textarea');
+
+        _setCKEditor(interaction);
 
         //remove event
+        $el.off('.commonRenderer');
         $(document).off('.commonRenderer');
 
         //remove instructions
@@ -598,8 +627,12 @@ define([
     var setState  = function setState(interaction, state){
         if(_.isObject(state)){
             if(state.response){
-                interaction.resetResponse();
-                interaction.setResponse(state.response);
+                try {
+                    interaction.setResponse(state.response);
+                } catch(e) {
+                    interaction.resetResponse();
+                    throw e;
+                }
             }
         }
     };
@@ -611,7 +644,6 @@ define([
      * @returns {Object} the interaction current state
      */
     var getState = function getState(interaction){
-        var $container;
         var state =  {};
         var response =  interaction.getResponse();
 

--- a/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -156,7 +156,7 @@ define([
                             evt.preventDefault();
                         }
                         if(maxLength){
-                            var value = _getTextareaValue(interaction);
+                            var value = _getTextareaValue(interaction, true);
                             setText(interaction,value);
                         }
                     }
@@ -414,7 +414,7 @@ define([
                     value = parseFloat(_getTextareaValue(interaction));
                 }
                 else if (baseType === 'string') {
-                    value = _getTextareaValue(interaction);
+                    value = _getTextareaValue(interaction, true);
                 }
             }
 
@@ -427,11 +427,12 @@ define([
     /**
      * return the value of the textarea or ckeditor data
      * @param  {Object} interaction
+     * @param  {Boolean} raw Tells if the returned data does not have to be filtered (i.e. XHTML tags not removed)
      * @return {String}             the value
      */
-    var _getTextareaValue = function(interaction) {
+    var _getTextareaValue = function(interaction, raw) {
         if (_getFormat(interaction) === 'xhtml') {
-            return _ckEditorData(interaction);
+            return _ckEditorData(interaction, raw);
         }
         else {
             return containerHelper.get(interaction).find('textarea').val();
@@ -469,15 +470,30 @@ define([
     /**
      * get the text content of the ckEditor ( not the entire html )
      * @param  {object} interaction the interaction
+     * @param  {Boolean} raw Tells if the returned data does not have to be filtered (i.e. XHTML tags not removed)
      * @return {string}             text content of the ckEditor
      */
-    var _ckEditorData = function(interaction) {
-        var tempNode = document.createElement('div');
+    var _ckEditorData = function(interaction, raw) {
         var editor = _getCKEditor(interaction);
-        if (editor) {
-            tempNode.innerHTML = editor.getData();
+        var data = editor && editor.getData() || '';
+
+        if (!raw) {
+            data = _stripTags(data);
         }
-        return  tempNode.textContent;
+
+        return data;
+    };
+
+    /**
+     * Remove HTML tags from a string
+     * @param {String} str
+     * @returns {String}
+     * @private
+     */
+    var _stripTags = function(str) {
+        var tempNode = document.createElement('div');
+        tempNode.innerHTML = str;
+        return tempNode.textContent;
     };
 
     var _getFormat = function(interaction) {

--- a/views/js/test/qtiCommonRenderer/interactions/extendedText/test.html
+++ b/views/js/test/qtiCommonRenderer/interactions/extendedText/test.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Extended Text Interaction Test</title>
+        <base href="../../../../../../../tao/views/" />
+
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="qtiCommonRenderer/renderers/"></script>
+
+        <script  type="text/javascript">
+
+            //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiItem/test/qtiCommonRenderer/interactions/extendedText/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.config.reorder = false;
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="item-container-0"></div>
+            <div id="item-container-1"></div>
+            <div id="item-container-2"></div>
+            <div id="item-container-3"></div>
+            <div id="item-container-4"></div>
+            <div id="item-container-5"></div>
+            <div id="item-container-6"></div>
+            <div id="item-container-7"></div>
+            <div id="item-container-8"></div>
+            <div id="item-container-9"></div>
+        </div>
+
+        <div id="outside-container"></div>
+    </body>
+</html>

--- a/views/js/test/qtiCommonRenderer/interactions/extendedText/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/extendedText/test.js
@@ -275,7 +275,7 @@ define([
         QUnit.expect(20);
 
         var $container = $('#' + fixtureContainerId + '7');
-        var response = { base  : { string : 'test' } };
+        var response = { base  : { string : '<strong>test</strong>' } };
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');

--- a/views/js/test/qtiCommonRenderer/interactions/extendedText/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/extendedText/test.js
@@ -1,0 +1,408 @@
+define([
+    'jquery',
+    'lodash',
+    'taoQtiItem/runner/qtiItemRunner',
+    'json!taoQtiItem/test/samples/json/postcard.json',
+    'json!taoQtiItem/test/samples/json/formated-card.json',
+    'lib/simulator/jquery.keystroker',
+    'taoQtiItem/qtiCommonRenderer/helpers/container',
+    'ckeditor'
+], function($, _, qtiItemRunner, itemDataPlain, itemDataXhtml, keystroker, containerHelper, ckEditor){
+    'use strict';
+
+    var fixtureContainerId = 'item-container-';
+
+    var showErrors = true;
+
+    var logError = function(err) {
+        if (showErrors) {
+            console.log('Error#', err);
+        }
+    };
+
+/** PLAIN **/
+
+    QUnit.module('Extended Text Interaction - plain format');
+
+
+    QUnit.asyncTest('renders correctly', function(assert){
+        QUnit.expect(10);
+
+        var $container = $('#' + fixtureContainerId + '0');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataPlain)
+            .on('error', logError)
+            .on('render', function(){
+
+                //check DOM
+                assert.equal($container.children().length, 1, 'the container a elements');
+                assert.equal($container.children('.qti-item').length, 1, 'the container contains a the root element .qti-item');
+                assert.equal($container.find('.qti-itemBody').length, 1, 'the container contains a the body element .qti-itemBody');
+                assert.equal($container.find('.qti-interaction').length, 1, 'the container contains an interaction .qti-interaction');
+                assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+                assert.equal($container.find('.qti-extendedTextInteraction .qti-prompt-container').length, 1, 'the interaction contains a prompt');
+                assert.equal($container.find('.qti-extendedTextInteraction .instruction-container').length, 1, 'the interaction contains a instruction box');
+
+                //check DOM data
+                assert.equal($container.children('.qti-item').data('identifier'), 'extendedText', 'the .qti-item node has the right identifier');
+
+                QUnit.start();
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('enables to input a response', function(assert){
+        QUnit.expect(16);
+
+        var $container = $('#' + fixtureContainerId + '1');
+        var responsesStack = [
+            { response : { base  : { string : 't' } } },
+            { response : { base  : { string : 'te' } } },
+            { response : { base  : { string : 'tes' } } },
+            { response : { base  : { string : 'test' } } }
+        ];
+        var stackPtr = 0;
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataPlain)
+            .on('error', logError)
+            .on('render', function(){
+                assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                keystroker.puts($container.find('textarea'), 'test');
+            })
+            .on('statechange', function(state){
+                assert.ok(typeof state === 'object', 'The state is an object');
+                assert.ok(typeof state.RESPONSE === 'object', 'The state has a response object');
+                assert.deepEqual(state.RESPONSE, responsesStack[stackPtr ++], 'A text is entered');
+                if (stackPtr === responsesStack.length) {
+                    assert.ok(true, 'A text is fully entered');
+                    QUnit.start();
+                }
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('enables to load a response', function(assert){
+        QUnit.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '2');
+        var response = { base  : { string : 'test' } };
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataPlain)
+            .on('error', logError)
+            .on('render', function(){
+                assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                var interaction = this._item.getInteractions()[0];
+                interaction.renderer.setResponse(interaction, response);
+
+                assert.deepEqual(this.getState(), {'RESPONSE': { response : response } }, 'the response state is equal to the loaded response');
+
+                assert.equal($container.find('textarea').val(), response.base.string, 'the textarea displays the loaded response');
+
+                QUnit.start();
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('destroys', function(assert){
+        QUnit.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '3');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataPlain)
+            .on('error', logError)
+            .on('render', function(){
+                var self = this;
+
+                //call destroy manually
+                var interaction = this._item.getInteractions()[0];
+                interaction.renderer.destroy(interaction);
+
+                assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                keystroker.puts($container.find('textarea'), 'test');
+
+                _.delay(function(){
+
+                    assert.deepEqual(self.getState(), {'RESPONSE': { response : { base  : { string : 'test' } } } }, 'The response state is still related to text content');
+                    assert.equal($container.find('.qti-extendedTextInteraction .instruction-container').children().length, 0, 'there is no instructions anymore');
+
+                    QUnit.start();
+                }, 100);
+            })
+            .on('statechange', function(){
+                assert.ok(false, 'Text input does not trigger response once destroyed');
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('resets the response', function(assert){
+        QUnit.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '4');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataPlain)
+            .on('error', logError)
+            .on('render', function(){
+                var self = this;
+
+                assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                keystroker.puts($container.find('textarea'), 'test');
+
+                _.delay(function(){
+
+                    assert.deepEqual(self.getState(), {'RESPONSE': { response : { base  : { string : 'test' } } } }, 'A response is set');
+
+                    //call destroy manually
+                    var interaction = self._item.getInteractions()[0];
+                    interaction.renderer.resetResponse(interaction);
+
+                    _.delay(function(){
+
+                        assert.deepEqual(self.getState(), {'RESPONSE': { response : { base  : { string : '' } } } }, 'The response is cleared');
+
+                        QUnit.start();
+                    }, 100);
+                }, 100);
+
+            })
+            .init()
+            .render($container);
+    });
+
+/** XHTML **/
+
+    QUnit.module('Extended Text Interaction - XHTML format');
+
+
+    QUnit.asyncTest('renders correctly', function(assert){
+        QUnit.expect(10);
+
+        var $container = $('#' + fixtureContainerId + '5');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataXhtml)
+            .on('error', logError)
+            .on('render', function(){
+                _.delay(function() {
+                    //check DOM
+                    assert.equal($container.children().length, 1, 'the container a elements');
+                    assert.equal($container.children('.qti-item').length, 1, 'the container contains a the root element .qti-item');
+                    assert.equal($container.find('.qti-itemBody').length, 1, 'the container contains a the body element .qti-itemBody');
+                    assert.equal($container.find('.qti-interaction').length, 1, 'the container contains an interaction .qti-interaction');
+                    assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+                    assert.equal($container.find('.qti-extendedTextInteraction .qti-prompt-container').length, 1, 'the interaction contains a prompt');
+                    assert.equal($container.find('.qti-extendedTextInteraction .instruction-container').length, 1, 'the interaction contains a instruction box');
+
+                    //check DOM data
+                    assert.equal($container.children('.qti-item').data('identifier'), 'extendedText', 'the .qti-item node has the right identifier');
+
+                    QUnit.start();
+
+                    // remove the container to avoid CKEditor error on the next test
+                    $container.remove();
+                }, 100);
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('enables to input a response', function(assert){
+        QUnit.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '6');
+        var response = 'test';
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataXhtml)
+            .on('error', logError)
+            .on('render', function(){
+                var self = this;
+                _.delay(function() {
+                    assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                    var interaction = self._item.getInteractions()[0];
+                    var editor = ckEditor.instances[containerHelper.get(interaction).data('editor')];
+
+                    editor.setData(response);
+
+                    assert.deepEqual(self.getState(), {'RESPONSE': { response : { base  : { string : response } } } }, 'the response state is equal to the loaded response');
+
+                    assert.equal(editor.getData(), response, 'the editor displays the loaded response');
+
+                    QUnit.start();
+
+                    // remove the container to avoid CKEditor error on the next test
+                    $container.remove();
+                }, 100);
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('enables to load a response', function(assert){
+        QUnit.expect(20);
+
+        var $container = $('#' + fixtureContainerId + '7');
+        var response = { base  : { string : 'test' } };
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        var cpt = 0;
+
+        var runner = qtiItemRunner('qti', itemDataXhtml)
+            .on('error', logError)
+            .on('render', function(){
+                var self = this;
+                _.delay(function() {
+                    assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                    var interaction = self._item.getInteractions()[0];
+                    var editor = ckEditor.instances[containerHelper.get(interaction).data('editor')];
+                    runner.setState({'RESPONSE': { response : response } });
+
+                    _.delay(function() {
+                        assert.deepEqual(self.getState(), {'RESPONSE': { response : response } }, 'the response state is equal to the loaded response');
+
+                        assert.equal(editor.getData(), response.base.string, 'the editor displays the loaded response');
+
+                        QUnit.start();
+
+                        // remove the container to avoid CKEditor error on the next test
+                        $container.remove();
+                    }, 100);
+
+                }, 100);
+            })
+            .on('statechange', function(state){
+                assert.ok(true, 'A statechange event has been fired #' + (cpt++));
+                assert.ok(typeof state === 'object', 'The state is an object');
+                assert.ok(typeof state.RESPONSE === 'object', 'The state has a response object');
+                assert.deepEqual(state.RESPONSE, { response : response }, 'A text is entered');
+
+                var interaction = this._item.getInteractions()[0];
+                var editor = ckEditor.instances[containerHelper.get(interaction).data('editor')];
+                assert.equal(editor.getData(), response.base.string, 'the editor displays the loaded response');
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('destroys', function(assert){
+        QUnit.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '8');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataXhtml)
+            .on('error', logError)
+            .on('render', function(){
+                var self = this;
+                _.delay(function() {
+                    //call destroy manually
+                    var interaction = self._item.getInteractions()[0];
+                    interaction.renderer.destroy(interaction);
+
+                    assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                    _.delay(function(){
+
+                        assert.deepEqual(self.getState(), {'RESPONSE': { response : { base  : { string : '' } } } }, 'The response state is cleared');
+                        assert.equal($container.find('.qti-extendedTextInteraction .instruction-container').children().length, 0, 'there is no instructions anymore');
+
+                        QUnit.start();
+
+                        // remove the container to avoid CKEditor error on the next test
+                        $container.remove();
+                    }, 100);
+                }, 100);
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('resets the response', function(assert){
+        QUnit.expect(6);
+
+        var $container = $('#' + fixtureContainerId + '9');
+        var response = 'test';
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        qtiItemRunner('qti', itemDataXhtml)
+            .on('error', logError)
+            .on('render', function(){
+                var self = this;
+
+                _.delay(function() {
+                    assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
+
+                    var interaction = self._item.getInteractions()[0];
+                    var editor = ckEditor.instances[containerHelper.get(interaction).data('editor')];
+
+                    editor.setData(response);
+
+                    _.delay(function(){
+
+                        assert.deepEqual(self.getState(), {'RESPONSE': { response : { base  : { string : response } } } }, 'A response is set');
+
+                        var interaction = self._item.getInteractions()[0];
+                        interaction.renderer.resetResponse(interaction);
+
+                        _.delay(function(){
+
+                            assert.deepEqual(self.getState(), {'RESPONSE': { response : { base  : { string : '' } } } }, 'The response is cleared');
+
+                            assert.equal(editor.getData(), '', 'the editor is cleared');
+
+                            QUnit.start();
+
+                            // remove the container to avoid CKEditor error on the next test
+                            $container.remove();
+                        }, 100);
+                    }, 100);
+                }, 100);
+            })
+            .init()
+            .render($container);
+    });
+
+});
+

--- a/views/js/test/runner/manual.html
+++ b/views/js/test/runner/manual.html
@@ -149,6 +149,7 @@
             <option value="edinburgh.json" disabled>Locate Edinburh (Select Point)</option>
             <option value="elections.json">Elections (Slider)</option>
             <option value="flying-home.json" disabled>Flying home (Graphic Order)</option>
+            <option value="formated-card.json">Formated Postcard (XHTML Extended Text)</option>
             <option value="history.json">History (Order)</option>
             <option value="lowcost-flying.json" disabled>Low cost flying (Graphic Associate)</option>
             <option value="postcard.json">Postcard (Extended Text)</option>

--- a/views/js/test/samples/json/formated-card.json
+++ b/views/js/test/samples/json/formated-card.json
@@ -1,0 +1,133 @@
+{
+    "identifier": "extendedText",
+    "serial": "item_555600ae567b2175433182",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "extendedText",
+        "title": "Writing a Postcard",
+        "label": "",
+        "xml:lang": "en-US",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "3.0.1"
+    },
+    "body": {
+        "serial": "container_containeritembody_555600ae5678c065265738",
+        "body": "<div class=\"grid-row\">\n      <div class=\"col-6\">\n        <p>Read this postcard from your English pen-friend, Sam.<\/p>\n        <p>\n          {{img_555600ae589e4816387779}}\n        <\/p>\n      <\/div>\n      <div class=\"col-6\">\n        {{interaction_extendedtextinteraction_555600ae5805f503322627}}\n      <\/div>\n    <\/div>",
+        "elements": {
+            "interaction_extendedtextinteraction_555600ae5805f503322627": {
+                "serial": "interaction_extendedtextinteraction_555600ae5805f503322627",
+                "qtiClass": "extendedTextInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE",
+                    "base": 10,
+                    "patternMask": "\/^(?:(?:[^\\s\\:\\!\\?\\;\\\u2026\\\u20ac]+)[\\s\\:\\!\\?\\;\\\u2026\\\u20ac]*){0,50}$\/",
+                    "minStrings": 0,
+                    "format": "xhtml"
+                },
+                "debug": {
+                    "relatedItem": "item_555600ae567b2175433182"
+                },
+                "choices": {},
+                "prompt": {
+                    "serial": "container_containerstatic_555600ae587dd468760533",
+                    "body": "Write Sam a short letter.\u00a0 Answer the questions.\u00a0 <em>Write 50 words.<\/em>",
+                    "elements": {},
+                    "debug": {
+                        "relatedItem": "item_555600ae567b2175433182"
+                    }
+                }
+            },
+            "img_555600ae589e4816387779": {
+                "serial": "img_555600ae589e4816387779",
+                "qtiClass": "img",
+                "attributes": {
+                    "src": "images\/postcard.png",
+                    "alt": "postcard",
+                    "width": "100%"
+                },
+                "debug": {
+                    "relatedItem": "item_555600ae567b2175433182"
+                }
+            }
+        },
+        "debug": {
+            "relatedItem": "item_555600ae567b2175433182"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_555600ae567b2175433182"
+    },
+    "namespaces": {
+        "xml": "http:\/\/www.w3.org\/XML\/1998\/namespace",
+        "xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+        "": "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p1"
+    },
+    "stylesheets": {
+        "stylesheet_555600ae56fa9052117496": {
+            "serial": "stylesheet_555600ae56fa9052117496",
+            "qtiClass": "stylesheet",
+            "attributes": {
+                "href": "style\/custom\/tao-user-styles.css",
+                "type": "text\/css",
+                "media": "all",
+                "title": ""
+            },
+            "debug": {
+                "relatedItem": "item_555600ae567b2175433182"
+            }
+        }
+    },
+    "outcomes": {
+        "outcomedeclaration_555600ae5788d747947578": {
+            "identifier": "SCORE",
+            "serial": "outcomedeclaration_555600ae5788d747947578",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "SCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_555600ae567b2175433182"
+            },
+            "defaultValue": null
+        }
+    },
+    "responses": {
+        "responsedeclaration_555600ae57568623654802": {
+            "identifier": "RESPONSE",
+            "serial": "responsedeclaration_555600ae57568623654802",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE",
+                "cardinality": "single",
+                "baseType": "string"
+            },
+            "debug": {
+                "relatedItem": "item_555600ae567b2175433182"
+            },
+            "correctResponses": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": null,
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        }
+    },
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_custom_555600ae59220089386409",
+        "qtiClass": "responseProcessing",
+        "attributes": [],
+        "debug": {
+            "relatedItem": ""
+        },
+        "processingType": "custom",
+        "data": "<responseProcessing\/>",
+        "responseRules": []
+    }
+}


### PR DESCRIPTION
The issue was due to deferred event call inside CKEditor engine.
When CKEDITOR.editor.setData() is called, a cascade of event is triggered, and the onchange event is also triggered.

Before my patch, each time the state was set, a reset of the response was performed before the update. The reset forces an erasing of the editor by calling the setData() method, and this method also triggers deferred onchange events, with outdated data in this case. If another call of the setData() method is made just after, the editor is updated twice : first with the new data, then with the reseted data, and the editor is erased.

The solution I found is to avoid to do a reset before updating the response. The reset is only made when the response use a wrong format.