### PR TITLE
fix QtiOutput unit test

### DIFF
--- a/test/QtiOutputTest.php
+++ b/test/QtiOutputTest.php
@@ -77,7 +77,7 @@ class QtiOutputTest extends TaoPhpUnitTestRunner
     /**
      * Test serializing array of pci properties into a pci xml
      */
-    public function testSerializePciProperties()
+    public function testSerializePortableProperties()
     {
         $properties = array(
             'prompt' => '<b>lorem ipsum</b>',
@@ -91,10 +91,10 @@ class QtiOutputTest extends TaoPhpUnitTestRunner
         );
         $PCI = new \oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction();
         
-        $method = new \ReflectionMethod('oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction', 'serializePciProperties');
+        $method = new \ReflectionMethod('\oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction', 'serializePortableProperties');
         $method->setAccessible(true);
         
-        $result = $method->invoke($PCI, $properties, 'pci');
+        $result = $method->invoke($PCI, $properties, 'pci', 'http://www.imsglobal.org/xsd/portableCustomInteraction');
         
         $this->assertFalse(strpos($result, '<b>lorem ipsum</b>'));
         $this->assertFalse(strpos($result, '<span class="test">Label 1</span>'));


### PR DESCRIPTION
After this commit:
https://github.com/oat-sa/extension-tao-itemqti/commit/2ac0b0bd63e64d1db4ceb60a4b405e29032fd606
`QtiOutputTest` unit test was broken.