### PR TITLE
made media insertion optional in container editor

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -229,6 +229,11 @@ define([
                     }else{
                         toolbarType = getTooltypeFromContainer($editableContainer);
                     }
+
+                    if(options.qtiMedia !== undefined){
+                        ckConfig.qtiMedia = options.qtiMedia;
+                    }
+
                     e.editor.config = ckConfigurator.getConfig(e.editor, toolbarType, ckConfig);
                 },
                 afterPaste : function(e){

--- a/views/js/qtiCreator/editor/containerEditor.js
+++ b/views/js/qtiCreator/editor/containerEditor.js
@@ -20,7 +20,8 @@ define([
     var _defaults = {
         change : _.noop,
         markup : '',
-        markupSelector : ''
+        markupSelector : '',
+        qtiMedia : false
     };
 
     function parser($container){
@@ -55,6 +56,7 @@ define([
      * @param {Function} [options.placeholder] - the placeholder text of the container editor when
      * @param {Function} [options.$toolbarLocation] - the location of the toolbar
      * @param {Function} [options.toolbar] - the ck toolbar
+     * @param {Function} [options.qtiMedia=false] - allow insert media object
      * @returns {undefined}
      */
     function create($container, options){
@@ -117,7 +119,8 @@ define([
                 buildEditor($container, container, {
                     hideTriggerOnBlur: !!options.hideTriggerOnBlur,
                     placeholder : options.placeholder || undefined,
-                    toolbar : options.toolbar || undefined
+                    toolbar : options.toolbar || undefined,
+                    qtiMedia : options.qtiMedia
                 });
 
                 $container.off('.' + _ns).on(event.getList(_ns + event.getNs() + event.getNsModel()).join(' '), _.throttle(function(e, data){

--- a/views/js/qtiCreator/helper/ckConfigurator.js
+++ b/views/js/qtiCreator/helper/ckConfigurator.js
@@ -18,8 +18,16 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['ui/ckeditor/ckConfigurator', 'mathJax'], function(ckConfigurator, mathJax) {
+define(['lodash', 'ui/ckeditor/ckConfigurator', 'mathJax'], function(_, ckConfigurator, mathJax) {
     'use strict';
+
+    var _defaults = {
+        qtiImage : true,
+        qtiMedia : true,
+        qtiInclude : true,
+        underline : true,
+        mathJax : !!mathJax
+    };
 
     /**
      * Generate a configuration object for CKEDITOR
@@ -39,15 +47,7 @@ define(['ui/ckeditor/ckConfigurator', 'mathJax'], function(ckConfigurator, mathJ
      * @see http://docs.ckeditor.com/#!/api/CKEDITOR.config
      */
     var getConfig = function(editor, toolbarType, options){
-        options = options || {};
-
-        options.qtiImage = true;
-        options.qtiMedia = true;
-        options.qtiInclude = true;
-        options.underline = true;
-        options.mathJax = !!mathJax;
-
-        return ckConfigurator.getConfig(editor, toolbarType, options);
+        return ckConfigurator.getConfig(editor, toolbarType, _.defaults(options || {}, _defaults));
     };
 
     return {


### PR DESCRIPTION
taoQtiItem/qtiCreator/editor/containerEditor is used by PCI creator widgets to edit their html content. However PCI does not handle object element natively so it is wise to made this optional and deactivate it by default. This PR adds this option.
 