### PR TITLE
Support flysystem source in PackageParser

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '6.2.1',
+    'version' => '6.2.2',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.23.0',

--- a/model/qti/PackageParser.php
+++ b/model/qti/PackageParser.php
@@ -136,24 +136,33 @@ class PackageParser
      * Short description of method extract
      *
      * @access public
+     * @throws \common_exception_Error
      * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
-     * @return string
+     * @return string|null
      */
     public function extract()
     {
         $returnValue = null;
 
+        if ($this->source instanceof \oat\oatbox\filesystem\File) {
+            $archiveFolder = tao_helpers_File::createTempDir();
+            if (!is_dir($archiveFolder)) {
+                mkdir($archiveFolder);
+            }
+            $filename = $archiveFolder . basename($this->source->getPrefix());
+            file_put_contents($filename, $this->source->read());
+            $this->source = $filename;
+        }
+
     	if(!is_file($this->source)){	//ultimate verification
         	throw new common_exception_Error("source ".$this->source." not a file");
         }
-        
-        $sourceFile = basename($this->source);
+
         $folder = tao_helpers_File::createTempDir();
-		
-		if(!is_dir($folder)){
-        	mkdir($folder);
+        if (!is_dir($folder)) {
+            mkdir($folder);
         }
-        
+
 	    $zip = new ZipArchive();
 		if ($zip->open($this->source) === true) {
 		    if($zip->extractTo($folder)){

--- a/model/qti/PackageParser.php
+++ b/model/qti/PackageParser.php
@@ -21,12 +21,12 @@
 
 namespace oat\taoQtiItem\model\qti;
 
-use oat\taoQtiItem\model\qti\PackageParser;
 use \tao_models_classes_Parser;
 use \Exception;
 use \tao_helpers_File;
 use \ZipArchive;
 use \common_exception_Error;
+use \oat\oatbox\filesystem\File;
 
 /**
  * Enables you to parse and validate a QTI Package.
@@ -144,7 +144,7 @@ class PackageParser
     {
         $returnValue = null;
 
-        if ($this->source instanceof \oat\oatbox\filesystem\File) {
+        if ($this->source instanceof File) {
             $archiveFolder = tao_helpers_File::createTempDir();
             if (!is_dir($archiveFolder)) {
                 mkdir($archiveFolder);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,7 +434,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.8.0');
         }
         
-        $this->skip('5.8.0', '6.2.1');
+        $this->skip('5.8.0', '6.2.2');
     }
 
 }


### PR DESCRIPTION
`__construct()` method of parent `tao_models_classes_Parser` class  accepts flysystem's `File` instances:
https://github.com/oat-sa/tao-core/blob/master/models/classes/class.Parser.php#L125
But `extract()` method expects that source property will be a string (path to file). I added support of flysystem's file instance in the `extract()` method.