### PR TITLE
Fix/ghost response creation

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -184,11 +184,8 @@ define([
                         widgets = _rebuildWidgets(options.data.container, $editable, {
                             restoreState : true
                         });
-
                         if(options.shieldInnerContent){
                             _shieldInnerContent($editable, options.data.widget);
-                        }else if(options.passthroughInnerContent){
-                            _passthroughInnerContent($editable);
                         }
                     }
 
@@ -409,21 +406,6 @@ define([
                 innerWidget = $widget.data('widget');
                 _activateInnerWidget(containerWidget, innerWidget);
             });
-        });
-
-    }
-
-    /**
-     * Allow the inner widgets to be selected
-     *
-     * @param {JQuery} $container
-     * @returns {undefined}
-     */
-    function _passthroughInnerContent($container){
-
-        $container.find('.widget-box').each(function(){
-            //just add the shield for visual consistency
-            addShield($(this));
         });
 
     }

--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -358,6 +358,8 @@ define([
                 _rebuildWidgets(container, $container, {
                     restoreState : true
                 });
+
+                _shieldInnerContent($container, container.data('widget'));
             });
 
             if (undoCmd){

--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -168,6 +168,7 @@ define([
                     $editable.data('editor', editor);
                     $editable.data('editor-options', options);
 
+                    //need to debounce the callback to prevent the changes made by undo to trigger the event change twice
                     editor.on('change', _.debounce(function markupChanged(){
                         _detectWidgetDeletion($editable, widgets, editor);
                         if(_.isFunction(options.change)){

--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -162,33 +162,13 @@ define([
                         editor = e.editor;
                     
                     /**
-                     * changed callback
-                     * @param {Object} editor - ckeditor instance
-                     */
-                    function changed(editor){
-
-                        _detectWidgetDeletion($editable, widgets, editor);
-
-                        //callback:
-                        if(_.isFunction(options.change)){
-                            options.change.call(editor, _htmlEncode(editor.getData()));
-                        }
-
-                    }
-
-                    /**
                      * Markup change callback
                      */
                     function markupChanged(){
-
-                        //callbacks:
-                        if(_.isFunction(options.markupChange)){
-                            options.markupChange.call($editable);
-                        }
+                        _detectWidgetDeletion($editable, widgets, editor);
                         if(_.isFunction(options.change)){
                             options.change.call(editor, _htmlEncode(editor.getData()));
                         }
-
                     }
 
                     //fix ck editor combo box display issue
@@ -197,10 +177,6 @@ define([
                     //store it in editable elt data attr
                     $editable.data('editor', editor);
                     $editable.data('editor-options', options);
-
-                    $editable.on('change', function(){
-                        changed(editor);
-                    });
 
                     editor.on('change', function(){
                         markupChanged(editor);
@@ -360,6 +336,7 @@ define([
         _.each(widgets, function(w){
 
             if(!w.element.data('removed')){
+                console.log(w);
                 var $widget = _findWidgetContainer($container, w.serial);
                 if(!$widget.length){
                     deleted.push(w);

--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -353,6 +353,7 @@ define([
 
                 editor.undoManager.undo();
 
+                //need to rebuild the inner widgets in case the undo restored some qti elements
                 _rebuildWidgets(container, $container, {
                     restoreState : true
                 });
@@ -361,6 +362,7 @@ define([
             });
 
             if (undoCmd){
+                //catch ckeditor's undo event to trigger the same behaviour as the undo action dialog
                 undoCmd.on('afterUndo', function(){
                     $messageBox.find('a.undo').click();
                 });

--- a/views/js/qtiCreator/editor/gridEditor/content.js
+++ b/views/js/qtiCreator/editor/gridEditor/content.js
@@ -70,7 +70,7 @@ define([
                 }
             });
 
-            //textWrapper.unwrap($pseudoContainer);
+            textWrapper.unwrap($pseudoContainer);
 
             container.body(contentHelper.getContent($pseudoContainer));
 

--- a/views/js/qtiCreator/editor/gridEditor/content.js
+++ b/views/js/qtiCreator/editor/gridEditor/content.js
@@ -1,8 +1,9 @@
 define([
     'jquery',
     'lodash',
-    'taoQtiItem/qtiCreator/editor/gridEditor/resizable'
-], function($, _, resizable){
+    'taoQtiItem/qtiCreator/editor/gridEditor/resizable',
+    'taoQtiItem/qtiCreator/widgets/helpers/textWrapper'
+], function($, _, resizable, textWrapper){
     "use strict";
     var contentHelper = {};
 
@@ -68,6 +69,8 @@ define([
                     return false;//breaks jquery each loop
                 }
             });
+
+            //textWrapper.unwrap($pseudoContainer);
 
             container.body(contentHelper.getContent($pseudoContainer));
 

--- a/views/js/qtiCreator/widgets/helpers/deletingState.js
+++ b/views/js/qtiCreator/widgets/helpers/deletingState.js
@@ -18,6 +18,7 @@ define(['lodash', 'jquery', 'tpl!taoQtiItem/qtiCreator/tpl/notifications/deletin
         $('body').on('mousedown.deleting keydown.deleting', function(e){
 
             if(e.ctrlKey || e.metaKey){
+                //trigger undo callback if the standard keyboard shortcut ctrl+z is triggered
                 if(e.keyCode == 90){//z-key
                     undo($messageBox);
                 }

--- a/views/js/qtiCreator/widgets/helpers/deletingState.js
+++ b/views/js/qtiCreator/widgets/helpers/deletingState.js
@@ -1,14 +1,31 @@
 define(['lodash', 'jquery', 'tpl!taoQtiItem/qtiCreator/tpl/notifications/deletingInfoBox'], function(_, $, deletingInfoTpl){
 
     var _timeout = 10000;
-    
-    var _bindEvents = function($messageBox){
 
-        var timeout = setTimeout(function(){
-            _confirmDeletion($messageBox, 1000);
-        }, _timeout);
+    var _destroy = function _destroy($messageBox){
+        $('body').off('.deleting');
+        $messageBox.trigger('undo.deleting');
+        $messageBox.remove();
+    };
+
+    var undo = function undo($messageBox){
+        $messageBox.trigger('undo.deleting');
+        _destroy($messageBox);
+    };
+
+    var _bindEvents = function _bindEvents($messageBox){
 
         $('body').on('mousedown.deleting keydown.deleting', function(e){
+
+            if(e.ctrlKey || e.metaKey){
+                if(e.keyCode == 90){//z-key
+                    console.log('ctrl Z');
+                    undo($messageBox);
+                }
+                e.preventDefault();
+                return;
+            }
+
             //confirm deleting whenever user interact with another object
             if(e.target !== $messageBox[0] && !$.contains($messageBox[0], e.target)){
                 _confirmDeletion($messageBox, 400);
@@ -17,23 +34,27 @@ define(['lodash', 'jquery', 'tpl!taoQtiItem/qtiCreator/tpl/notifications/deletin
         
         $messageBox.find('a.undo').on('click', function(e){
             e.preventDefault();
-            $messageBox.trigger('undo.deleting');
-            clearTimeout(timeout);
-            $messageBox.remove();
+            undo($messageBox);
         });
 
         $messageBox.find('.close-trigger').on('click', function(e){
             e.preventDefault();
             _confirmDeletion($messageBox, 0);
         });
+
+        setTimeout(function(){
+            _confirmDeletion($messageBox, 1000);
+        }, _timeout);
     };
 
     var _confirmDeletion = function($messageBox, fadeDelay){
-        
-        $messageBox.trigger('confirm.deleting');
-        $messageBox.fadeOut(fadeDelay, function(){
-            $(this).remove();
-        });
+        //only allow deletion if the message has not already been deleted yet
+        if($messageBox.length && $.contains(document, $messageBox[0])){
+            $messageBox.trigger('confirm.deleting');
+            $messageBox.fadeOut(fadeDelay, function(){
+                _destroy($messageBox);
+            });
+        }
     };
     
     var deletingHelper = {

--- a/views/js/qtiCreator/widgets/helpers/deletingState.js
+++ b/views/js/qtiCreator/widgets/helpers/deletingState.js
@@ -19,7 +19,6 @@ define(['lodash', 'jquery', 'tpl!taoQtiItem/qtiCreator/tpl/notifications/deletin
 
             if(e.ctrlKey || e.metaKey){
                 if(e.keyCode == 90){//z-key
-                    console.log('ctrl Z');
                     undo($messageBox);
                 }
                 e.preventDefault();

--- a/views/js/qtiCreator/widgets/helpers/textWrapper.js
+++ b/views/js/qtiCreator/widgets/helpers/textWrapper.js
@@ -50,9 +50,12 @@ define(['jquery'], function($){
 
     function unwrapSelection($editable){
 
+        var $wrapper = $editable.find('#selection-wrapper');
+
         $editable.trigger('beforeunwrap');
 
-        $editable.find('#selection-wrapper').replaceWith(function(){
+        $wrapper.find('[data-role]').remove();
+        $wrapper.replaceWith(function(){
             return $(this).html();
         });
 

--- a/views/js/qtiCreator/widgets/interactions/containerInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/containerInteraction/states/Question.js
@@ -70,9 +70,6 @@ define([
             htmlEditor.buildEditor($editableContainer, {
                 shieldInnerContent : false,
                 change : gridContentHelper.getChangeCallbackForBlockStatic(container),
-                markupChange : function(){
-                    textWrapper.unwrap(this);
-                },
                 data : {
                     container : container,
                     widget : _widget


### PR DESCRIPTION
This fixes creation of ghost response when the user delete an inline interaction by pressing backspace or by mouse-selection+delete.
This removes a problematic old hack introduced by the fix from http://forge.taotesting.com/issues/3041