### PR TITLE
Removing comma from number in text entry interaction for valid parsing

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -29,9 +29,10 @@ define([
     'taoQtiItem/qtiCommonRenderer/helpers/container',
     'taoQtiItem/qtiCommonRenderer/helpers/instructions/instructionManager',
     'taoQtiItem/qtiCommonRenderer/helpers/PciResponse',
+    'util/locale',
     'polyfill/placeholders',
     'tooltipster'
-], function($, _, __, tpl, containerHelper, instructionMgr, pciResponse){
+], function($, _, __, tpl, containerHelper, instructionMgr, pciResponse, locale){
     'use strict';
 
     /**
@@ -146,11 +147,11 @@ define([
             //invalid response or response equals to the placeholder text are considered empty
             value = '';
         }else{
-            if(baseType === 'integer'){
-                value = parseInt($el.val(), numericBase);
-            }else if(baseType === 'float'){
-                value = parseFloat($el.val());
-            }else if(baseType === 'string'){
+            if (baseType === 'integer') {
+                value = locale.parseInt($el.val(), numericBase);
+            } else if (baseType === 'float') {
+                value = locale.parseFloat($el.val());
+            } else if (baseType === 'string') {
                 value = $el.val();
             }
         }

--- a/views/js/test/runner/interactions/textentry/test.js
+++ b/views/js/test/runner/interactions/textentry/test.js
@@ -283,5 +283,6 @@ define([
             .init()
             .render(container);
     });
+
 });
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-1726
And also description in comments here https://oat-sa.atlassian.net/browse/TAO-1723

parseFloat works only with dot in numbers, independently from user locale, so I think remove comma will be enough and better then include big library for this small operation.