### PR TITLE
TAO-908 Missing class InvalidArgumentException

### DIFF
--- a/model/qti/container/Container.php
+++ b/model/qti/container/Container.php
@@ -104,7 +104,7 @@ abstract class Container extends Element implements IdentifiedElementContainer
                 $placeholder = $qtiElement->getPlaceholder();
                 if(strpos($body, $placeholder) === false){
                     if($requiredPlaceholder){
-                        throw new InvalidArgumentException('no placeholder found for the element in the new container body: '.get_class($qtiElement).':'.$placeholder);
+                        throw new \InvalidArgumentException('no placeholder found for the element in the new container body: '.get_class($qtiElement).':'.$placeholder);
                     }else{
                         //assume implicitly add to the end
                         $body .= $placeholder;

--- a/test/QtiParsingTest.php
+++ b/test/QtiParsingTest.php
@@ -42,12 +42,13 @@ class QtiParsingTest extends TaoPhpUnitTestRunner {
 		TaoPhpUnitTestRunner::initTest();
 		$this->qtiService = Service::singleton();
 	}
-
+    
 	/**
 	 * test qti file parsing: validation and loading in a non-persistant context
 	 */
 	public function testFileParsingQti2p1(){
-
+        common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiItem');
+        
 		//check if wrong files are not validated correctly
 		foreach(glob(dirname(__FILE__).'/samples/wrong/*.*') as $file){
 			$qtiParser = new Parser($file);
@@ -85,6 +86,8 @@ class QtiParsingTest extends TaoPhpUnitTestRunner {
      * @author Thibault Milan <thibault.milan@vesperiagroup.com>
      */
     public function testFileParsingCDATA(){
+        common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiItem');
+        
         $file = dirname(__FILE__).'/samples/xml/cdata/item.xml';
 
         $qtiParser = new Parser($file);


### PR DESCRIPTION
Add missed slash to the class name.

I didn't write the regression test for this bug because I could not reproduce it. I didn't figure out how to create a container or a qtiElement without placeholder.

Sam, I found that this functionality has been written by you. Maybe you know how to reproduce this bug.