### PR TITLE
Fix/containers clear cache

### DIFF
--- a/views/js/qtiCommonRenderer/helpers/container.js
+++ b/views/js/qtiCommonRenderer/helpers/container.js
@@ -99,6 +99,14 @@ define([
         },
 
         /**
+         * Clear the containers cache
+         */
+        clear : function clear(){
+            _containers = {};
+            _$containerContext = $();
+        },
+
+        /**
          * Trigger an event on the element's container
          * @param {String} eventType - the name of the event
          * @param {QtiElement} element - find the container of this element
@@ -143,7 +151,6 @@ define([
             });
         }
     };
-
 
     return containerHelper;
 });

--- a/views/js/qtiCommonRenderer/renderers/Item.js
+++ b/views/js/qtiCommonRenderer/renderers/Item.js
@@ -1,19 +1,56 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ */
+
+/**
+ * Define the Item Element Renderer
+ */
 define([
     'tpl!taoQtiItem/qtiCommonRenderer/tpl/item',
     'taoQtiItem/qtiCommonRenderer/helpers/container',
     'taoQtiItem/qtiCommonRenderer/helpers/itemStylesheetHandler'
 ], function(tpl, containerHelper, itemStylesheetHandler) {
+    'use strict';
+
     return {
         qtiClass: 'assessmentItem',
         template: tpl,
         getContainer: containerHelper.get,
-        render: function(item) {
-            
+
+        /**
+         * Rendering initializations for the item
+         * @param {Object} item - the item model
+         */
+        render: function render(item) {
+
             //target blank for all <a>
             containerHelper.targetBlank(containerHelper.get(item));
-            
+
             //add stylesheets
             itemStylesheetHandler.attach(item.stylesheets);
+        },
+
+        /**
+         * Unrender
+         */
+        destroy : function destroy(){
+
+            //clear the container cache
+            containerHelper.clear();
         }
     };
 });

--- a/views/js/qtiItem/core/Item.js
+++ b/views/js/qtiItem/core/Item.js
@@ -1,3 +1,28 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+/**
+ * QTI Item Element model
+ *
+ * @author Sam Sipasseuth <sam@taotesting.com>
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
 define([
     'taoQtiItem/qtiItem/core/Element',
     'taoQtiItem/qtiItem/core/IdentifiedElement',
@@ -6,6 +31,7 @@ define([
     'jquery',
     'taoQtiItem/qtiItem/helper/util'
 ], function(Element, IdentifiedElement, Container, _, $, util){
+    'use strict';
 
     var Item = IdentifiedElement.extend({
         qtiClass : 'assessmentItem',
@@ -136,32 +162,33 @@ define([
             return this;
         },
         toArray : function(){
+            var i;
             var arr = this._super();
             arr.outcomes = {};
-            for(var i in this.outcomes){
+            for(i in this.outcomes){
                 arr.outcomes[i] = this.outcomes[i].toArray();
             }
             arr.responses = {};
-            for(var i in this.responses){
+            for(i in this.responses){
                 arr.responses[i] = this.responses[i].toArray();
             }
             arr.stylesheets = {};
-            for(var i in this.stylesheets){
+            for(i in this.stylesheets){
                 arr.stylesheets[i] = this.stylesheets[i].toArray();
             }
             arr.namespaces = this.namespaces;
             return arr;
         },
         isEmpty : function(){
-        
+
             var body = this.body().trim();
-            
+
             if(body){
-                
+
                 //hack to fix #2652
                 var $dummy = $('<div>').html(body),
                     $children = $dummy.children();
-                
+
                 if($children.length === 1 && $children.hasClass('empty')){
                     return true;
                 }else{
@@ -170,7 +197,20 @@ define([
             }else{
                 return true;
             }
-        }
+        },
+
+        /**
+         * Clean up an item rendering.
+         * Ask the renderer to run destroy if exists.
+         */
+        clear : function(){
+            var renderer = this.getRenderer();
+            if(renderer){
+                if(_.isFunction(renderer.destroy)){
+                    renderer.destroy(this);
+                }
+            }
+        },
     });
 
     Container.augment(Item);

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -65,7 +65,7 @@ define([
 
         render : function(elt, done){
             var self = this;
-            var pics;
+            var pics, picsList;
             var renderDone;
             var current = 0;
             var timeout = this.options.timeout || 20000;
@@ -105,6 +105,8 @@ define([
 
                 //the collection of PICs
                 pics = picManager.collection(self._item);
+                picsList = pics.getList();
+
 
                 //call once the rendering is done
                 renderDone = function renderDone(){
@@ -117,11 +119,12 @@ define([
                     self.trigger('listpic', pics);
                 };
 
-                if(pics.getList().length){
+                if(picsList.length){
+
                     //wait until all PICs are loaded/ready
                     async.until(
                         function arePicReady(){
-                            return _.every(pics.getList(), function(pic){
+                            return _.every(picsList, function(pic){
                                 return pic.getTypeIdentifier() === 'studentToolbar' || pic.getPic().data('_ready');
                             });
                         },
@@ -141,8 +144,7 @@ define([
                     );
                     return;
                 }
-
-                renderDone();
+                _.defer(renderDone);
             }
         },
 
@@ -152,6 +154,7 @@ define([
         clear : function(elt, done){
             if(this._item){
 
+                this._item.clear();
                _.invoke(this._item.getInteractions(), 'clear');
 
                 $(elt).off('responseChange')

--- a/views/js/test/qtiCommonRenderer/interactions/associate/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/associate/test.js
@@ -4,11 +4,20 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/rivals.json',
 ], function($, _, qtiItemRunner, associateData){
+    'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container';
     var outsideContainerId = 'outside-container';
 
-    module('Associate Interaction');
+
+    module('Associate Interaction', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('renders correclty', function(assert){
         QUnit.expect(21);
@@ -18,7 +27,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', associateData)
+        runner = qtiItemRunner('qti', associateData)
             .on('render', function(){
 
                 //check DOM
@@ -60,7 +69,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', associateData)
+        runner = qtiItemRunner('qti', associateData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-associateInteraction').length, 1, 'the container contains an associate interaction .qti-associateInteraction');
 

--- a/views/js/test/qtiCommonRenderer/interactions/choice/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/choice/test.js
@@ -5,11 +5,19 @@ define([
     'json!taoQtiItem/test/samples/json/space-shuttle.json',
     'json!taoQtiItem/test/samples/json/space-shuttle-m.json'
 ], function($, _, qtiItemRunner, choiceData, multipleChoiceData){
+    'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container';
     var outsideContainerId = 'outside-container';
 
-    module('Choice Interaction');
+    module('Choice Interaction', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('renders correclty', function(assert){
         QUnit.expect(17);
@@ -19,7 +27,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', choiceData)
+        runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
 
                 //check DOM
@@ -57,7 +65,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', choiceData)
+        runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
@@ -88,7 +96,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', choiceData)
+        runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
@@ -132,7 +140,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', multipleChoiceData)
+        runner = qtiItemRunner('qti', multipleChoiceData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
@@ -172,7 +180,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', choiceData)
+        runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
 
                 assert.ok( ! $('[data-identifier="Atlantis"] input', $container).prop('checked'), 'Atlantis is not checked');
@@ -195,7 +203,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', choiceData)
+        runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
                 var self = this;
 
@@ -228,7 +236,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', choiceData)
+        runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
                 var self = this;
 
@@ -271,7 +279,7 @@ define([
         var shuffled = _.cloneDeep(choiceData);
         shuffled.body.elements.interaction_choiceinteraction_546cb89e04090230494786.attributes.shuffle = true;
 
-        qtiItemRunner('qti', shuffled)
+        runner = qtiItemRunner('qti', shuffled)
             .on('render', function(){
                 var self = this;
 

--- a/views/js/test/qtiCommonRenderer/interactions/extendedText/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/extendedText/test.js
@@ -10,6 +10,7 @@ define([
 ], function($, _, qtiItemRunner, itemDataPlain, itemDataXhtml, keystroker, containerHelper, ckEditor){
     'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container-';
 
     var showErrors = true;
@@ -22,7 +23,13 @@ define([
 
 /** PLAIN **/
 
-    QUnit.module('Extended Text Interaction - plain format');
+    QUnit.module('Extended Text Interaction - plain format', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
 
     QUnit.asyncTest('renders correctly', function(assert){
@@ -33,7 +40,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataPlain)
+        runner = qtiItemRunner('qti', itemDataPlain)
             .on('error', logError)
             .on('render', function(){
 
@@ -71,7 +78,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataPlain)
+        runner = qtiItemRunner('qti', itemDataPlain)
             .on('error', logError)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
@@ -101,7 +108,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataPlain)
+        runner = qtiItemRunner('qti', itemDataPlain)
             .on('error', logError)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-extendedTextInteraction').length, 1, 'the container contains a text interaction .qti-extendedTextInteraction');
@@ -128,7 +135,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataPlain)
+        runner = qtiItemRunner('qti', itemDataPlain)
             .on('error', logError)
             .on('render', function(){
                 var self = this;
@@ -165,7 +172,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataPlain)
+        runner = qtiItemRunner('qti', itemDataPlain)
             .on('error', logError)
             .on('render', function(){
                 var self = this;
@@ -197,8 +204,13 @@ define([
 
 /** XHTML **/
 
-    QUnit.module('Extended Text Interaction - XHTML format');
-
+    QUnit.module('Extended Text Interaction - XHTML format', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('renders correctly', function(assert){
         QUnit.expect(10);
@@ -208,7 +220,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataXhtml)
+        runner = qtiItemRunner('qti', itemDataXhtml)
             .on('error', logError)
             .on('render', function(){
                 _.delay(function() {
@@ -244,7 +256,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataXhtml)
+        runner = qtiItemRunner('qti', itemDataXhtml)
             .on('error', logError)
             .on('render', function(){
                 var self = this;
@@ -282,7 +294,7 @@ define([
 
         var cpt = 0;
 
-        var runner = qtiItemRunner('qti', itemDataXhtml)
+        runner = qtiItemRunner('qti', itemDataXhtml)
             .on('error', logError)
             .on('render', function(){
                 var self = this;
@@ -329,7 +341,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataXhtml)
+        runner = qtiItemRunner('qti', itemDataXhtml)
             .on('error', logError)
             .on('render', function(){
                 var self = this;
@@ -366,7 +378,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemDataXhtml)
+        runner = qtiItemRunner('qti', itemDataXhtml)
             .on('error', logError)
             .on('render', function(){
                 var self = this;

--- a/views/js/test/qtiCommonRenderer/interactions/gapMatch/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/gapMatch/test.js
@@ -4,11 +4,20 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/tao-item.json',
 ], function($, _, qtiItemRunner, gapMatchData){
+    'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container';
     var outsideContainerId = 'outside-container';
 
-    module('GapMatch Interaction');
+    module('GapMatch Interaction', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
+
 
     QUnit.asyncTest('renders correclty', function(assert){
         QUnit.expect(30);
@@ -18,7 +27,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', gapMatchData)
+        runner = qtiItemRunner('qti', gapMatchData)
             .on('render', function(){
 
                 //check DOM
@@ -69,7 +78,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', gapMatchData)
+        runner = qtiItemRunner('qti', gapMatchData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-gapMatchInteraction').length, 1, 'the container contains a choice interaction .qti-gapMatchInteraction');
                 assert.equal($container.find('.qti-gapMatchInteraction .qti-choice').length, 16, 'the interaction has 16 choices including gaps');
@@ -105,7 +114,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', gapMatchData)
+        runner = qtiItemRunner('qti', gapMatchData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-gapMatchInteraction').length, 1, 'the container contains a choice interaction .qti-gapMatchInteraction');
                 assert.equal($container.find('.qti-gapMatchInteraction .qti-choice').length, 16, 'the interaction has 16 choices including gaps');
@@ -141,7 +150,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', gapMatchData)
+        runner = qtiItemRunner('qti', gapMatchData)
             .on('render', function(){
 
                 assert.equal($container.find('.qti-interaction.qti-gapMatchInteraction').length, 1, 'the container contains a choice interaction .qti-gapMatchInteraction');
@@ -215,7 +224,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', gapMatchData)
+        runner = qtiItemRunner('qti', gapMatchData)
             .on('render', function(){
                 var self = this;
 
@@ -265,7 +274,7 @@ define([
         var shuffled = _.cloneDeep(gapMatchData);
         shuffled.body.elements.interaction_gapmatchinteraction_547dd4d24d2d0146858817.attributes.shuffle = true;
 
-        qtiItemRunner('qti', shuffled)
+        runner = qtiItemRunner('qti', shuffled)
             .on('render', function(){
                 var self = this;
 

--- a/views/js/test/qtiCommonRenderer/interactions/inlineChoice/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/inlineChoice/test.js
@@ -4,11 +4,20 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/richardIII-1.json'
 ], function($, _, qtiItemRunner, inlineChoiceData){
+    'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container';
     var outsideContainerId = 'outside-container';
 
-    module('Inline Choice Interaction');
+    module('Inline Choice Interaction', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
+
 
     QUnit.asyncTest('renders correclty', function(assert){
         QUnit.expect(17);
@@ -18,7 +27,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', inlineChoiceData)
+        runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function(){
 
                 //check DOM
@@ -58,7 +67,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', inlineChoiceData)
+        runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function(){
 
                 var $select = $('select.qti-inlineChoiceInteraction', $container);
@@ -89,7 +98,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', inlineChoiceData)
+        runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function(){
 
                 var $select = $('select.qti-inlineChoiceInteraction', $container);
@@ -118,7 +127,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', inlineChoiceData)
+        runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function(){
                 var self = this;
 
@@ -156,7 +165,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', inlineChoiceData)
+        runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function(){
                 var self = this;
 
@@ -200,7 +209,7 @@ define([
         var shuffled = _.cloneDeep(inlineChoiceData);
         shuffled.body.elements.interaction_inlinechoiceinteraction_547464dbc7afc574464937.attributes.shuffle = true;
 
-        qtiItemRunner('qti', shuffled)
+        runner = qtiItemRunner('qti', shuffled)
             .on('render', function(){
                 var self = this;
 
@@ -241,7 +250,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', inlineChoiceData)
+        runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function(){
                 var $select = $('select.qti-inlineChoiceInteraction', $container);
                 assert.equal($select.length, 1, 'the container contains an inlineChoice interaction .qti-inlineChoiceInteraction');

--- a/views/js/test/qtiCommonRenderer/interactions/match/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/match/test.js
@@ -4,11 +4,19 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/characters.json',
 ], function($, _, qtiItemRunner, matchData){
+    'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container';
     var outsideContainerId = 'outside-container';
 
-    module('Match Interaction');
+    module('Match Interaction', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('renders correclty', function(assert){
         QUnit.expect(20);
@@ -18,7 +26,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', matchData)
+        runner = qtiItemRunner('qti', matchData)
             .on('render', function(){
 
                 //check DOM
@@ -60,7 +68,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', matchData)
+        runner = qtiItemRunner('qti', matchData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-matchInteraction').length, 1, 'the container contains a choice interaction .qti-matchInteraction');
                 assert.equal($container.find('.qti-matchInteraction .qti-choice').length, 7, 'the interaction has 5 choices');
@@ -91,7 +99,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', matchData)
+        runner = qtiItemRunner('qti', matchData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-matchInteraction').length, 1, 'the container contains a choice interaction .qti-matchInteraction');
                 assert.equal($container.find('.qti-matchInteraction .qti-choice').length, 7, 'the interaction has 5 choices');
@@ -124,7 +132,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', matchData)
+        runner = qtiItemRunner('qti', matchData)
             .on('render', function(){
 
                 var $cr = $('tbody tr:eq(0) td:eq(0) input', $container);
@@ -157,7 +165,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', matchData)
+        runner = qtiItemRunner('qti', matchData)
             .on('render', function(){
                 var self = this;
 
@@ -190,7 +198,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', matchData)
+        runner = qtiItemRunner('qti', matchData)
             .on('render', function(){
                 var self = this;
 
@@ -234,7 +242,7 @@ define([
         var shuffled = _.cloneDeep(matchData);
         shuffled.body.elements.interaction_matchinteraction_547481b197d23287450469.attributes.shuffle = true;
 
-        qtiItemRunner('qti', shuffled)
+        runner = qtiItemRunner('qti', shuffled)
             .on('render', function(){
                 var self = this;
 
@@ -279,7 +287,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', matchData)
+        runner = qtiItemRunner('qti', matchData)
             .on('render', function(){
 
                 assert.equal($container.find('.qti-interaction.qti-matchInteraction').length, 1, 'the container contains a choice interaction .qti-matchInteraction');

--- a/views/js/test/qtiCommonRenderer/interactions/media/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/media/test.js
@@ -6,10 +6,17 @@ define([
 ], function($, _, qtiItemRunner, mediaData){
     'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container';
     var outsideContainerId = 'outside-container';
 
-    module('Media Interaction');
+    module('Media Interaction', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('renders correctly', function(assert){
         QUnit.expect(12);
@@ -19,7 +26,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', mediaData)
+        runner = qtiItemRunner('qti', mediaData)
             .on('render', function(){
 
                 //check DOM
@@ -53,7 +60,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', mediaData)
+        runner = qtiItemRunner('qti', mediaData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-mediaInteraction').length, 1, 'the container contains a choice interaction .qti-mediaInteraction');
                 assert.equal($container.find('.qti-mediaInteraction video').length, 1, 'the interaction has element');

--- a/views/js/test/qtiCommonRenderer/interactions/order/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/order/test.js
@@ -4,11 +4,19 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/history.json'
 ], function($, _, qtiItemRunner, orderData){
+    'use strict';
 
+    var runner;
     var fixtureContainerId = 'item-container';
     var outsideContainerId = 'outside-container';
 
-    module('Order Interaction');
+    module('Order Interaction', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('renders correclty', function(assert){
         QUnit.expect(18);
@@ -18,7 +26,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', orderData)
+        runner = qtiItemRunner('qti', orderData)
             .on('render', function(){
 
                 //check DOM
@@ -56,7 +64,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', orderData)
+        runner = qtiItemRunner('qti', orderData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-orderInteraction').length, 1, 'the container contains a choice interaction .qti-orderInteraction');
                 assert.equal($container.find('.qti-orderInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
@@ -89,7 +97,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', orderData)
+        runner = qtiItemRunner('qti', orderData)
             .on('render', function(){
                 assert.equal($container.find('.qti-interaction.qti-orderInteraction').length, 1, 'the container contains a choice interaction .qti-orderInteraction');
                 assert.equal($container.find('.qti-orderInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
@@ -140,7 +148,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', orderData)
+        runner = qtiItemRunner('qti', orderData)
             .on('render', function(){
 
                 assert.equal($container.find('.qti-orderInteraction .choice-area .qti-choice').length, 5, 'the choice list contains all choices');
@@ -167,7 +175,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', orderData)
+        runner = qtiItemRunner('qti', orderData)
             .on('render', function(){
                 var self = this;
 
@@ -199,7 +207,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', orderData)
+        runner = qtiItemRunner('qti', orderData)
             .on('render', function(){
                 var self = this;
 
@@ -244,7 +252,7 @@ define([
         var shuffled = _.cloneDeep(orderData);
         shuffled.body.elements.interaction_orderinteraction_547481ffc8c1b803673841.attributes.shuffle = true;
 
-        qtiItemRunner('qti', shuffled)
+        runner = qtiItemRunner('qti', shuffled)
             .on('render', function(){
                 var self = this;
 
@@ -283,7 +291,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', orderData)
+        runner = qtiItemRunner('qti', orderData)
             .on('render', function(){
 
                 assert.equal($container.find('.qti-interaction.qti-orderInteraction').length, 1, 'the container contains a choice interaction .qti-orderInteraction');

--- a/views/js/test/runner/interactions/choice/test.js
+++ b/views/js/test/runner/interactions/choice/test.js
@@ -4,15 +4,23 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/space-shuttle.json'
 ], function($, _, qtiItemRunner, itemData){
+    'use strict';
 
+    var runner;
     var containerId = 'item-container';
 
-    module('Init');
+    module('Init', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('Item data loading', function(assert){
         QUnit.expect(2);
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
           .on('init', function(){
 
             assert.ok(typeof this._item === 'object', 'The item data is loaded and mapped to an object');
@@ -22,7 +30,13 @@ define([
           }).init();
     });
 
-    module('Render');
+    module('Render', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('Item rendering', function(assert){
         QUnit.expect(3);
@@ -32,7 +46,7 @@ define([
         assert.ok(container instanceof HTMLElement , 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.equal(container.children.length, 1, 'the container has children');
@@ -53,7 +67,7 @@ define([
         assert.ok(container instanceof HTMLElement , 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
                 assert.equal(container.children.length, 1, 'the container has children');
 
@@ -69,7 +83,13 @@ define([
             .render(container);
     });
 
-    module('State');
+    module('State', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('get state after changes', function(assert){
         QUnit.expect(12);
@@ -78,7 +98,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('error', function(e){
                 console.error(e);
             })
@@ -125,7 +145,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.ok( ! $('[data-identifier="Atlantis"] input', $(container)).prop('checked'), 'The choice is not checked');
@@ -147,7 +167,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.ok( ! $('[data-identifier="Atlantis"] input', $(container)).prop('checked'), 'The choice is not checked');
@@ -181,7 +201,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('statechange', function(state){
 
                 assert.ok($('[data-identifier="Atlantis"] input', $(container)).prop('checked'), 'The choice is checked');
@@ -208,7 +228,13 @@ define([
             .render(container);
     });
 
-    module('Get responses');
+    module('Get responses', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('no responses set', function(assert){
         QUnit.expect(4);
@@ -217,7 +243,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
                 var responses  = this.getResponses();
 
@@ -238,7 +264,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
                 var responses  = this.getResponses();
 

--- a/views/js/test/runner/interactions/textentry/test.js
+++ b/views/js/test/runner/interactions/textentry/test.js
@@ -4,15 +4,23 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/richardIII-2.json'
 ], function($, _, qtiItemRunner, itemData){
+    'use strict';
 
+    var runner;
     var containerId = 'item-container';
 
-    module('Init');
+    module('Init', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('Item data loading', function(assert){
         QUnit.expect(2);
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
           .on('init', function(){
 
             assert.ok(typeof this._item === 'object', 'The item data is loaded and mapped to an object');
@@ -22,7 +30,13 @@ define([
           }).init();
     });
 
-    module('Render');
+    module('Render', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('Item rendering', function(assert){
         QUnit.expect(3);
@@ -32,7 +46,7 @@ define([
         assert.ok(container instanceof HTMLElement , 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.equal(container.children.length, 1, 'the container has children');
@@ -53,7 +67,7 @@ define([
         assert.ok(container instanceof HTMLElement , 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
                 assert.equal(container.children.length, 1, 'the container has children');
 
@@ -69,7 +83,13 @@ define([
             .render(container);
     });
 
-    module('State');
+    module('State', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('get state after changes', function(assert){
         QUnit.expect(12);
@@ -80,7 +100,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('error', function(e){
                 console.error(e);
             })
@@ -126,7 +146,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.equal($('input.qti-textEntryInteraction', $(container)).val(), '', 'The current value is empty');
@@ -148,7 +168,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
 
                 //default state
@@ -179,7 +199,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('statechange', function(state){
 
                 assert.equal($('input.qti-textEntryInteraction', $(container)).val(), 'woopsy', 'The current value matches the given state');
@@ -205,7 +225,13 @@ define([
             .render(container);
     });
 
-    module('Get responses');
+    module('Get responses', {
+        teardown : function(){
+            if(runner){
+                runner.clear();
+            }
+        }
+    });
 
     QUnit.asyncTest('no responses set', function(assert){
         QUnit.expect(4);
@@ -214,7 +240,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
                 var responses  = this.getResponses();
 
@@ -235,7 +261,7 @@ define([
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
 
-        qtiItemRunner('qti', itemData)
+        runner = qtiItemRunner('qti', itemData)
             .on('render', function(){
                 var responses  = this.getResponses();
 

--- a/views/js/test/runner/provider/test.js
+++ b/views/js/test/runner/provider/test.js
@@ -8,6 +8,7 @@ define([
 ], function($, _, itemRunner, qtiRuntimeProvider, itemData, itemDataPic){
     'use strict';
 
+    var runner;
     var containerId = 'item-container';
 
 
@@ -85,7 +86,9 @@ define([
     QUnit.module('Provider render', {
         teardown : function(){
             //reset the provides
+            runner.clear();
             itemRunner.providers = undefined;
+
         }
     });
 
@@ -99,7 +102,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.equal(container.children.length, 1, 'the container has children');
@@ -117,7 +120,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('init', function(){
                 this._item.renderer = null;
                 this.render(container);
@@ -173,6 +176,7 @@ define([
     QUnit.module('Provider state', {
         teardown : function(){
             //reset the provides
+            runner.clear();
             itemRunner.providers = undefined;
         }
     });
@@ -186,7 +190,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('render', function(){
                 var state  = this.getState();
 
@@ -209,7 +213,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('error', function(e){
                 console.error(e);
             })
@@ -258,7 +262,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.ok( ! $('[data-identifier="Atlantis"] input', $(container)).prop('checked'), 'The choice is not checked');
@@ -282,7 +286,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('render', function(){
 
                 assert.ok( ! $('[data-identifier="Atlantis"] input', $(container)).prop('checked'), 'The choice is not checked');
@@ -318,7 +322,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('statechange', function(state){
 
                 assert.ok($('[data-identifier="Atlantis"] input', $(container)).prop('checked'), 'The choice is checked');
@@ -348,6 +352,7 @@ define([
     QUnit.module('Provider responses', {
         teardown : function(){
             //reset the provides
+            runner.clear();
             itemRunner.providers = undefined;
         }
     });
@@ -361,7 +366,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('render', function(){
                 var responses  = this.getResponses();
 
@@ -384,7 +389,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemData)
+        runner = itemRunner('qti', itemData)
             .on('render', function(){
                 var responses  = this.getResponses();
 
@@ -411,6 +416,7 @@ define([
     QUnit.module('Provider PIC', {
         teardown : function(){
             //reset the provides
+            runner.clear();
             itemRunner.providers = undefined;
         }
     });
@@ -424,7 +430,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemDataPic)
+        runner = itemRunner('qti', itemDataPic)
             .on('listpic', function(picManager){
                 assert.ok(typeof picManager === 'object', 'the pic manager is an object');
                 assert.ok(typeof picManager.getList === 'function', 'the pic manager has a getList method');
@@ -454,7 +460,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemDataPic)
+        runner = itemRunner('qti', itemDataPic)
             .on('listpic', function(picManager){
                 assert.ok(typeof picManager === 'object', 'the pic manager is an object');
                 assert.ok(typeof picManager.getPic === 'function', 'the pic manager has a getPic method');
@@ -496,7 +502,7 @@ define([
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
-        itemRunner('qti', itemDataPic)
+        runner = itemRunner('qti', itemDataPic)
             .on('render', function(){
                 var state = this.getState();
                 assert.ok(typeof state === 'object', 'The state is an object');


### PR DESCRIPTION
A regression (that was fixing `views/js/qtiCommonRenderer/helpers/container.js` in adding containers to a cache) has introduced issues in interaction/pic/pci rendering. 
All tests were failing.
This fix the unit tests (except the theme loader and extendedText tests that fails for other reasons)