### PR TITLE
Fix/scoring lib null values

### DIFF
--- a/views/js/scoring/processor/expressions/preprocessor.js
+++ b/views/js/scoring/processor/expressions/preprocessor.js
@@ -90,22 +90,23 @@ define([
              * @returns {*} the parsed value
              */
             parseValue : function(value, baseType, cardinality){
+                if(value !== null){
+                    if (cardinality === 'record') {
+                        return _.mapValues(value, preProcessor.parseVariable);
+                    }
 
-                if (cardinality === 'record') {
-                    return _.mapValues(value, preProcessor.parseVariable);
-                }
+                    var caster = typeCaster(baseType);
+                    cardinality = cardinality || 'single';
 
-                var caster = typeCaster(baseType);
-                cardinality = cardinality || 'single';
+                    if(cardinality === 'single'){
+                        value = caster(value, state);
+                    } else {
+                        value = _.map(value, caster);
+                    }
 
-                if(cardinality === 'single'){
-                    value = caster(value, state);
-                } else {
-                    value = _.map(value, caster);
-                }
-
-                if(cardinality === 'multiple'){
-                    value = value.sort();   //sort for comparison
+                    if(cardinality === 'multiple'){
+                        value = value.sort();   //sort for comparison
+                    }
                 }
                 return value;
             },

--- a/views/js/test/samples/json/es6.json
+++ b/views/js/test/samples/json/es6.json
@@ -129,7 +129,7 @@
                     "attributes": {
                         "responseIdentifier": "RESPONSE_1",
                         "shuffle": false,
-                        "maxChoices": 0,
+                        "maxChoices": 1,
                         "minChoices": 0,
                         "orientation": "vertical"
                     },
@@ -285,15 +285,15 @@
                 "qtiClass": "responseDeclaration",
                 "attributes": {
                     "identifier": "RESPONSE_1",
-                    "cardinality": "multiple",
+                    "cardinality": "single",
                     "baseType": "identifier"
                 },
                 "debug": {
                     "relatedItem": "item_5576b71e3bd72041243459"
                 },
-                "correctResponses": [
+                "correctResponses":
                     "choice_7"
-                ],
+                ,
                 "mapping": [],
                 "areaMapping": [],
                 "howMatch": "http:\/\/www.imsglobal.org\/question\/qti_v2p1\/rptemplates\/match_correct",

--- a/views/js/test/scoring/processor/expressions/baseValue/test.js
+++ b/views/js/test/scoring/processor/expressions/baseValue/test.js
@@ -25,6 +25,17 @@ define([
             value : 5
         }
     }, {
+        title : 'null identifier',
+        expression : {
+            attributes : { baseType : 'indentifier' },
+            value : null
+        },
+        expectedResult : {
+            cardinality : 'single',
+            baseType : 'indentifier',
+            value : null
+        }
+    }, {
         title : 'float',
         expression : {
             attributes : { baseType : 'float' },

--- a/views/js/test/scoring/processor/expressions/variable/test.js
+++ b/views/js/test/scoring/processor/expressions/variable/test.js
@@ -38,6 +38,19 @@ define([
 
     QUnit.test('Get the variable value even null', function(assert){
         var state = {
+            RESPONSE :  null
+        };
+        variableProcessor.expression = {
+            attributes : { identifier : 'RESPONSE' }
+        };
+        variableProcessor.state = state;
+        variableProcessor.preProcessor = preProcessorFactory(state);
+
+        assert.equal(variableProcessor.process(), null, 'returns null');
+    });
+
+    QUnit.test('Get the variable value even with a null value', function(assert){
+        var state = {
             RESPONSE :  {
                 cardinality         : 'single',
                 baseType            : 'identifier',
@@ -50,7 +63,12 @@ define([
         variableProcessor.state = state;
         variableProcessor.preProcessor = preProcessorFactory(state);
 
-        assert.equal(variableProcessor.process(), null, 'returns null');
+        var expectedResult =  {
+            cardinality         : 'single',
+            baseType            : 'identifier',
+            value               : null
+        };
+        assert.deepEqual(variableProcessor.process(), expectedResult, 'returns null');
     });
 
     QUnit.asyncTest('Fails if no variable is found', function(assert){

--- a/views/js/test/scoring/processor/expressions/variable/test.js
+++ b/views/js/test/scoring/processor/expressions/variable/test.js
@@ -38,7 +38,11 @@ define([
 
     QUnit.test('Get the variable value even null', function(assert){
         var state = {
-            RESPONSE : null
+            RESPONSE :  {
+                cardinality         : 'single',
+                baseType            : 'identifier',
+                value               : null
+            }
         };
         variableProcessor.expression = {
             attributes : { identifier : 'RESPONSE' }

--- a/views/js/test/scoring/provider/test.js
+++ b/views/js/test/scoring/provider/test.js
@@ -199,7 +199,7 @@ define([
 
             var responses = {
                 'RESPONSE' : { list : { identifier : ["choice_3"] } },
-                'RESPONSE_1' : { list : { identifier : ["choice_7"] } },
+                'RESPONSE_1' : { base : { identifier : "choice_7" } },
             };
             scorer.register('qti', qtiScoringProvider);
 
@@ -216,6 +216,35 @@ define([
                     assert.deepEqual(outcomes.RESPONSE_1, responses.RESPONSE_1, "the response is the same");
                     assert.ok(typeof outcomes.SCORE === 'object', "the outcomes contains the score");
                     assert.deepEqual(outcomes.SCORE, { base : { float : 2 } }, "the score has the correct value");
+
+                    QUnit.start();
+                })
+                .process(responses, multipleResponseCorrectData);
+    });
+
+    QUnit.asyncTest('process multiple responses one is empty', function(assert){
+
+            QUnit.expect(7);
+
+            var responses = {
+                'RESPONSE' : { list : { identifier : ["choice_3"] } },
+                'RESPONSE_1' : { base : null }
+            };
+            scorer.register('qti', qtiScoringProvider);
+
+            scorer('qti')
+                .on('error', function(err){
+                    assert.ok(false, 'Got an error : ' + err);
+                })
+                .on('outcome', function(outcomes){
+
+                    assert.ok(typeof outcomes === 'object', "the outcomes are an object");
+                    assert.ok(typeof outcomes.RESPONSE === 'object', "the outcomes contains the response");
+                    assert.deepEqual(outcomes.RESPONSE, responses.RESPONSE, "the response is the same");
+                    assert.ok(typeof outcomes.RESPONSE_1 === 'object', "the outcomes contains the response");
+                    assert.deepEqual(outcomes.RESPONSE_1, responses.RESPONSE_1, "the response is the same");
+                    assert.ok(typeof outcomes.SCORE === 'object', "the outcomes contains the score");
+                    assert.deepEqual(outcomes.SCORE, { base : { float : 1 } }, "the score has the correct value");
 
                     QUnit.start();
                 })


### PR DESCRIPTION
Fixes TAO-906

When receiving a response as `base : null` the scoring lib was in error. (it was expecting a NULL variable instead). 

Can be tested using `taoQtiItem/views/js/test/scoring/provider/test.html` and `/taoQtiItem/views/js/test/scoring/processor/expressions/variable/test.html`