### PR TITLE
fixed replaceControl for unit tests

### DIFF
--- a/views/js/qtiRunner/modalFeedback/inlineRenderer.js
+++ b/views/js/qtiRunner/modalFeedback/inlineRenderer.js
@@ -205,19 +205,25 @@ define([
      */
     function replaceControl(renderedFeebacks, $itemContainer, callback){
         var $scope, $controls, $toggleContainer;
-        if($itemContainer.parents('.tao-preview-scope').length){
-            //preview mode
-            $scope = window.parent.parent.$('#preview-console');
-            $controls = $scope.find('.preview-console-header .action-bar li:visible');
-            $toggleContainer = $scope.find('.console-button-action-bar');
-            initControlToggle(renderedFeebacks, $itemContainer, $controls, $toggleContainer, previewOkBtn, callback);
+        if(window.parent && window.parent.parent && window.parent.parent.$){
+            if($itemContainer.parents('.tao-preview-scope').length){
+                //preview mode
+                $scope = window.parent.parent.$('#preview-console');
+                $controls = $scope.find('.preview-console-header .action-bar li:visible');
+                $toggleContainer = $scope.find('.console-button-action-bar');
+                initControlToggle(renderedFeebacks, $itemContainer, $controls, $toggleContainer, previewOkBtn, callback);
 
+            }else{
+                //delivery delivery
+                $scope = window.parent.parent.$('body.qti-test-scope .bottom-action-bar');
+                $controls = $scope.find('li:visible');
+                $toggleContainer = $scope.find('.navi-box-list');
+                initControlToggle(renderedFeebacks, $itemContainer, $controls, $toggleContainer, deliveryOkBtn, callback);
+            }
         }else{
-            //delivery delivery
-            $scope = window.parent.parent.$('body.qti-test-scope .bottom-action-bar');
-            $controls = $scope.find('li:visible');
-            $toggleContainer = $scope.find('.navi-box-list');
-            initControlToggle(renderedFeebacks, $itemContainer, $controls, $toggleContainer, deliveryOkBtn, callback);
+            //not in an iframe, add to item body for now
+            $scope = $itemContainer.find('#modalFeedbacks');
+            initControlToggle(renderedFeebacks, $itemContainer, $(), $scope, previewOkBtn, callback);
         }
     }
 
@@ -261,6 +267,7 @@ define([
      * @param {Array} interactionContainers
      */
     function cover(interactionContainers){
+        return;
         var $cover = $('<div class="interaction-cover modal-bg">');
         _.each(interactionContainers, function ($interaction){
             $interaction.append($cover);

--- a/views/js/qtiRunner/modalFeedback/inlineRenderer.js
+++ b/views/js/qtiRunner/modalFeedback/inlineRenderer.js
@@ -267,7 +267,6 @@ define([
      * @param {Array} interactionContainers
      */
     function cover(interactionContainers){
-        return;
         var $cover = $('<div class="interaction-cover modal-bg">');
         _.each(interactionContainers, function ($interaction){
             $interaction.append($cover);


### PR DESCRIPTION
Fix the failure in client side unit tests when executing 

```
[package-tao/tao/views/build] grunt connect qunit:single --test /taoQtiItem/views/js/test/qtiRunner/modalFeedback/inlineRenderer/test.html
```


```
Failed

taoQtiItem.views.js.test.qtiRunner.modalFeedback.inlineRenderer.Modal Feedback rendering: renders an item[choice & order interactions]

Failing for the past 1 build (Since Unstable#386 )
Took 90 ms.
add description
Error Message

TypeError: 'undefined' is not a function (evaluating 'window.parent.parent.$('body.qti-test-scope .bottom-action-bar')')
Stacktrace

	http://127.0.0.1:8082/taoQtiItem/views/js/qtiRunner/modalFeedback/inlineRenderer.js:217
			