### PR TITLE
Do not add slash to the begining of path

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '5.1.0',
+    'version' => '5.1.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.21.0',

--- a/model/portableElement/storage/PortableElementFileStorage.php
+++ b/model/portableElement/storage/PortableElementFileStorage.php
@@ -70,7 +70,7 @@ class PortableElementFileStorage extends ConfigurableService
         if (! is_dir($source)) {
             throw new PortableElementFileStorageException('Unable to locate the source directory.');
         }
-        return DIRECTORY_SEPARATOR . trim($source, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        return rtrim($source, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -398,7 +398,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.31.0');
         }
 
-        $this->skip('2.31.0', '5.1.0');
+        $this->skip('2.31.0', '5.1.1');
     }
 
 }


### PR DESCRIPTION
During of installation of Tao on Windows I got the following error:
`A fatal error occured during installation: File cannot be opened : \C:\domains\package-tao\qtiItemPci\views\js\pciCreator\dev\likertScaleInteraction\./runtime/likertScaleInteraction.amd.js`

First slash is redundant there.