### PR TITLE
portable shared util

### DIFF
--- a/install/scripts/addPortableSharedLibraries.php
+++ b/install/scripts/addPortableSharedLibraries.php
@@ -38,6 +38,8 @@ $registry->registerFromFile('OAT/util/math', $installBasePath . '/OAT/util/math.
 $registry->registerFromFile('OAT/util/html', $installBasePath . '/OAT/util/html.js');
 $registry->registerFromFile('OAT/util/EventMgr', $installBasePath . '/OAT/util/EventMgr.js');
 $registry->registerFromFile('OAT/util/event', $installBasePath . '/OAT/util/event.js');
+$registry->registerFromFile('OAT/util/asset', $installBasePath . '/OAT/util/asset.js');
+$registry->registerFromFile('OAT/util/tpl', $installBasePath . '/OAT/util/tpl.js');
 $registry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
 $registry->registerFromFile('OAT/interact', $installBasePath . '/OAT/interact.js');
 $registry->registerFromFile('OAT/interact-rotate', $installBasePath . '/OAT/interact-rotate.js');

--- a/install/scripts/portableSharedLibraries/OAT/util/asset.js
+++ b/install/scripts/portableSharedLibraries/OAT/util/asset.js
@@ -17,8 +17,15 @@
  *
  */
 define(['IMSGlobal/jquery_2_1_1', 'OAT/lodash'], function($, _){
-
-
+    
+    'use strict';
+    
+    /**
+     * Get all assets found in the $container and returns an object containing [assetId => assetUrl]
+     * 
+     * @param {jQuery} $container
+     * @returns {object}
+     */
     function getAllAssets($container){
         var assets = {};
         var $assets = $($container.find('[type="text/x-asset-manifest"]').html());
@@ -35,11 +42,20 @@ define(['IMSGlobal/jquery_2_1_1', 'OAT/lodash'], function($, _){
         return assets;
     }
     
-    function asset($container){
+    /**
+     * Create an asset manager object from a JQuery container
+     * 
+     * @param {jQuery} $container
+     * @returns {object}
+     */
+    return function asset($container){
         
         var assets = getAllAssets($container);
         
         return {
+            exists : function exists(id){
+                return (id && assets[id]);
+            },
             get : function get(id){
                 return assets[id] || '';
             },
@@ -48,6 +64,4 @@ define(['IMSGlobal/jquery_2_1_1', 'OAT/lodash'], function($, _){
             }
         };
     };
-    
-    return asset;
 });

--- a/install/scripts/portableSharedLibraries/OAT/util/asset.js
+++ b/install/scripts/portableSharedLibraries/OAT/util/asset.js
@@ -1,0 +1,53 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ *
+ */
+define(['IMSGlobal/jquery_2_1_1', 'OAT/lodash'], function($, _){
+
+
+    function getAllAssets($container){
+        var assets = {};
+        var $assets = $($container.find('[type="text/x-asset-manifest"]').html());
+        $assets.each(function(){
+            
+            var $asset = $(this),
+                id = $asset.data('asset-id'),
+                src = $asset.attr('src');
+                
+            if(id && src){
+                assets[id] = src;
+            }
+        });
+        return assets;
+    }
+    
+    function asset($container){
+        
+        var assets = getAllAssets($container);
+        
+        return {
+            get : function get(id){
+                return assets[id] || '';
+            },
+            getAll : function(){
+                return _.clone(assets);
+            }
+        };
+    };
+    
+    return asset;
+});

--- a/install/scripts/portableSharedLibraries/OAT/util/tpl.js
+++ b/install/scripts/portableSharedLibraries/OAT/util/tpl.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
  *
  */
-define(['OAT/handlebars'], function(handlebars){
+define(['IMSGlobal/jquery_2_1_1', 'OAT/handlebars'], function($, handlebars){
     
     'use strict';
     

--- a/install/scripts/portableSharedLibraries/OAT/util/tpl.js
+++ b/install/scripts/portableSharedLibraries/OAT/util/tpl.js
@@ -16,6 +16,46 @@
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
  *
  */
-define([], function(){
+define(['OAT/handlebars'], function(handlebars){
     
+    /**
+     * Find and compile templates found in the $container
+     */
+    function loadTemplates($container){
+        
+        var templates = {};
+        var $templates = $($container.find('[type="text/x-template-manifest"]').html());
+        $templates.each(function(){
+            
+            var $template = $(this),
+                id = $template.data('template-id'),
+                tplBody = $template.html();
+                
+            if(id && tplBody){
+                templates[id] = handlebars.compile();
+            }    
+        });
+        
+        return templates;
+    }
+    
+    function tpl($container){
+        
+        var templates = loadTemplates($container);
+        
+        return {
+            exists : function exists(templateId){
+                return (templateId && templates[templateId]);
+            },
+            render : function render(templateId, data){
+                if(templateId && templates[templateId]){
+                    return templates[templateId](data || {});
+                }else{
+                    throw 'no valid template found for the id ' + templateId;
+                }
+            }
+        };
+    }
+    
+    return tpl;
 });

--- a/install/scripts/portableSharedLibraries/OAT/util/tpl.js
+++ b/install/scripts/portableSharedLibraries/OAT/util/tpl.js
@@ -18,8 +18,13 @@
  */
 define(['OAT/handlebars'], function(handlebars){
     
+    'use strict';
+    
     /**
      * Find and compile templates found in the $container
+     * 
+     * @param {jQuery} $container
+     * @returns {object}
      */
     function loadTemplates($container){
         
@@ -29,17 +34,23 @@ define(['OAT/handlebars'], function(handlebars){
             
             var $template = $(this),
                 id = $template.data('template-id'),
-                tplBody = $template.html();
+                tplSource = $template.html();
                 
-            if(id && tplBody){
-                templates[id] = handlebars.compile();
+            if(id && tplSource){
+                templates[id] = handlebars.compile(tplSource);
             }    
         });
         
         return templates;
     }
     
-    function tpl($container){
+    /**
+     * Create a template manager object from a JQuery container
+     * 
+     * @param {JQuery} $container
+     * @returns {Object}
+     */
+    return function tpl($container){
         
         var templates = loadTemplates($container);
         
@@ -55,7 +66,5 @@ define(['OAT/handlebars'], function(handlebars){
                 }
             }
         };
-    }
-    
-    return tpl;
+    };
 });

--- a/install/scripts/portableSharedLibraries/OAT/util/tpl.js
+++ b/install/scripts/portableSharedLibraries/OAT/util/tpl.js
@@ -1,0 +1,21 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ *
+ */
+define([], function(){
+    
+});

--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'QTI item model',
 	'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '2.11.0',
+    'version' => '2.12.0',
 	'author' => 'Open Assessment Technologies',
 	'requires' => array(
 	    'taoItems' => '>=2.6'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -179,6 +179,11 @@ class Updater extends \common_ext_ExtensionUpdater
         if($currentVersion === '2.10.0') {
             $currentVersion = '2.11.0';
         }
+        if($currentVersion === '2.11.0') {
+            $registry->registerFromFile('OAT/util/asset', $installBasePath . '/OAT/util/asset.js');
+            $registry->registerFromFile('OAT/util/tpl', $installBasePath . '/OAT/util/tpl.js');
+            $currentVersion = '2.12.0';
+        }
 
         return $currentVersion;
     }

--- a/views/js/test/portableSharedLibraries/asset/test.html
+++ b/views/js/test/portableSharedLibraries/asset/test.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="core/Renderer"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="asset"></script>
 
         <script  type="text/javascript">
 

--- a/views/js/test/portableSharedLibraries/asset/test.html
+++ b/views/js/test/portableSharedLibraries/asset/test.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>portable shared lib "asset" Test</title>
+        <base href="../../../../../../../tao/views/" />
+
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="core/Renderer"></script>
+
+        <script  type="text/javascript">
+
+            //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiItem/test/portableSharedLibraries/asset/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.config.reorder = false;
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="interaction-container">
+                <script type="text/x-asset-manifest">
+                    <asset data-asset-id="asset/add.png" src="some/path/to/asset/icon_add.png"/>
+                    <asset data-asset-id="asset/eraser.png" src="some/path/to/asset/icon_eraser.png"/>
+                    <asset data-asset-id="asset/hand.png" src="some/path/to/asset/icon_hand.png"/>
+                    <asset data-asset-id="asset/notepad.png" src="some/path/to/asset/icon_notepad.png"/>
+                    <asset data-asset-id="asset/pen.png" src="some/path/to/asset/icon_pen.png"/>
+                    <asset data-asset-id="asset/tape.mp4" src="some/path/to/asset/tape.mp4"/>
+                    <asset data-asset-id="asset/sample.ogg" src="some/path/to/asset/sample.ogg"/>
+                    <asset data-asset-id="asset/runtime.swf" src="some/path/to/asset/runtime.swf"/>
+                </script>
+            </div>
+        </div>
+    </body>
+</html>

--- a/views/js/test/portableSharedLibraries/asset/test.html
+++ b/views/js/test/portableSharedLibraries/asset/test.html
@@ -18,7 +18,15 @@
 
             //load the config
             require(['/tao/ClientConfig/config'], function(){
-
+                
+                require.config({
+                    paths : {
+                        'IMSGlobal/jquery_2_1_1':   '../../../taoQtiItem/views/js/portableSharedLibraries/IMSGlobal/jquery_2_1_1',
+                        'OAT/lodash':               '../../../taoQtiItem/views/js/portableSharedLibraries/OAT/lodash',
+                        'OAT/util/asset':               '../../../taoQtiItem/views/js/portableSharedLibraries/OAT/util/asset'
+                    }
+                });
+                
                 //load the test
                 require(['taoQtiItem/test/portableSharedLibraries/asset/test'], function(){
 

--- a/views/js/test/portableSharedLibraries/asset/test.js
+++ b/views/js/test/portableSharedLibraries/asset/test.js
@@ -19,6 +19,13 @@ define([
         assert.ok(typeof asset.getAll === 'function', 'asset.getAll() is a function');
     });
     
+    QUnit.test('exists', function(assert){
+        var $container = $('#'+containerId);
+        var asset = assetMgr($container);
+        assert.equal(_.size(asset.getAll()), 8, 'all assets identified');
+        assert.ok(asset.exists('asset/add.png'), 'asset url found');
+    });
+    
     QUnit.test('get', function(assert){
         var $container = $('#'+containerId);
         var asset = assetMgr($container);

--- a/views/js/test/portableSharedLibraries/asset/test.js
+++ b/views/js/test/portableSharedLibraries/asset/test.js
@@ -1,0 +1,30 @@
+define([
+    'jquery',
+    'lodash',
+    'OAT/util/asset'
+], function($, _, assetMgr){
+
+    var containerId = 'interaction-container';
+    
+    QUnit.test('api', function(assert){
+        
+        var asset,
+            $container = $('#'+containerId);
+            
+        assert.ok(typeof assetMgr === 'function', 'asset helper is a function');
+        
+        asset = assetMgr($container);
+        
+        assert.ok(typeof asset.get === 'function', 'asset.get() is a function');
+        assert.ok(typeof asset.getAll === 'function', 'asset.getAll() is a function');
+    });
+    
+    QUnit.test('get', function(assert){
+        var $container = $('#'+containerId);
+        var asset = assetMgr($container);
+        assert.equal(_.size(asset.getAll()), 8, 'all assets identified');
+        assert.equal(asset.get('asset/add.png'), 'some/path/to/asset/icon_add.png', 'asset url found');
+    });
+    
+});
+

--- a/views/js/test/portableSharedLibraries/tpl/test.html
+++ b/views/js/test/portableSharedLibraries/tpl/test.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>portable shared lib "tpl" Test</title>
+        <base href="../../../../../../../tao/views/" />
+
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="tpl"></script>
+
+        <script  type="text/javascript">
+
+            //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiItem/test/portableSharedLibraries/tpl/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.config.reorder = false;
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="interaction-container">
+                <script type="text/x-template-manifest">
+                    <template data-template-id="list" type="handlebars">
+                        <ul class="nav-list">
+                            {{#each items}}
+                            <li class="nav-item">
+                                <a href="#" data-nav-id="{{id}}">{{title}}</a>
+                            </li>
+                            {{/each}}
+                        </ul>
+                    </template>
+                    <template data-template-id="page" type="handlebars">
+                        <div class="page">
+                            {{{content}}}
+                        </div>
+                    </template>
+                </script>
+            </div>
+        </div>
+    </body>
+</html>

--- a/views/js/test/portableSharedLibraries/tpl/test.html
+++ b/views/js/test/portableSharedLibraries/tpl/test.html
@@ -18,7 +18,15 @@
 
             //load the config
             require(['/tao/ClientConfig/config'], function(){
-
+                
+                require.config({
+                    paths : {
+                        'IMSGlobal/jquery_2_1_1':   '../../../taoQtiItem/views/js/portableSharedLibraries/IMSGlobal/jquery_2_1_1',
+                        'OAT/handlebars':               '../../../taoQtiItem/views/js/portableSharedLibraries/OAT/handlebars',
+                        'OAT/util/tpl':               '../../../taoQtiItem/views/js/portableSharedLibraries/OAT/util/tpl'
+                    }
+                });
+                
                 //load the test
                 require(['taoQtiItem/test/portableSharedLibraries/tpl/test'], function(){
 

--- a/views/js/test/portableSharedLibraries/tpl/test.js
+++ b/views/js/test/portableSharedLibraries/tpl/test.js
@@ -1,0 +1,65 @@
+define([
+    'jquery',
+    'lodash',
+    'OAT/util/tpl'
+], function($, _, tplMgr){
+
+    var containerId = 'interaction-container';
+
+    QUnit.test('api', 2, function(assert){
+
+        var tpl,
+            $container = $('#' + containerId);
+
+        assert.ok(typeof tplMgr === 'function', 'tpl manageris a function');
+
+        tpl = tplMgr($container);
+
+        assert.ok(typeof tpl.render === 'function', 'tpl.render() is a function');
+    });
+
+    QUnit.test('exists', 2, function(assert){
+        var $container = $('#' + containerId);
+        var tpl = tplMgr($container);
+        assert.ok(tpl.exists('list'), 'list tpl found');
+        assert.ok(tpl.exists('page'), 'list tpl found');
+    });
+
+    QUnit.test('render', 8, function(assert){
+        var $container = $('#' + containerId);
+        var tpl = tplMgr($container);
+
+        $container.append(tpl.render('page', {content : '<p class="paragraph">paragraph content</p>'}));
+        assert.equal($container.children('.page').children('.paragraph').length, 1, 'rendered "page" element found');
+
+        $container.append(tpl.render('list',
+            {items :
+                    [
+                        {
+                            id : 'element1',
+                            title : 'title of item 1'
+                        },
+                        {
+                            id : 'element2',
+                            title : 'title of item 2'
+                        },
+                        {
+                            id : 'element3',
+                            title : 'title of item 3'
+                        }
+                    ]
+            }));
+        
+        var $li = $container.children('.nav-list').children('.nav-item');
+        assert.equal($li.length, 3, 'rendered "list" element found');
+        assert.equal($($li[0]).children('a').data('nav-id'), 'element1', 'template data properly rendered');
+        assert.equal($($li[0]).children('a').text(), 'title of item 1', 'template data properly rendered');
+        assert.equal($($li[1]).children('a').data('nav-id'), 'element2', 'template data properly rendered');
+        assert.equal($($li[1]).children('a').text(), 'title of item 2', 'template data properly rendered');
+        assert.equal($($li[2]).children('a').data('nav-id'), 'element3', 'template data properly rendered');
+        assert.equal($($li[2]).children('a').text(), 'title of item 3', 'template data properly rendered');
+        
+    });
+
+});
+


### PR DESCRIPTION
This add a standard compliant and more convenient way to manage assets and templates within a pci.
Two util libs are added as shared libs. They rely on the pci markups and custom `<script>` tag  to store additional asset and templates data.
This is best alternative I have found until we have a full-featured PCI SDK.