### PR TITLE
added support for ar-arb lang it used to make serializer fails when u…

### DIFF
--- a/model/qti/datatype/Language.php
+++ b/model/qti/datatype/Language.php
@@ -37,7 +37,7 @@ class Language extends Datatype
 {
 	
 	public static function validate($value){
-		return preg_match('/^[a-z]{2,3}(?:-[A-Z]{2,3}(?:-[a-zA-Z]{4})?)?$/', $value);
+        return preg_match('/^[a-z]{2,3}(?:-[a-zA-Z]{2,3}(?:-[a-zA-Z]{4})?)?$/', $value);
 	}
 	
 	public static function fix($value){


### PR DESCRIPTION
if the user chooses Arabic as data language => ar-arb fails to pass language validate, this simple regex fixes the issue