### PR TITLE
Fix the regression in unit test for the choice interaction

### DIFF
--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -82,7 +82,7 @@ define([
             var eliminator = e.target.dataset.eliminable;
 
             // if the click has been triggered by a keyboard check, prevent this listener to cancel this check
-            if ($(e.originalEvent.target).is('input')) {
+            if (e.originalEvent && $(e.originalEvent.target).is('input')) {
                 return;
             }
 


### PR DESCRIPTION
Fix the regression in unit tests about the choice interaction.
However, that does not fix the provider unit test that still fail on 'Get the list of PIC'.