### PR TITLE
changed color picker position to be close to the color control

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'QTI item model',
 	'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '2.12.13',
+    'version' => '2.12.14',
 	'author' => 'Open Assessment Technologies',
 	'requires' => array(
 	    'taoItems' => '>=2.9.7'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -213,7 +213,7 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->setVersion($currentVersion);
-        $this->skip('2.12.9', '2.12.13');
+        $this->skip('2.12.9', '2.12.14');
     }
 
 }

--- a/views/js/qtiCreator/widgets/interactions/customInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/customInteraction/states/Question.js
@@ -29,7 +29,13 @@ define([
                 $colorPicker = $container.find('.color-picker'),
                 $colorPickerInput = $container.find('.color-picker-input'),
                 $input = $colorTrigger.siblings('input[type="hidden"]'),
-                color = $input.val();
+                color = $input.val(),
+                $itemEditorWidgetBar = $('#item-editor-item-widget-bar');
+
+            $container.css({
+                right : $itemEditorWidgetBar.width() + 2, 
+                top : $colorTrigger.offset().top - ($container.width() / 2) - $itemEditorWidgetBar.offset().top
+            });
 
             // Init the color picker
             $colorPicker.farbtastic('.color-picker-input', $context);


### PR DESCRIPTION
this is used by parcc pci like graphFunction or PointAndLine, the color picker should appear close to the mouse cursor and not on top of the item window