### PR TITLE
encode/decode mathML annotations

### DIFF
--- a/views/js/qtiItem/core/Loader.js
+++ b/views/js/qtiItem/core/Loader.js
@@ -382,7 +382,9 @@ define(['lodash', 'class', 'taoQtiItem/qtiItem/core/qtiClasses', 'taoQtiItem/qti
         loadMathData : function(math, data){
             math.ns = data.ns || {};
             math.setMathML(data.mathML || '');
-            math.annotations = data.annotations || {};
+            _.forIn(data.annotations || {}, function(value, encoding){
+                math.setAnnotation(encoding, value);
+            });
         },
         loadPciData : function(pci, data){
             loadPortableCustomElementData(pci, data);

--- a/views/js/qtiItem/core/Math.js
+++ b/views/js/qtiItem/core/Math.js
@@ -61,7 +61,7 @@ define([
             this.annotations = {};
         },
         setAnnotation : function(encoding, value){
-            this.annotations[encoding] = value;
+            this.annotations[encoding] = _.unescape(value);
         },
         getAnnotation : function(encoding){
             return this.annotations[encoding];
@@ -93,7 +93,7 @@ define([
                 annotations = '';
 
             for(var encoding in this.annotations){
-                annotations += '<annotation encoding="' + encoding + '">' + this.annotations[encoding] + '</annotation>';
+                annotations += '<annotation encoding="' + encoding + '">' + _.escape(this.annotations[encoding]) + '</annotation>';
             }
 
             if(annotations){

--- a/views/js/qtiItem/helper/simpleParser.js
+++ b/views/js/qtiItem/helper/simpleParser.js
@@ -62,7 +62,7 @@ define([
             var $annotation = $(this);
             var encoding = $annotation.attr('encoding');
             if(encoding){
-                elt.annotations[encoding] = $annotation.html();
+                elt.setAnnotation(encoding, $annotation.html());
             }
             $annotation.remove();
         });


### PR DESCRIPTION
This encodes the annotation in the mathML expression, which may be invalid otherwise. For instance, the `&` in `M = \begin{bmatrix} \frac{5}{6} & \frac{1}{6} & 0 \\[0.3em] \frac{5}{6} & 0 & \frac{1}{6} \\[0.3em] 0 & \frac{5}{6} & \frac{1}{6} \end{bmatrix}` will cause invalid entity error for xml parser.