### PR TITLE
fix  cyclic reference in the console output

### DIFF
--- a/views/js/qtiCreator/helper/itemSerializer.js
+++ b/views/js/qtiCreator/helper/itemSerializer.js
@@ -37,7 +37,6 @@ define(['lodash'], function(_){
            if(item){
                try {
                     //clone and serialize the cleaned up value
-                    console.log('item.toArray()', item.toArray());
                     serialized = JSON.stringify(item.toArray());
                 } catch(e){
                     console.error(e);

--- a/views/js/qtiCreator/helper/itemSerializer.js
+++ b/views/js/qtiCreator/helper/itemSerializer.js
@@ -37,6 +37,7 @@ define(['lodash'], function(_){
            if(item){
                try {
                     //clone and serialize the cleaned up value
+                    console.log('item.toArray()', item.toArray());
                     serialized = JSON.stringify(item.toArray());
                 } catch(e){
                     console.error(e);

--- a/views/js/qtiItem/core/Item.js
+++ b/views/js/qtiItem/core/Item.js
@@ -162,23 +162,16 @@ define([
             return this;
         },
         toArray : function(){
-            var i;
             var arr = this._super();
-            arr.outcomes = {};
-            for(i in this.outcomes){
-                arr.outcomes[i] = this.outcomes[i].toArray();
-            }
-            arr.responses = {};
-            for(i in this.responses){
-                arr.responses[i] = this.responses[i].toArray();
-            }
-            arr.stylesheets = {};
-            for(i in this.stylesheets){
-                arr.stylesheets[i] = this.stylesheets[i].toArray();
-            }
+            var toArray = function(elt){
+                return elt.toArray();
+            };
             arr.namespaces = this.namespaces;
-            arr.responseProcessing = this.responseProcessing;
-            arr.modalFeedbacks = this.modalFeedbacks;
+            arr.outcomes = _.map(this.outcomes, toArray);
+            arr.responses = _.map(this.responses, toArray);
+            arr.stylesheets = _.map(this.stylesheets, toArray);
+            arr.modalFeedbacks = _.map(this.modalFeedbacks, toArray);
+            arr.responseProcessing = this.responseProcessing.toArray();
             return arr;
         },
         isEmpty : function(){

--- a/views/js/qtiItem/core/ResponseProcessing.js
+++ b/views/js/qtiItem/core/ResponseProcessing.js
@@ -3,7 +3,13 @@ define(['taoQtiItem/qtiItem/core/Element', 'lodash'], function(Element, _){
     var ResponseProcessing = Element.extend({
         qtiClass : 'responseProcessing',
         processingType : '',
-        xml : ''
+        xml : '',
+        toArray : function(){
+            var arr = this._super();
+            arr.processingType = this.processingType;
+            arr.xml = this.xml;
+            return arr;
+        }
     });
     
     return ResponseProcessing;

--- a/views/js/qtiItem/core/response/SimpleFeedbackRule.js
+++ b/views/js/qtiItem/core/response/SimpleFeedbackRule.js
@@ -92,6 +92,26 @@ define(['taoQtiItem/qtiItem/core/Element', 'lodash'], function(Element, _){
             if(Element.isA(feedback, 'feedback')){
                 this.feedbackElse = feedback;
             }
+        },
+        toArray : function(){
+            var val = this.comparedValue;
+            var _toString = function(v){
+                if(val instanceof Element){
+                    return val.attr('identifier') ;
+                }else{
+                    return val+'';
+                }
+            };
+            if(_.isArray(val)){
+                val = _.map(val, _toString);
+            }else{
+                val = _toString(val);
+            }
+            return {
+                condition : this.condition,
+                comparedOutcome : this.comparedOutcome.id(),
+                comparedValue : val
+            };
         }
     });
 

--- a/views/js/qtiItem/core/variables/ResponseDeclaration.js
+++ b/views/js/qtiItem/core/variables/ResponseDeclaration.js
@@ -52,6 +52,9 @@ define(['taoQtiItem/qtiItem/core/variables/VariableDeclaration', 'lodash'], func
             arr.correctResponses = this.correctResponse;
             arr.mapping = this.mapEntries;
             arr.mappingAttributes = this.mappingAttributes;
+            arr.feedbackRules = _.map(this.feedbackRules, function(rule){
+                return rule.toArray();
+            });
             return arr;
         },
         getInteraction : function(){


### PR DESCRIPTION
fix implementation of toArray() to prevent cyclic reference in json serialization.

Without this fix, you should have a warning or error message in your console output saying that there is a cyclic reference in an object. It was indeed due to cyclic reference of nested object in the argument of JSON.stringify.