### PR TITLE
Tao 1239 large preview

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
@@ -84,7 +84,7 @@ define([
             var $previewArea = $container.find('.file-upload-preview');
 
             $previewArea
-                .toggleClass('visible-file-upload-preview runtime-visible-file-upload-preview', visibleFileUploadPreview.isPreviewable)
+                .toggleClass('visible-file-upload-preview runtime-visible-file-upload-preview', !visibleFileUploadPreview.isPreviewable)
                 .previewer({
                     url: reader.result,
                     name: filename,
@@ -95,8 +95,8 @@ define([
             $previewArea.waitForMedia(function(){
 
                 var $originalImg = $previewArea.find('img'), // the previable image
-                    imgNaturalWidth = $originalImg[0].naturalWidth;
-                    //imgNaturalHeight = $originalImg[0].naturalHeight;
+                    imgNaturalWidth = $originalImg[0].naturalWidth,
+                    imgNaturalHeight = $originalImg[0].naturalHeight;
 
                 // if the image natural width is smaller than the qti-item, we do nothing
                 if( imgNaturalWidth <= $('.qti-item').width() ) {
@@ -111,34 +111,44 @@ define([
                     var $popupImg = $originalImg.clone(),
                         $largeDisplayer = $('.file-upload-preview-popup'),
                         $modalBody = $largeDisplayer.find('.modal-body'),
-                        winWidth = $(window).width();
+                        winWidth = $(window).width(),
+                        winHeight = $(window).height(),
+                        $modalOverlay = $container.find('.modal-bg'),
+                        $taoItemScope = $('.tao-item-scope');
+
+                    if( imgNaturalWidth <= $('.qti-item').width() ) {
+                        $largeDisplayer.modal('remove');
+                    }
 
                     // remove any previous unnecessary content before inserting the preview image
+                    $modalOverlay.remove();
                     $modalBody.empty().append($popupImg);
+
+                    $popupImg.wrap('<div>');
 
                     $largeDisplayer
                         .on('opened.modal', function(){
 
-                            console.log($modalBody.length);
                             // setting the modal width depending on the size of the popup image
                             var width = Math.min(winWidth, imgNaturalWidth);
+                            var height = Math.min(winHeight, imgNaturalHeight);
 
                             // prevents the rest of the page from scrolling when modal is open
-                            $('.tao-item-scope.tao-preview-scope').css('overflow', 'hidden');
+                            $taoItemScope.css('overflow', 'hidden');
 
                             $largeDisplayer.width(width);
-                            $largeDisplayer.height($(document).height());
+                            $largeDisplayer.height(height);
+
+                            console.log('$largeDisplayer width =' , $largeDisplayer.width());
+                            console.log('$largeDisplayer height =' , $largeDisplayer.height());
+                            console.log('imgNaturalHeight' , imgNaturalHeight);
                     })
                         .on('closed.modal', function(){
                             // make the page scrollable again
-                            $('.tao-item-scope.tao-preview-scope').css('overflow', 'auto');
+                            $taoItemScope.css('overflow', 'auto');
 
-                            //$largeDisplayer.modal('destroy');
                         })
                         .modal();
-                        /*.on('destroyed.modal', function(){
-                            console.log('destroyed');
-                        })*/
 
                 });
 

--- a/views/js/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
@@ -94,7 +94,7 @@ define([
             // we wait for the image to be completely loaded
             $previewArea.waitForMedia(function(){
 
-                var $originalImg = $previewArea.find('img'), // the previable image
+                var $originalImg = $previewArea.find('img'), // the previewable image
                     imgNaturalWidth = $originalImg[0].naturalWidth,
                     imgNaturalHeight = $originalImg[0].naturalHeight;
 
@@ -104,9 +104,17 @@ define([
                 }
 
                 // otherwise, we allow the user to see the preview image in its natural width inside the modal
+
+                $originalImg.addClass('cursor-pointer');
+
                 $previewArea.on('click', function(){
 
-                    console.log(imgNaturalWidth);
+                    var $self = $(this),
+                    clickedImgNatWidth = $self.find('img')[0].naturalWidth;
+
+                    if( clickedImgNatWidth <= $('.qti-item').width() ) {
+                        return;
+                    }
 
                     var $popupImg = $originalImg.clone(),
                         $largeDisplayer = $('.file-upload-preview-popup'),
@@ -116,9 +124,6 @@ define([
                         $modalOverlay = $container.find('.modal-bg'),
                         $taoItemScope = $('.tao-item-scope');
 
-                    if( imgNaturalWidth <= $('.qti-item').width() ) {
-                        $largeDisplayer.modal('remove');
-                    }
 
                     // remove any previous unnecessary content before inserting the preview image
                     $modalOverlay.remove();
@@ -133,20 +138,15 @@ define([
                             var width = Math.min(winWidth, imgNaturalWidth);
                             var height = Math.min(winHeight, imgNaturalHeight);
 
-                            // prevents the rest of the page from scrolling when modal is open
-                            $taoItemScope.css('overflow', 'hidden');
-
                             $largeDisplayer.width(width);
                             $largeDisplayer.height(height);
 
-                            console.log('$largeDisplayer width =' , $largeDisplayer.width());
-                            console.log('$largeDisplayer height =' , $largeDisplayer.height());
-                            console.log('imgNaturalHeight' , imgNaturalHeight);
-                    })
+                            // prevents the rest of the page from scrolling when modal is open
+                            $taoItemScope.css('overflow', 'hidden');
+                        })
                         .on('closed.modal', function(){
                             // make the page scrollable again
                             $taoItemScope.css('overflow', 'auto');
-
                         })
                         .modal();
 
@@ -169,10 +169,6 @@ define([
             $container.find('.progressbar').progressbar('value', percentProgress);
         };
 
-        /*reader.onloadend = function () {
-            console.log('end load', $('.modal-body').length );
-        };
-*/
         reader.readAsDataURL(file);
 
     };

--- a/views/scss/qti/_upload.scss
+++ b/views/scss/qti/_upload.scss
@@ -73,6 +73,10 @@
                 display: block !important;
             }
         }
+
+        img.cursor-pointer {
+            cursor: pointer;
+        }
     }
 
     .file-upload-preview-popup {

--- a/views/scss/qti/_upload.scss
+++ b/views/scss/qti/_upload.scss
@@ -38,18 +38,19 @@
         height: auto;
         position: relative;
         overflow: hidden;
-        cursor: pointer;
-        display: none;
 
-        &.visible-file-upload-preview {
-            display: block;
-        }
+        //display: none;
+
+        //&.visible-file-upload-preview {
+        //    display: block;
+        //}
 
         &.runtime-visible-file-upload-preview {
             min-width: unset;
             min-height: unset;
             height: auto;
             background: transparent;
+            //cursor: pointer;
         }
 
         p.nopreview {
@@ -77,16 +78,27 @@
     .file-upload-preview-popup {
         padding: 40px 0;
         max-width: 100%;
-        width: auto !important;
+        overflow: scroll;
+        //width: auto !important;
 
         // position absolute allows the scroll on the a big picture
-        &.modal {
-            position: absolute;
+        //&.modal {
+        //    position: absolute;
+        //}
+
+        //& > div {
+        //    min-height: 100%;
+        //    min-width: 100%;
+        //}
+
+        .modal-body {
+            overflow: scroll;
         }
 
         img {
             display: block;
             margin: auto;
+            max-width: none;
         }
     }
 }

--- a/views/scss/qti/_upload.scss
+++ b/views/scss/qti/_upload.scss
@@ -78,7 +78,8 @@
     .file-upload-preview-popup {
         padding: 40px 0;
         max-width: 100%;
-        overflow: scroll;
+        overflow: auto;
+        top: 0 !important;
         //width: auto !important;
 
         // position absolute allows the scroll on the a big picture
@@ -86,19 +87,22 @@
         //    position: absolute;
         //}
 
-        //& > div {
-        //    min-height: 100%;
-        //    min-width: 100%;
-        //}
-
         .modal-body {
-            overflow: scroll;
+            overflow: auto;
+            height: 100%;
+            width: 100%;
+
+            div {
+                height: 100%;
+                width: 100%;
+            }
         }
 
         img {
             display: block;
             margin: auto;
             max-width: none;
+            overflow: auto;
         }
     }
 }


### PR DESCRIPTION
The situation now requires to enable a preview of the picture in its naturalWidth (if it is bigger than the preview box) inside a popup modal, full width within the limit of the widow's width. 

Several issues arose then, like the display of previous modalOverlay when a new image is brought into view. 

I have tried to use the modal('destroy'), but didn't found yet how to regenerate a new modal after previous was destroy. The use of 'destroy' was to cancel the reference to the previous picture modal, in order to start a display of the new image. 
