### PR TITLE
Fix/tao 2310 mathjax bug

### DIFF
--- a/views/js/qtiCreator/editor/MathEditor.js
+++ b/views/js/qtiCreator/editor/MathEditor.js
@@ -96,11 +96,11 @@ define(['lodash', 'jquery', 'mathJax'], function(_, $, MathJax){
     MathEditor.prototype.renderFromTex = function(){
 
         var args = _processArguments(this, arguments);
+        var _this = this;
+        var jaxQueue = MathJax.Hub.queue;
 
-        if(typeof(MathJax) !== 'undefined'){
+        if(typeof (MathJax) !== 'undefined'){
 
-            var _this = this;
-            var jaxQueue = MathJax.Hub.queue;
             if(this.display === 'block'){
                 _this.$buffer.text('\\[\\displaystyle{' + _this.tex + '}\\]');
             }else{
@@ -110,14 +110,14 @@ define(['lodash', 'jquery', 'mathJax'], function(_, $, MathJax){
             //render preview:
             jaxQueue.Push(
                 //programmatically typeset the buffer
-                    ["Typeset", MathJax.Hub, _this.$buffer[0]],
+                    ['Typeset', MathJax.Hub, _this.$buffer[0]],
                     function(){
+                        //store mathjax "tex", for tex for later mathML conversion
+                        var texJax = _getJaxByElement(_this.$buffer);
 
                         //replace the target element
                         args.target.html(_this.$buffer.html());
 
-                        //store mathjax "tex", for tex for later mathML conversion
-                        var texJax = _getJaxByElement(_this.$buffer);
 
                         //empty buffer;
                         _this.$buffer.empty();

--- a/views/js/qtiCreator/editor/MathEditor.js
+++ b/views/js/qtiCreator/editor/MathEditor.js
@@ -102,9 +102,9 @@ define(['lodash', 'jquery', 'mathJax'], function(_, $, MathJax){
             var _this = this;
             var jaxQueue = MathJax.Hub.queue;
             if(this.display === 'block'){
-                _this.$buffer.html('\\[\\displaystyle{' + _this.tex + '}\\]');
+                _this.$buffer.text('\\[\\displaystyle{' + _this.tex + '}\\]');
             }else{
-                _this.$buffer.html('\\(\\displaystyle{' + _this.tex + '}\\)');
+                _this.$buffer.text('\\(\\displaystyle{' + _this.tex + '}\\)');
             }
 
             //render preview:

--- a/views/js/qtiCreator/editor/MathEditor.js
+++ b/views/js/qtiCreator/editor/MathEditor.js
@@ -1,4 +1,9 @@
-define(['lodash', 'jquery', 'mathJax'], function(_, $, MathJax){
+define([
+    'lodash',
+    'jquery',
+    'mathJax',
+    'ui/feedback'
+], function(_, $, MathJax, feedback){
     "use strict";
     var MathEditor = function MathEditor(config){
 
@@ -112,20 +117,26 @@ define(['lodash', 'jquery', 'mathJax'], function(_, $, MathJax){
                 //programmatically typeset the buffer
                     ['Typeset', MathJax.Hub, _this.$buffer[0]],
                     function(){
-                        //store mathjax "tex", for tex for later mathML conversion
-                        var texJax = _getJaxByElement(_this.$buffer);
+                        var texJax;
+                        try {
+                            //replace the target element
+                            args.target.html(_this.$buffer.html());
 
-                        //replace the target element
-                        args.target.html(_this.$buffer.html());
+                            //store mathjax "tex", for tex for later mathML conversion
+                            texJax = _getJaxByElement(_this.$buffer);
 
+                            //empty buffer;
+                            _this.$buffer.empty();
 
-                        //empty buffer;
-                        _this.$buffer.empty();
-
-                        //sync MathML
-                        _this.texToMathML(texJax, function(mathML){
-                            _this.setMathML(_stripMathTags(mathML));
-                        });
+                            //sync MathML
+                            if (typeof (texJax) !== 'undefined') {
+                                _this.texToMathML(texJax, function (mathML) {
+                                    _this.setMathML(_stripMathTags(mathML));
+                                });
+                            }
+                        } catch (err) {
+                            feedback().error('Mathjax error: ' + err.message);
+                        }
                     }
                 );
 

--- a/views/js/qtiCreator/test/MathEditor/test.html
+++ b/views/js/qtiCreator/test/MathEditor/test.html
@@ -19,9 +19,11 @@
     </head>
     <body>
         <div id="qunit"></div>
-        <div id="qunit-fixture">
+        <div id="qunit-fixture"></div>
+        <!-- we don't use qunit-fixture on purpose, as it seems to be re-initialised by QUnit.start() -->
+        <div id="fixtures" style="display: none">
+            <div class="mj-buffer"></div>
+            <div class="mj-target"></div>
         </div>
-        <div class="mj-buffer"></div>
-        <div class="mj-target"></div>
     </body>
 </html>

--- a/views/js/qtiCreator/test/MathEditor/test.html
+++ b/views/js/qtiCreator/test/MathEditor/test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>QtiElements Test - QTI item model information model definition </title>
+        <link rel="stylesheet" type="text/css" href="/tao/views/js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="/tao/views/js/lib/require.js"></script>
+        <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="/tao/views/js/lib/blanket/blanket.min.js" data-cover-only="/taoQtiItem/views/js/qtiCreator/editor/MathEditor.js"></script>
+        <script  type="text/javascript">
+            QUnit.config.autostart = false;
+            require(['/tao/ClientConfig/config'], function(){
+                require(['taoQtiItem/qtiCreator/test/MathEditor/test'], function(){
+                    QUnit.start();
+                });
+            });
+        </script>
+        <!-- http://xxx/taoQtiItem/views/js/qtiCreator/test/MathEditor/test.html -->
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+        </div>
+        <div class="mj-buffer"></div>
+        <div class="mj-target"></div>
+    </body>
+</html>

--- a/views/js/qtiCreator/test/MathEditor/test.js
+++ b/views/js/qtiCreator/test/MathEditor/test.js
@@ -3,7 +3,7 @@ define([
     'taoQtiItem/qtiCreator/editor/MathEditor',
     'mathJax'
 ],
-function($, MathEditor, MathJax) {
+function($, MathEditor) {
     "use strict";
 
     QUnit.asyncTest('Latex rendering', function test(assert) {
@@ -13,7 +13,7 @@ function($, MathEditor, MathJax) {
             ],
             displayType = [
                 'block',
-                'inline'
+                'other'
             ],
 
             $bufferContainer = $('.mj-buffer'),
@@ -40,11 +40,6 @@ function($, MathEditor, MathJax) {
                 mathEditor.renderFromTex();
             });
         });
-
-        // in we want to log into the error handler...
-        //MathJax.Hub.Register.MessageHook("TeX Jax - parse error", function (message) {
-        //    console.log('============ message = ' + message);
-        //});
 
         setTimeout(function checkMathJaxOutput() {
             QUnit.start();

--- a/views/js/qtiCreator/test/MathEditor/test.js
+++ b/views/js/qtiCreator/test/MathEditor/test.js
@@ -1,10 +1,9 @@
 define([
     'jquery',
-    'taoQtiItem/qtiCreator/editor/MathEditor',
-    'mathJax'
+    'taoQtiItem/qtiCreator/editor/MathEditor'
 ],
 function($, MathEditor) {
-    "use strict";
+    'use strict';
 
     QUnit.asyncTest('Latex rendering', function test(assert) {
         var texExprs = [
@@ -13,7 +12,9 @@ function($, MathEditor) {
                 '\\begin{align} f(x) & = (a+b)^2 \\\\ & = a^2+2ab+b^2 \\\\ \\end{align}',
                 '\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}',
                 '\\sum_{i=0}^n i^2 = \\frac{(n^2+n)(2n+1)}{6}',
-                'A_{m,n} = \\begin{pmatrix} a_{1,1} & a_{1,2} & \\cdots & a_{1,n} \\\\ a_{2,1} & a_{2,2} & \\cdots & a_{2,n} \\\\ \\vdots & \\vdots & \\ddots & \\vdots \\\\ a_{m,1} & a_{m,2} & \\cdots & a_{m,n} \\end{pmatrix}'
+                'A_{m,n} = \\begin{pmatrix} a_{1,1} & a_{1,2} & \\cdots & a_{1,n} \\\\ a_{2,1} & a_{2,2} & ' +
+                    '\\cdots & a_{2,n} \\\\ \\vdots & \\vdots & \\ddots & \\vdots \\\\ a_{m,1} & a_{m,2} & ' +
+                    '\\cdots & a_{m,n} \\end{pmatrix}'
             ],
             displayType = [
                 'block',

--- a/views/js/qtiCreator/test/MathEditor/test.js
+++ b/views/js/qtiCreator/test/MathEditor/test.js
@@ -9,7 +9,11 @@ function($, MathEditor) {
     QUnit.asyncTest('Latex rendering', function test(assert) {
         var texExprs = [
                 '\\fr<ac1 2{',
-                '\\frac1 2{'
+                '\\frac1 2{',
+                '\\begin{align} f(x) & = (a+b)^2 \\\\ & = a^2+2ab+b^2 \\\\ \\end{align}',
+                '\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}',
+                '\\sum_{i=0}^n i^2 = \\frac{(n^2+n)(2n+1)}{6}',
+                'A_{m,n} = \\begin{pmatrix} a_{1,1} & a_{1,2} & \\cdots & a_{1,n} \\\\ a_{2,1} & a_{2,2} & \\cdots & a_{2,n} \\\\ \\vdots & \\vdots & \\ddots & \\vdots \\\\ a_{m,1} & a_{m,2} & \\cdots & a_{m,n} \\end{pmatrix}'
             ],
             displayType = [
                 'block',
@@ -54,7 +58,7 @@ function($, MathEditor) {
                         'Error in Mathjax output: expected ' + expectedScript + ' but was ' + actualScript);
                 });
             });
-        }, 1500); // we give Mathjax some time to generate the output
+        }, texExprs.length * 750); // we give Mathjax some time to generate the output
     });
 
 });

--- a/views/js/qtiCreator/test/MathEditor/test.js
+++ b/views/js/qtiCreator/test/MathEditor/test.js
@@ -7,33 +7,39 @@ function($, MathEditor, MathJax) {
     "use strict";
 
     QUnit.asyncTest('Latex rendering', function test(assert) {
-        var $bufferContainer = $('.mj-buffer'),
-            $targetContainer = $('.mj-target'),
-
-            texExprs = [
+        var texExprs = [
                 '\\fr<ac1 2{',
                 '\\frac1 2{'
-            ];
+            ],
+            displayType = [
+                'block',
+                'inline'
+            ],
 
-        QUnit.expect(texExprs.length);
+            $bufferContainer = $('.mj-buffer'),
+            $targetContainer = $('.mj-target');
+
+        QUnit.expect(texExprs.length * displayType.length);
 
         texExprs.forEach(function generateMathJaxOutput(texExpr, index) {
-            var $buffer = $('<div class="mj-buffer-' + index + '"></div>'),
-                $target = $('<div class="mj-target-' + index + '"></div>'),
+            displayType.forEach(function loopDisplay(display) {
+                var key = display + '-' + index,
+                    $buffer = $('<div class="mj-buffer-' + key + '"></div>'),
+                    $target = $('<div class="mj-target-' + key + '"></div>'),
 
-                mathEditor = new MathEditor({
-                    buffer: $buffer,
-                    target: $target,
-                    display: 'block',
-                    tex: texExpr
-                });
+                    mathEditor = new MathEditor({
+                        buffer: $buffer,
+                        target: $target,
+                        display: display
+                    });
 
-            $bufferContainer.append($buffer);
-            $targetContainer.append($target);
+                $bufferContainer.append($buffer);
+                $targetContainer.append($target);
 
-            mathEditor.renderFromTex();
+                mathEditor.setTex(texExpr);
+                mathEditor.renderFromTex();
+            });
         });
-
 
         // in we want to log into the error handler...
         //MathJax.Hub.Register.MessageHook("TeX Jax - parse error", function (message) {
@@ -44,14 +50,14 @@ function($, MathEditor, MathJax) {
             QUnit.start();
 
             texExprs.forEach(function checkForExpression(texExpr, index) {
-                var $target = $targetContainer.find('.mj-target-' + index),
-                    actualScript = $target.find('script').text(),
-                    expectedScript = '\\displaystyle{' + texExpr + '}';
+                displayType.forEach(function loopDisplay(display) {
+                    var $target = $targetContainer.find('.mj-target-' + display + '-' + index),
+                        actualScript = $target.find('script').text(),
+                        expectedScript = '\\displaystyle{' + texExpr + '}';
 
-                console.log('$target = ' + JSON.stringify($target, null, 2));
-
-                assert.ok(actualScript === expectedScript,
-                    'Error in Mathjax output: expected ' + expectedScript + ' but was ' + actualScript);
+                    assert.ok(actualScript === expectedScript,
+                        'Error in Mathjax output: expected ' + expectedScript + ' but was ' + actualScript);
+                });
             });
         }, 1500); // we give Mathjax some time to generate the output
     });

--- a/views/js/qtiCreator/test/MathEditor/test.js
+++ b/views/js/qtiCreator/test/MathEditor/test.js
@@ -1,0 +1,61 @@
+define([
+    'jquery',
+    'taoQtiItem/qtiCreator/editor/MathEditor',
+    'mathJax'
+],
+function($, MathEditor, MathJax) {
+    "use strict";
+
+    QUnit.asyncTest('Latex rendering', function test(assert) {
+        var $bufferContainer = $('.mj-buffer'),
+            $targetContainer = $('.mj-target'),
+
+            texExprs = [
+                '\\fr<ac1 2{',
+                '\\frac1 2{'
+            ];
+
+        QUnit.expect(texExprs.length);
+
+        texExprs.forEach(function generateMathJaxOutput(texExpr, index) {
+            var $buffer = $('<div class="mj-buffer-' + index + '"></div>'),
+                $target = $('<div class="mj-target-' + index + '"></div>'),
+
+                mathEditor = new MathEditor({
+                    buffer: $buffer,
+                    target: $target,
+                    display: 'block',
+                    tex: texExpr
+                });
+
+            $bufferContainer.append($buffer);
+            $targetContainer.append($target);
+
+            mathEditor.renderFromTex();
+        });
+
+
+        // in we want to log into the error handler...
+        //MathJax.Hub.Register.MessageHook("TeX Jax - parse error", function (message) {
+        //    console.log('============ message = ' + message);
+        //});
+
+        setTimeout(function checkMathJaxOutput() {
+            QUnit.start();
+
+            texExprs.forEach(function checkForExpression(texExpr, index) {
+                var $target = $targetContainer.find('.mj-target-' + index),
+                    actualScript = $target.find('script').text(),
+                    expectedScript = '\\displaystyle{' + texExpr + '}';
+
+                console.log('$target = ' + JSON.stringify($target, null, 2));
+
+                assert.ok(actualScript === expectedScript,
+                    'Error in Mathjax output: expected ' + expectedScript + ' but was ' + actualScript);
+            });
+        }, 1500); // we give Mathjax some time to generate the output
+    });
+
+});
+
+


### PR DESCRIPTION
How to test:
- add a mathjax latex element
- add the following string: 
- \frac12
- insert a < before the a:
- \fr<ac12
- with this fix, editor shouldn't become unresponsive anymore and we can still use Mathjax (edit current expression, create new ones...)