### PR TITLE
Fix/creator plugin override

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '5.11.0',
+    'version' => '5.11.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.22.1',

--- a/model/CreatorConfig.php
+++ b/model/CreatorConfig.php
@@ -127,7 +127,7 @@ Class CreatorConfig extends Config
 
         //as the config overrides the plugins, we get the list from the registry
         $registry = QtiCreatorClientConfigRegistry::getRegistry();
-        $this->plugins = $registry->getPlugins();
+        $this->plugins = array_merge($this->plugins, $registry->getPlugins());
     }
 
     protected function prepare($hook){

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,7 +434,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(ItemCategoriesService::SERVICE_ID, $categoriesService);
             $this->setVersion('5.8.0');
         }
-        $this->skip('5.8.0', '5.11.0');
+        $this->skip('5.8.0', '5.11.1');
     }
 
 }


### PR DESCRIPTION
This prevent a manually registered creator plugin e.g. blockAdder to be overwritten by the global plugins.

To test this, you only need to activate the option in config/taoQtiItem/qtiCreator.conf.php multi-column -> true