### PR TITLE
fix theme loader in chrome that loads all themes

### DIFF
--- a/views/js/runner/themes/loader.js
+++ b/views/js/runner/themes/loader.js
@@ -166,7 +166,7 @@ define(['jquery', 'lodash'], function($, _){
             load : function load(){
                 _.forEach(styles, function($link, id){
                     if(!isAttached(id)){
-/bin/bash: q : commande introuvable
+                        disable($link);
                         $container.append($link);
                     }
                     if(id !== 'base' && id !== defaultTheme){

--- a/views/js/runner/themes/loader.js
+++ b/views/js/runner/themes/loader.js
@@ -166,6 +166,7 @@ define(['jquery', 'lodash'], function($, _){
             load : function load(){
                 _.forEach(styles, function($link, id){
                     if(!isAttached(id)){
+/bin/bash: q : commande introuvable
                         $container.append($link);
                     }
                     if(id !== 'base' && id !== defaultTheme){


### PR DESCRIPTION
disable link before attaching to prevent chrome strange behavior