### PR TITLE
default response on media interaction

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -397,7 +397,7 @@ define([
      * @returns {Array} of points
      */
     var _getRawResponse = function _getRawResponse(interaction) {
-        return [containerHelper.get(interaction).data('timesPlayed')];
+        return [containerHelper.get(interaction).data('timesPlayed') || 0];
     };
 
     /**


### PR DESCRIPTION
The media interaction gives the default response when the flash plugin blocks the interaction.