### PR TITLE
do not render empty value

### DIFF
--- a/model/qti/templates/qti.responseDeclaration.tpl.php
+++ b/model/qti/templates/qti.responseDeclaration.tpl.php
@@ -28,7 +28,9 @@ $areaMapping = get_data('areaMapping');
 	<correctResponse>
 	    <?php foreach($correctResponses as $value):?>
 	        <?php /** @var oat\taoQtiItem\model\qti\Value $value*/ ?>
+	        <?php if ($value->getValue() !== ''): ?>
 	        <value<?php foreach($value->getAttributeValues() as $attrName => $attrValue):?> <?=$attrName?>="<?=$attrValue?>"<?php endforeach;?>><![CDATA[<?= $value ?>]]></value>
+	        <?php endif; ?>
 	    <?php endforeach?>
 	</correctResponse>
     <?php endif?>

--- a/views/js/qtiXmlRenderer/tpl/responseDeclaration.tpl
+++ b/views/js/qtiXmlRenderer/tpl/responseDeclaration.tpl
@@ -12,7 +12,9 @@
     <correctResponse>
         {{~#each correctResponse}}
         {{~#if ../isRecord}}
+        {{~#if value}}
         <value fieldIdentifier="{{fieldIdentifier}}" baseType="{{baseType}}"><![CDATA[{{{value}}}]]></value>
+        {{/if}}
         {{else}}
         <value><![CDATA[{{{.}}}]]></value>
         {{/if}}


### PR DESCRIPTION
If correct value has not been selected then value element will look like this:
```
<value fieldIdentifier="actualResponse" baseType="integer"><![CDATA[]]></value>
```
to prevent rendering element with empty value I added this condition.