### PR TITLE
cast outcome variables

### DIFF
--- a/views/js/test/scoring/provider/test.js
+++ b/views/js/test/scoring/provider/test.js
@@ -75,7 +75,7 @@ define([
 
         var noRulesItemData = _.cloneDeep(singleCorrectData);
         noRulesItemData.responseProcessing.responseRules = [];
-        console.log(noRulesItemData);
+
         scorer.register('qti', qtiScoringProvider);
 
         scorer('qti')

--- a/views/js/test/scoring/provider/test.js
+++ b/views/js/test/scoring/provider/test.js
@@ -75,7 +75,7 @@ define([
 
         var noRulesItemData = _.cloneDeep(singleCorrectData);
         noRulesItemData.responseProcessing.responseRules = [];
-
+        console.log(noRulesItemData);
         scorer.register('qti', qtiScoringProvider);
 
         scorer('qti')
@@ -88,7 +88,7 @@ define([
                 assert.ok(typeof outcomes.RESPONSE === 'object', "the outcomes contains the response");
                 assert.deepEqual(outcomes.RESPONSE, responses.RESPONSE, "the response is the same");
                 assert.ok(typeof outcomes.SCORE === 'object', "the outcomes contains the score");
-                assert.deepEqual(outcomes.SCORE, { base : { integer : '0' } }, "the score has the default value");
+                assert.deepEqual(outcomes.SCORE, { base : { integer : 0 } }, "the score has the default value");
 
                 QUnit.start();
             })
@@ -266,7 +266,7 @@ define([
         item    : customChoiceMultipleData,
         resp    : { RESPONSE_13390220 : { list : { identifier: ['choice_853818748'] } } },
         outcomes : {
-            SCORE : { base : { 'float' : '0.0' } },
+            SCORE : { base : { 'float' : 0 } },
             FEEDBACKBASIC : { base : { 'identifier' : 'incorrect' } }
         }
     }, {
@@ -290,7 +290,7 @@ define([
         item    : customTextEntryNumericData,
         resp    : { RESPONSE_1 : { base : { float: 5.8756 } } },
         outcomes : {
-            SCORE : { base : { 'float' : '0.0' } },
+            SCORE : { base : { 'float' : 0 } },
             FEEDBACKBASIC : { base : { 'identifier' : 'incorrect' } }
         }
     },{
@@ -322,7 +322,7 @@ define([
         item    : customChoiceSingleData,
         resp    : { RESPONSE : { list : { directedPair: [ 'Match29886762 Match30518135', 'Match2607634 Match5256823', 'Match4430647 Match8604807', 'Match1403839 Match5570831'] } } },
         outcomes : {
-            SCORE : { base : { 'float' : "0.0" } },
+            SCORE : { base : { 'float' : 0 } },
             FEEDBACKBASIC : { base : { 'identifier' : 'incorrect' } }
         }
     },{


### PR DESCRIPTION
Outcome variable values needs to be casted and also I need to apply a rule for consistency with qti-sm sdk:
 - an outcome variable, single cardinality, float or int, with a default value to null will be defaulted to 0 (because the default scoring tempaltes rule lacks of that part).

The unit test `/taoQtiItem/views/js/test/scoring/provider/test.html` is the only way to test it.