### PR TITLE
Feature/qti 22 export

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '3.5.0',
+    'version' => '3.6.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.19.0',

--- a/model/Export/AbstractQTIItemExporter.php
+++ b/model/Export/AbstractQTIItemExporter.php
@@ -46,6 +46,10 @@ abstract class AbstractQTIItemExporter extends taoItems_models_classes_ItemExpor
     );
 
     abstract public function buildBasePath();
+    
+    abstract protected function renderManifest(array $options, array $qtiItemData);
+    
+    abstract protected function itemContentPostProcessing($content);
 
     /**
      * Overriden export from QTI items.
@@ -142,6 +146,9 @@ abstract class AbstractQTIItemExporter extends taoItems_models_classes_ItemExpor
                 $this->addFile($sourcePath, $destPath);
             }
         }
+        
+        // Possibility to delegate (if necessary) some item content post-processing to sub-classes.
+        $content = $this->itemContentPostProcessing($content);
         
         // add xml file
         $this->getZip()->addFromString($basePath . '/' . $dataFile, $content);

--- a/model/Export/QTIPackedItem22Exporter.php
+++ b/model/Export/QTIPackedItem22Exporter.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * 
+ * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
+ *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2013-2016 (update and modification) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * 
+ */
+
+namespace oat\taoQtiItem\model\Export;
+
+class QTIPackedItem22Exporter extends QTIPackedItemExporter {
+    
+    protected function renderManifest(array $options, array $qtiItemData)
+    {
+        $dir = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiItem')->getDir();
+        $tpl = $dir . 'model/qti/templates/imsmanifestQti22.tpl.php';
+        
+        $templateRenderer = new \taoItems_models_classes_TemplateRenderer($tpl, array(
+            'qtiItems' 				=> array($qtiItemData),
+            'manifestIdentifier'    => 'MANIFEST-' . \tao_helpers_Display::textCleaner(uniqid('tao', true), '-')
+        ));
+            
+        $renderedManifest = $templateRenderer->render();
+        $newManifest = new \DOMDocument('1.0', TAO_DEFAULT_ENCODING);
+        $newManifest->loadXML($renderedManifest);
+        
+        return $newManifest;
+    }
+    
+    protected function itemContentPostProcessing($content)
+    {
+        $content = str_replace(
+            'http://www.imsglobal.org/xsd/imsqti_v2p1',
+            'http://www.imsglobal.org/xsd/imsqti_v2p2',
+            $content
+        );
+        
+        $content = str_replace(
+            'http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd',
+            'http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p1.xsd',
+            $content
+        );
+        
+        $content = str_replace(
+            'http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct',
+            'http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct',
+            $content
+        );
+        
+        $content = str_replace(
+            'http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response',
+            'http://www.imsglobal.org/question/qti_v2p2/rptemplates/map_response',
+            $content
+        );
+        
+        $content = str_replace(
+            'http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response_point',
+            'http://www.imsglobal.org/question/qti_v2p2/rptemplates/map_response_point',
+            $content
+        );
+        
+        return $content;
+    }
+}

--- a/model/Export/QtiPackage22ExportHandler.php
+++ b/model/Export/QtiPackage22ExportHandler.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * 
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *               
+ * 
+ */
+
+namespace oat\taoQtiItem\model\Export;
+
+use \ZipArchive;
+use \DomDocument;
+
+class QtiPackage22ExportHandler extends QtiPackageExportHandler
+{
+
+    public function getLabel() {
+    	return __('QTI Package 2.2');
+    }
+    
+    protected function createExporter($item, ZipArchive $zipArchive, DOMDocument $manifest = null)
+    {
+        return new QTIPackedItem22Exporter($item, $zipArchive, $manifest);
+    }
+}

--- a/model/Export/QtiPackageExportHandler.php
+++ b/model/Export/QtiPackageExportHandler.php
@@ -28,6 +28,7 @@ use \taoItems_models_classes_ItemsService;
 use \tao_helpers_File;
 use \Exception;
 use \ZipArchive;
+use \DomDocument;
 use \common_Logger;
 use oat\taoQtiItem\model\ItemModel;
 
@@ -91,8 +92,8 @@ class QtiPackageExportHandler implements tao_models_classes_export_ExportHandler
 				foreach($instances as $instance){
 					$item = new core_kernel_classes_Resource($instance);
 					if($itemService->hasItemModel($item, array(ItemModel::MODEL_URI))){
-						$exporter = new QTIPackedItemExporter($item, $zipArchive, $manifest);
-						
+						$exporter = $this->createExporter($item, $zipArchive, $manifest);
+                        
 						$subReport = $exporter->export();
 						$manifest = $exporter->getManifest();
                         $report->add($subReport);
@@ -111,5 +112,10 @@ class QtiPackageExportHandler implements tao_models_classes_export_ExportHandler
 			}
 		}
 		return $report;
+    }
+    
+    protected function createExporter($item, ZipArchive $zipArchive, DOMDocument $manifest = null)
+    {
+        return new QTIPackedItemExporter($item, $zipArchive, $manifest);
     }
 }

--- a/model/ItemModel.php
+++ b/model/ItemModel.php
@@ -25,6 +25,7 @@ use oat\taoQtiItem\model\Export\ApipPackageExportHandler;
 use oat\taoQtiItem\model\import\ApipPackageImport;
 use oat\taoQtiItem\model\qti\Service;
 use oat\taoQtiItem\model\Export\QtiPackageExportHandler;
+use oat\taoQtiItem\model\Export\QtiPackage22ExportHandler;
 use oat\taoQtiItem\model\import\QtiPackageImport;
 use oat\taoQtiItem\model\import\QtiItemImport;
 use \tao_models_classes_export_ExportProvider;
@@ -115,7 +116,8 @@ class ItemModel
     public function getExportHandlers() {
     	return array(
     	    new ApipPackageExportHandler(),
-    		new QtiPackageExportHandler()
+    		new QtiPackageExportHandler(),
+            new QtiPackage22ExportHandler()
     	);
     }
     

--- a/model/qti/templates/imsmanifestQti22.tpl.php
+++ b/model/qti/templates/imsmanifestQti22.tpl.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * 
+ * Copyright (c) 2013-2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * 
+ */
+?>
+<manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.imsglobal.org/xsd/imscp_v1p1 http://www.imsglobal.org/xsd/qti/qtiv2p2/qtiv2p2_imscpv1p2_v1p0.xsd"
+          identifier="<?php echo $manifestIdentifier; ?>">
+    <metadata>
+        <schema>QTIv2.2 Package</schema>
+        <schemaversion>1.0.0</schemaversion>
+    </metadata>
+    <organizations/>
+    <resources>
+        <?php foreach ($qtiItems as $qtiItem): ?>
+        <resource identifier="<?php echo $qtiItem['identifier']; ?>" type="imsqti_item_xmlv2p2" href="<?php echo str_replace(DIRECTORY_SEPARATOR, '/', $qtiItem['filePath']); ?>">
+            <file href="<?php echo str_replace(DIRECTORY_SEPARATOR, '/', $qtiItem['filePath']);?>"/>
+            <?php foreach ($qtiItem['medias'] as $media):?>
+            <file href="<?php echo str_replace(DIRECTORY_SEPARATOR, '/', $media);?>"/>
+            <?php endforeach ?>
+        </resource>
+        <?php endforeach ?>
+    </resources>
+</manifest>

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -398,7 +398,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.31.0');
         }
 
-        $this->skip('2.31.0', '3.5.0');
+        $this->skip('2.31.0', '3.6.0');
     }
 
 }


### PR DESCRIPTION
This PR aims at providing QTI 2.2 items export. QTI 2.X items can be exported as QTI 2.2 content packages. Appropriate namespaces and schema locations will be applied if necessary.