### PR TITLE
count children instead of childNodes to prevent count of textNodes

### DIFF
--- a/views/js/test/runner/interactions/choice/test.js
+++ b/views/js/test/runner/interactions/choice/test.js
@@ -30,12 +30,12 @@ define([
         var container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
-        assert.equal(container.childNodes.length, 0, 'the container has no children');
+        assert.equal(container.children.length, 0, 'the container has no children');
 
         qtiItemRunner('qti', itemData)
             .on('render', function(){
 
-                assert.equal(container.childNodes.length, 1, 'the container has children');
+                assert.equal(container.children.length, 1, 'the container has children');
 
                 QUnit.start();
             })
@@ -51,17 +51,17 @@ define([
         var container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
-        assert.equal(container.childNodes.length, 0, 'the container has no children');
+        assert.equal(container.children.length, 0, 'the container has no children');
 
         qtiItemRunner('qti', itemData)
             .on('render', function(){
-                assert.equal(container.childNodes.length, 1, 'the container has children');
+                assert.equal(container.children.length, 1, 'the container has children');
 
                 this.clear();
 
             }).on('clear', function(){
 
-                assert.equal(container.childNodes.length, 0, 'the container children are removed');
+                assert.equal(container.children.length, 0, 'the container children are removed');
 
                 QUnit.start();
             })

--- a/views/js/test/runner/interactions/textentry/test.js
+++ b/views/js/test/runner/interactions/textentry/test.js
@@ -30,12 +30,12 @@ define([
         var container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
-        assert.equal(container.childNodes.length, 0, 'the container has no children');
+        assert.equal(container.children.length, 0, 'the container has no children');
 
         qtiItemRunner('qti', itemData)
             .on('render', function(){
 
-                assert.equal(container.childNodes.length, 1, 'the container has children');
+                assert.equal(container.children.length, 1, 'the container has children');
 
                 QUnit.start();
             })
@@ -51,17 +51,17 @@ define([
         var container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
-        assert.equal(container.childNodes.length, 0, 'the container has no children');
+        assert.equal(container.children.length, 0, 'the container has no children');
 
         qtiItemRunner('qti', itemData)
             .on('render', function(){
-                assert.equal(container.childNodes.length, 1, 'the container has children');
+                assert.equal(container.children.length, 1, 'the container has children');
 
                 this.clear();
 
             }).on('clear', function(){
 
-                assert.equal(container.childNodes.length, 0, 'the container children are removed');
+                assert.equal(container.children.length, 0, 'the container children are removed');
 
                 QUnit.start();
             })

--- a/views/js/test/runner/provider/test.js
+++ b/views/js/test/runner/provider/test.js
@@ -95,14 +95,14 @@ define([
         var container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
-        assert.equal(container.childNodes.length, 0, 'the container has no children');
+        assert.equal(container.children.length, 0, 'the container has no children');
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
         itemRunner('qti', itemData)
             .on('render', function(){
 
-                assert.equal(container.childNodes.length, 1, 'the container has children');
+                assert.equal(container.children.length, 1, 'the container has children');
 
                 QUnit.start();
             })
@@ -148,19 +148,19 @@ define([
         var container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
-        assert.equal(container.childNodes.length, 0, 'the container has no children');
+        assert.equal(container.children.length, 0, 'the container has no children');
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
         itemRunner('qti', itemData)
             .on('render', function(){
-                assert.equal(container.childNodes.length, 1, 'the container has children');
+                assert.equal(container.children.length, 1, 'the container has children');
 
                 this.clear();
 
             }).on('clear', function(){
 
-                assert.equal(container.childNodes.length, 0, 'the container children are removed');
+                assert.equal(container.children.length, 0, 'the container children are removed');
 
                 QUnit.start();
             })


### PR DESCRIPTION
A blank line has been added to the qti item template causing the tests to fail in http://build.taotesting.com:8180/job/build-tao-js/177/ 
This PR fixes the way children are counted by ignoring text nodes.