### PR TITLE
Added extra check for prevent errors during dran&drop interactions in…

### DIFF
--- a/views/js/qtiCreator/model/helper/container.js
+++ b/views/js/qtiCreator/model/helper/container.js
@@ -20,15 +20,11 @@ define(['jquery', 'lodash', 'taoQtiItem/qtiCreator/model/qtiClasses'], function(
             require(_.values(required), function(){
 
                 //register and name all loaded classes:
-                var Qti = {};
-                for(var i in arguments) {
-                    if (!arguments.hasOwnProperty(i)) {
-                        continue;
-                    }
-                    if (arguments[i].prototype) {
-                        Qti[arguments[i].prototype.qtiClass] = arguments[i];
-                    }
-                }
+                var Qti = _.reduce([].slice.call(arguments), function (acc, qtiClassElt) {
+                    acc[qtiClassElt.prototype.qtiClass] = qtiClassElt;
+
+                    return acc;
+                }, {});
                 
                 //create new elements
                 var newElts = {};

--- a/views/js/qtiCreator/model/helper/container.js
+++ b/views/js/qtiCreator/model/helper/container.js
@@ -21,8 +21,13 @@ define(['jquery', 'lodash', 'taoQtiItem/qtiCreator/model/qtiClasses'], function(
 
                 //register and name all loaded classes:
                 var Qti = {};
-                for(var i in arguments){
-                    Qti[arguments[i].prototype.qtiClass] = arguments[i];
+                for(var i in arguments) {
+                    if (!arguments.hasOwnProperty(i)) {
+                        continue;
+                    }
+                    if (arguments[i].prototype) {
+                        Qti[arguments[i].prototype.qtiClass] = arguments[i];
+                    }
                 }
                 
                 //create new elements


### PR DESCRIPTION
… Safari

Before in Safari was error

```
TypeError: undefined is not an object (evaluating 'arguments[i].prototype.qtiClass')
(anonymous function)container.js:24
execCbrequire.js:1657
checkrequire.js:873
(anonymous function)require.js:1120
(anonymous function)require.js:131
(anonymous function)require.js:1163
eachrequire.js:56
emitrequire.js:1162
checkrequire.js:924
(anonymous function)require.js:1120
(anonymous function)require.js:131
(anonymous function)require.js:1163
eachrequire.js:56
emitrequire.js:1162
checkrequire.js:924
enablerequire.js:1150
initrequire.js:781
callGetModulerequire.js:1177
completeLoadrequire.js:1551
onScriptLoadrequire.js:1678
```