### PR TITLE
Fix/tao 3251 item responses

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '6.0.0',
+    'version' => '6.0.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.23.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -433,7 +433,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(ItemCategoriesService::SERVICE_ID, $categoriesService);
             $this->setVersion('5.8.0');
         }
-        $this->skip('5.8.0', '6.0.0');
+        $this->skip('5.8.0', '6.0.1');
     }
 
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -62,6 +62,7 @@ define([
             }
 
             if( keyCode === KEY_CODE_SPACE || keyCode === KEY_CODE_ENTER){
+                // delay the trigger to be sure the selection will not be invalidated by the browser
                 _.delay(function(){
                     _triggerInput($this.closest('.qti-choice'));
                 }, 100);

--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -55,13 +55,16 @@ define([
         var $choiceInputs = $container.find('.qti-choice').find('input:radio,input:checkbox').not('[disabled]').not('.disabled');
 
         $choiceInputs.on('keydown.commonRenderer', function(e){
+            var $this = $(this);
             var keyCode = e.keyCode ? e.keyCode : e.charCode;
             if(keyCode !== KEY_CODE_TAB){
                 e.preventDefault();
             }
 
             if( keyCode === KEY_CODE_SPACE || keyCode === KEY_CODE_ENTER){
-                _triggerInput($(this).closest('.qti-choice'));
+                _.delay(function(){
+                    _triggerInput($this.closest('.qti-choice'));
+                }, 100);
             }
 
             var $nextInput = $(this).closest('.qti-choice').next('.qti-choice').find('input:radio,input:checkbox').not('[disabled]').not('.disabled');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3251

Fix the behaviour of the shortcut that allows to check a choice (SPACE key).

Without this fix, when you press the space bar to check a response, the radio button is checked, then immediately unchecked