### PR TITLE
Make the ImportService::importItemMetadata available for client

### DIFF
--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -411,7 +411,7 @@ class ImportService extends tao_models_classes_GenerisService
      * @param oat\taoQtiItem\model\qti\metadata\MetadataInjector[] $ontologyInjectors Implementations of MetadataInjector that will take care to inject the metadata values in the appropriate Ontology Resource Properties.
      * @throws oat\taoQtiItem\model\qti\metadata\MetadataInjectionException If an error occurs while importing the metadata. 
      */
-    protected function importItemMetadata(array $metadataValues, Resource $qtiResource, core_kernel_classes_Resource $resource, array $ontologyInjectors = array())
+    public function importItemMetadata(array $metadataValues, Resource $qtiResource, core_kernel_classes_Resource $resource, array $ontologyInjectors = array())
     {
         // Filter metadata values for this given item.
         $identifier = $qtiResource->getIdentifier();


### PR DESCRIPTION
code. The rationale is that it might used by other import systems
e.g. QTI Test Import.