### PR TITLE
Fix/pci properties entry replacement

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '6.2.0',
+    'version' => '6.2.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.23.0',

--- a/model/Export/AbstractQTIItemExporter.php
+++ b/model/Export/AbstractQTIItemExporter.php
@@ -169,7 +169,7 @@ abstract class AbstractQTIItemExporter extends taoItems_models_classes_ItemExpor
                 }
             }
             foreach ($portableEntryNodes as $node) {
-                $node->nodeValue = strtr($node->nodeValue, $replacementList);
+                $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);
             }
 
             $this->exportPortableAssets($dom, 'portableCustomInteraction', 'customInteractionTypeIdentifier', 'pci', $portableElementsToExport, $portableAssetsToExport);

--- a/model/QtiItemCompiler.php
+++ b/model/QtiItemCompiler.php
@@ -275,7 +275,7 @@ class QtiItemCompiler extends taoItems_models_classes_ItemCompiler
             $attributeNodes = $xpath->query("//*[local-name()='entry']") ?: [];
             unset($xpath);
             foreach ($attributeNodes as $node) {
-                $node->nodeValue = strtr($node->nodeValue, $replacementList);
+                $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);
             }
         } else {
             throw new taoItems_models_classes_CompilationFailedException('Unable to load XML');

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,7 +434,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.8.0');
         }
         
-        $this->skip('5.8.0', '6.2.0');
+        $this->skip('5.8.0', '6.2.1');
     }
 
 }


### PR DESCRIPTION
Fixed compilation and delivery for pcis which have any property entry htmlentity-encoded .

@no-chris please validate the functionality and check that fix is applicable to the client who reported it
@siwane please review the php code, this solution fixes a the nodeValue replacement, in case it is html-encoded. Somehow such DomNode when given an htmlentity-encoded value is decoded when one tries to access it with $mode->nodeValue.