### PR TITLE
call initLastItemData directly 

### DIFF
--- a/views/js/qtiCreator/editor/editor.js
+++ b/views/js/qtiCreator/editor/editor.js
@@ -189,9 +189,7 @@ define([
         askForSave = false;
 
         //serialize the item at the initialization level
-        widget.on('ready.qti-widget', function() {
-            initLastItemData(widget.element);
-        });
+        initLastItemData(widget.element);
 
         //get the last value by saving
         $('#save-trigger')


### PR DESCRIPTION
because the widget is already ready when initGui is called