### PR TITLE
just prevent unwanted typeerror

### DIFF
--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -83,7 +83,9 @@ define([
                             _.forEach(item.modalFeedbacks, function(feedback){
 
                                 var outcomeIdentifier = feedback.attr('outcomeIdentifier');
-                                if(itemSession[outcomeIdentifier].base.identifier === feedback.id()){
+                                if( outcomeIdentifier && itemSession[outcomeIdentifier] &&
+                                    itemSession[outcomeIdentifier].base.identifier === feedback.id()){
+
                                     queue.push(new Promise(function(resolve){
                                         var $feedbackContent = $(feedback.render());
 


### PR DESCRIPTION
I think I've got the error when being timed out on an item that have a modal feedback. But this patch will prevent a nasty `TypeError` at least.

![](http://pix.toile-libre.org/upload/original/1468419515.png)