### PR TITLE
prevent error whithout a type

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
@@ -289,7 +289,7 @@ define([
      */
     var getCustomData = function (interaction, data) {
         return _.merge(data || {}, {
-            isPreviewable: interaction.attr('type').indexOf('image') === 0
+            isPreviewable: interaction.attr('type') && interaction.attr('type').indexOf('image') === 0
         });
     };
     //console.log(this.getData());


### PR DESCRIPTION
Prevent the interaction to break the runtime when the attr is missing.