### PR TITLE
remove $path variable

### DIFF
--- a/model/pack/QtiItemPacker.php
+++ b/model/pack/QtiItemPacker.php
@@ -110,7 +110,7 @@ class QtiItemPacker extends ItemPacker
             $assetParser->setGetXinclude(!$this->replaceXinclude);
 
             foreach ($assetParser->extract($itemPack) as $type => $assets) {
-                $itemPack->setAssets($type, $assets, $path);
+                $itemPack->setAssets($type, $assets);
             }
         } catch (common_Exception $e) {
             throw new common_Exception('Unable to pack item ' . $item->getUri() . ' : ' . $e->getMessage());


### PR DESCRIPTION
After this change:
https://github.com/oat-sa/extension-tao-itemqti/commit/3bffee60f2ac360c259badc559d7f4abc17a23a6#diff-f75b6dac2741b1eca5d33eef5a20e9b7L69
`$path` variable no longer exists.

related PR:
https://github.com/oat-sa/extension-tao-item/pull/220
