### PR TITLE
Fix/tao 3187 empty item

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '5.11.3',
+    'version' => '5.11.4',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.22.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,7 +434,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(ItemCategoriesService::SERVICE_ID, $categoriesService);
             $this->setVersion('5.8.0');
         }
-        $this->skip('5.8.0', '5.11.3');
+        $this->skip('5.8.0', '5.11.4');
     }
 
 }

--- a/views/js/qtiItem/core/RubricBlock.js
+++ b/views/js/qtiItem/core/RubricBlock.js
@@ -1,7 +1,10 @@
 define(['taoQtiItem/qtiItem/core/Element', 'taoQtiItem/qtiItem/mixin/Container'], function(Element, Container){
 
     var RubricBlock = Element.extend({
-        qtiClass : 'rubricBlock'
+        qtiClass : 'rubricBlock',
+        isEmpty : function isEmpty(){
+            return !(this.bdy && this.bdy.body());
+        }
     });
     
     Container.augment(RubricBlock);

--- a/views/js/qtiItem/mixin/Container.js
+++ b/views/js/qtiItem/mixin/Container.js
@@ -25,9 +25,6 @@ define(['taoQtiItem/qtiItem/mixin/Mixin', 'taoQtiItem/qtiItem/core/Container'], 
         },
         getElement : function(serial){
             return this.bdy.getElement(serial);
-        },
-        isEmpty : function isEmpty(){
-            return !this.bdy.body();
         }
     };
 


### PR DESCRIPTION
This PR fixes the issue https://oat-sa.atlassian.net/browse/TAO-3187
It is actually a regression introduced by https://github.com/oat-sa/extension-tao-itemqti/pull/785.
The container mixin should not have the isEmpty() function as the container mixin should only add container specific method and not change the container owner's behaviour like isEmpty() in this example.