### PR TITLE
Fix/update registery overwride

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '5.12.1',
+    'version' => '5.12.2',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.22.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -61,21 +61,21 @@ class Updater extends \common_ext_ExtensionUpdater
         $libBasePath = ROOT_PATH.'taoQtiItem/views/js/portableSharedLibraries';
         $libRootUrl = ROOT_URL.'taoQtiItem/views/js/portableSharedLibraries';
         $installBasePath = ROOT_PATH.'taoQtiItem/install/scripts/portableSharedLibraries';
-        $registry = new SharedLibrariesRegistry($libBasePath, $libRootUrl);
+        $sharedLibRegistry = new SharedLibrariesRegistry($libBasePath, $libRootUrl);
 
         //migrate from 2.6 to 2.7.0
         if($currentVersion == '2.6'){
 
-            $registry->registerFromFile('IMSGlobal/jquery_2_1_1', $installBasePath.'/IMSGlobal/jquery_2_1_1.js');
-            $registry->registerFromFile('OAT/lodash', $installBasePath.'/OAT/lodash.js');
-            $registry->registerFromFile('OAT/async', $installBasePath.'/OAT/async.js');
-            $registry->registerFromFile('OAT/raphael', $installBasePath.'/OAT/raphael.js');
-            $registry->registerFromFile('OAT/scale.raphael', $installBasePath.'/OAT/scale.raphael.js');
-            $registry->registerFromFile('OAT/util/xml', $installBasePath.'/OAT/util/xml.js');
-            $registry->registerFromFile('OAT/util/math', $installBasePath.'/OAT/util/math.js');
-            $registry->registerFromFile('OAT/util/html', $installBasePath.'/OAT/util/html.js');
-            $registry->registerFromFile('OAT/util/EventMgr', $installBasePath.'/OAT/util/EventMgr.js');
-            $registry->registerFromFile('OAT/util/event', $installBasePath.'/OAT/util/event.js');
+            $sharedLibRegistry->registerFromFile('IMSGlobal/jquery_2_1_1', $installBasePath.'/IMSGlobal/jquery_2_1_1.js');
+            $sharedLibRegistry->registerFromFile('OAT/lodash', $installBasePath.'/OAT/lodash.js');
+            $sharedLibRegistry->registerFromFile('OAT/async', $installBasePath.'/OAT/async.js');
+            $sharedLibRegistry->registerFromFile('OAT/raphael', $installBasePath.'/OAT/raphael.js');
+            $sharedLibRegistry->registerFromFile('OAT/scale.raphael', $installBasePath.'/OAT/scale.raphael.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/xml', $installBasePath.'/OAT/util/xml.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/math', $installBasePath.'/OAT/util/math.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/html', $installBasePath.'/OAT/util/html.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/EventMgr', $installBasePath.'/OAT/util/EventMgr.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/event', $installBasePath.'/OAT/util/event.js');
 
             $currentVersion = '2.7.0';
         }
@@ -83,9 +83,9 @@ class Updater extends \common_ext_ExtensionUpdater
         //migrate from 2.7.0 to 2.7.1
         if($currentVersion == '2.7.0'){
 
-            $registry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
-            $registry->registerFromFile('OAT/interact', $installBasePath . '/OAT/interact.js');
-            $registry->registerFromFile('OAT/interact-rotate', $installBasePath . '/OAT/interact-rotate.js');
+            $sharedLibRegistry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
+            $sharedLibRegistry->registerFromFile('OAT/interact', $installBasePath . '/OAT/interact.js');
+            $sharedLibRegistry->registerFromFile('OAT/interact-rotate', $installBasePath . '/OAT/interact-rotate.js');
 
             $currentVersion = '2.7.1';
         }
@@ -93,7 +93,7 @@ class Updater extends \common_ext_ExtensionUpdater
         //migrate from 2.7.0 to 2.7.1
         if($currentVersion == '2.7.1'){
 
-            $registry->registerFromFile('OAT/sts/transform-helper', $installBasePath . '/OAT/sts/transform-helper.js');
+            $sharedLibRegistry->registerFromFile('OAT/sts/transform-helper', $installBasePath . '/OAT/sts/transform-helper.js');
 
             $currentVersion = '2.7.2';
         }
@@ -101,27 +101,27 @@ class Updater extends \common_ext_ExtensionUpdater
         //migrate from 2.7.2 to 2.7.3
         if($currentVersion == '2.7.2'){
 
-            $registry->registerFromFile('IMSGlobal/jquery_2_1_1', $installBasePath.'/IMSGlobal/jquery_2_1_1.js');
-            $registry->registerFromFile('OAT/lodash', $installBasePath.'/OAT/lodash.js');
-            $registry->registerFromFile('OAT/async', $installBasePath.'/OAT/async.js');
-            $registry->registerFromFile('OAT/raphael', $installBasePath.'/OAT/raphael.js');
-            $registry->registerFromFile('OAT/scale.raphael', $installBasePath.'/OAT/scale.raphael.js');
-            $registry->registerFromFile('OAT/util/xml', $installBasePath.'/OAT/util/xml.js');
-            $registry->registerFromFile('OAT/util/math', $installBasePath.'/OAT/util/math.js');
-            $registry->registerFromFile('OAT/util/html', $installBasePath.'/OAT/util/html.js');
-            $registry->registerFromFile('OAT/util/EventMgr', $installBasePath.'/OAT/util/EventMgr.js');
-            $registry->registerFromFile('OAT/util/event', $installBasePath.'/OAT/util/event.js');
-            $registry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
-            $registry->registerFromFile('OAT/interact', $installBasePath . '/OAT/interact.js');
-            $registry->registerFromFile('OAT/interact-rotate', $installBasePath . '/OAT/interact-rotate.js');
-            $registry->registerFromFile('OAT/sts/transform-helper', $installBasePath . '/OAT/sts/transform-helper.js');
+            $sharedLibRegistry->registerFromFile('IMSGlobal/jquery_2_1_1', $installBasePath.'/IMSGlobal/jquery_2_1_1.js');
+            $sharedLibRegistry->registerFromFile('OAT/lodash', $installBasePath.'/OAT/lodash.js');
+            $sharedLibRegistry->registerFromFile('OAT/async', $installBasePath.'/OAT/async.js');
+            $sharedLibRegistry->registerFromFile('OAT/raphael', $installBasePath.'/OAT/raphael.js');
+            $sharedLibRegistry->registerFromFile('OAT/scale.raphael', $installBasePath.'/OAT/scale.raphael.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/xml', $installBasePath.'/OAT/util/xml.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/math', $installBasePath.'/OAT/util/math.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/html', $installBasePath.'/OAT/util/html.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/EventMgr', $installBasePath.'/OAT/util/EventMgr.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/event', $installBasePath.'/OAT/util/event.js');
+            $sharedLibRegistry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
+            $sharedLibRegistry->registerFromFile('OAT/interact', $installBasePath . '/OAT/interact.js');
+            $sharedLibRegistry->registerFromFile('OAT/interact-rotate', $installBasePath . '/OAT/interact-rotate.js');
+            $sharedLibRegistry->registerFromFile('OAT/sts/transform-helper', $installBasePath . '/OAT/sts/transform-helper.js');
 
             $currentVersion = '2.7.3';
         }
 
         //migrate from 2.7.3 to 2.7.4
         if($currentVersion == '2.7.3'){
-            $registry->registerFromFile('OAT/handlebars', $installBasePath.'/OAT/handlebars.js');
+            $sharedLibRegistry->registerFromFile('OAT/handlebars', $installBasePath.'/OAT/handlebars.js');
             $currentVersion = '2.7.4';
         }
 
@@ -133,14 +133,14 @@ class Updater extends \common_ext_ExtensionUpdater
 
         if($currentVersion == '2.7.5'){
 
-            $registry->registerFromFile('OAT/sts/stsEventManager', $installBasePath . '/OAT/sts/stsEventManager.js');
+            $sharedLibRegistry->registerFromFile('OAT/sts/stsEventManager', $installBasePath . '/OAT/sts/stsEventManager.js');
 
             $currentVersion = '2.7.6';
         }
 
         if($currentVersion == '2.7.6'){
 
-            $registry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
+            $sharedLibRegistry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
 
             $currentVersion = '2.7.7';
         }
@@ -174,7 +174,7 @@ class Updater extends \common_ext_ExtensionUpdater
 
         if($currentVersion == '2.8.0'){
             $currentVersion = '2.8.1';
-            $registry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
+            $sharedLibRegistry->registerFromFile('OAT/sts/common', $installBasePath . '/OAT/sts/common.js');
         }
 
         if ($currentVersion == '2.8.1') {
@@ -184,7 +184,7 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         if ($currentVersion === '2.9.0') {
-            $registry->registerFromFile('OAT/waitForMedia', $installBasePath . '/OAT/waitForMedia.js');
+            $sharedLibRegistry->registerFromFile('OAT/waitForMedia', $installBasePath . '/OAT/waitForMedia.js');
             $currentVersion = '2.9.1';
         }
         if ($currentVersion === '2.9.1') {
@@ -194,8 +194,8 @@ class Updater extends \common_ext_ExtensionUpdater
             $currentVersion = '2.11.0';
         }
         if($currentVersion === '2.11.0') {
-            $registry->registerFromFile('OAT/util/asset', $installBasePath . '/OAT/util/asset.js');
-            $registry->registerFromFile('OAT/util/tpl', $installBasePath . '/OAT/util/tpl.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/asset', $installBasePath . '/OAT/util/asset.js');
+            $sharedLibRegistry->registerFromFile('OAT/util/tpl', $installBasePath . '/OAT/util/tpl.js');
             $currentVersion = '2.12.0';
         }
 
@@ -401,14 +401,14 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('2.31.0', '5.1.2');
 
         if ($this->isVersion('5.1.2')) {
-            $registry->registerFromFile('OAT/jquery.qtip', $installBasePath . '/OAT/jquery.qtip.js');
+            $sharedLibRegistry->registerFromFile('OAT/jquery.qtip', $installBasePath . '/OAT/jquery.qtip.js');
             $this->setVersion('5.2.0');
         }
 
         $this->skip('5.2.0', '5.3.0');
 
         if ($this->isVersion('5.3.0')) {
-            $registry->registerFromFile('OAT/customEvent', $installBasePath . '/OAT/customEvent.js');
+            $sharedLibRegistry->registerFromFile('OAT/customEvent', $installBasePath . '/OAT/customEvent.js');
             $this->setVersion('5.4.0');
         }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -433,7 +433,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(ItemCategoriesService::SERVICE_ID, $categoriesService);
             $this->setVersion('5.8.0');
         }
-        $this->skip('5.8.0', '5.12.1');
+        $this->skip('5.8.0', '5.12.2');
     }
 
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -370,8 +370,7 @@ class Updater extends \common_ext_ExtensionUpdater
 
         if ($this->isVersion('2.25.0')) {
 
-            $registry = QtiCreatorClientConfigRegistry::getRegistry();
-            $registry->registerPlugin('back', 'taoQtiItem/qtiCreator/plugins/navigation/back', 'navigation');
+            QtiCreatorClientConfigRegistry::getRegistry()->registerPlugin('back', 'taoQtiItem/qtiCreator/plugins/navigation/back', 'navigation');
 
             $this->setVersion('2.26.0');
         }


### PR DESCRIPTION
This PR fixes the issue from updating taoQtiItem from a version older than 2.24.0.
The issue happens with the variable registry overwritten,
To prevent this from happening in the future, I renamed the variable registry to a more specific name.