### PR TITLE
Trial to have correct messages when items fail to import.

### DIFF
--- a/model/qti/Parser.php
+++ b/model/qti/Parser.php
@@ -55,11 +55,36 @@ class Parser extends tao_models_classes_Parser
     public function validate($schema = ''){
         
         if (empty($schema)) {
-            $validSchema = $this->validateMultiple(array(
-                __DIR__.'/data/qtiv2p1/imsqti_v2p1.xsd',
-                __DIR__.'/data/qtiv2p0/imsqti_v2p0.xsd',
-                __DIR__.'/data/apipv1p0/Core_Level/Package/apipv1p0_qtiitemv2p1_v1p0.xsd'
-            ));
+            
+            // Let's detect NS in use...
+            $dom = new DOMDocument('1.0', 'UTF-8');
+            $dom->loadXML($this->source);
+            
+            // default is QTI 2.1.
+            $schemas = array(
+                __DIR__.'/data/qtiv2p1/imsqti_v2p1.xsd'
+            );
+            
+            // Retrieve Root's namespace.
+            $ns = $dom->documentElement->lookupNamespaceUri(null);
+            switch ($ns) {
+                case 'http://www.imsglobal.org/xsd/imsqti_v2p0':
+                    $schemas = array(
+                        __DIR__.'/data/qtiv2p0/imsqti_v2p0.xsd',
+                    );
+                    break;
+                    
+                case 'http://www.imsglobal.org/xsd/apip/apipv1p0/qtiitem/imsqti_v2p1':
+                    $schemas = array(
+                        __DIR__.'/data/qtiv2p0/imsqti_v2p0.xsd',
+                        __DIR__.'/data/apipv1p0/Core_Level/Package/apipv1p0_qtiitemv2p1_v1p0.xsd'
+                    );
+                    break;
+            }
+            
+            \common_Logger::i("The following schema will be used to validate: '" . $schemas[0] . "'.");
+            
+            $validSchema = $this->validateMultiple($schemas);
             $returnValue = $validSchema !== '';
         } elseif(!file_exists($schema)) {
             throw new \common_Exception('no schema found in the location '.$schema);

--- a/model/qti/Parser.php
+++ b/model/qti/Parser.php
@@ -59,12 +59,7 @@ class Parser extends tao_models_classes_Parser
             // Let's detect NS in use...
             $dom = new DOMDocument('1.0', 'UTF-8');
             $dom->loadXML($this->source);
-            
-            // default is QTI 2.1.
-            $schemas = array(
-                __DIR__.'/data/qtiv2p1/imsqti_v2p1.xsd'
-            );
-            
+
             // Retrieve Root's namespace.
             $ns = $dom->documentElement->lookupNamespaceUri(null);
             switch ($ns) {
@@ -73,11 +68,18 @@ class Parser extends tao_models_classes_Parser
                         __DIR__.'/data/qtiv2p0/imsqti_v2p0.xsd',
                     );
                     break;
-                    
+
                 case 'http://www.imsglobal.org/xsd/apip/apipv1p0/qtiitem/imsqti_v2p1':
                     $schemas = array(
                         __DIR__.'/data/qtiv2p0/imsqti_v2p0.xsd',
                         __DIR__.'/data/apipv1p0/Core_Level/Package/apipv1p0_qtiitemv2p1_v1p0.xsd'
+                    );
+                    break;
+                
+                // default is QTI 2.1.
+                default :
+                    $schemas = array(
+                        __DIR__.'/data/qtiv2p1/imsqti_v2p1.xsd'
                     );
                     break;
             }


### PR DESCRIPTION
This PR inspects the parser's source to determines which is the correct XSD to be used for validation at QTI Item Package import time.

Antoine, I would like you to check

1. When importing an invalid QTI Package (select QTI in import form), the error message is correctly displayed and appropriate.
2. When importing an invalid APIP Package (select APIP in import form), the error message is correctly displayed and appropriate.
3. When importing a valid QTI Package, there is no error message and everything is there.
4. When importing a valid APIP Package, there is no error message and everything is there.

I send you some samples by email.