### PR TITLE
override the plugins registry from the config

### DIFF
--- a/model/CreatorConfig.php
+++ b/model/CreatorConfig.php
@@ -21,6 +21,7 @@
 namespace oat\taoQtiItem\model;
 
 use oat\taoQtiItem\model\Config;
+use oat\taoQtiItem\model\QtiCreatorClientConfigRegistry;
 
 /**
  * Interface defining required method for a plugin
@@ -71,6 +72,10 @@ Class CreatorConfig extends Config
         foreach($this->infoControls as $infoControl){
             $this->prepare($infoControl);
         }
+
+        //as the config overrides the plugins, we get the list from the registry
+        $registry = QtiCreatorClientConfigRegistry::getRegistry();
+        $this->plugins = $registry->getPlugins();
     }
 
     protected function prepare($hook){

--- a/model/QtiCreatorClientConfigRegistry.php
+++ b/model/QtiCreatorClientConfigRegistry.php
@@ -115,4 +115,23 @@ class QtiCreatorClientConfigRegistry extends ClientLibConfigRegistry
         $config['plugins'] = $plugins;
         $registry->set(self::CREATOR, $config);
     }
+
+    /**
+     * Quick access to the plugins
+     * @return array the registered plugins
+     */
+    public function getPlugins(){
+        $config = [];
+        $registry = self::getRegistry();
+
+        if ($registry->isRegistered(self::CREATOR)) {
+            $config = $registry->get(self::CREATOR);
+        }
+
+        if (!isset($config['plugins'])) {
+            return [];
+        }
+
+        return $config['plugins'];
+    }
 }


### PR DESCRIPTION
Enables the config to override the plugin registry (in order to have plugins per controller)

Linked to https://github.com/oat-sa/extension-tao-itemqti/pull/658