### PR TITLE
Toggle the CSS class 'user-selected' to react to user input on choice interactions

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '6.4.1',
+    'version' => '6.5.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.23.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,7 +434,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.8.0');
         }
         
-        $this->skip('5.8.0', '6.4.1');
+        $this->skip('5.8.0', '6.5.1');
     }
 
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -114,9 +114,12 @@ define([
 
         var $input = $choiceBox.find('input:radio,input:checkbox').not('[disabled]').not('.disabled');
 
+
         if(!_.isBoolean(state)) {
             state = !$input.prop('checked');
         }
+
+        $choiceBox.toggleClass('user-selected', state);
 
         if($input.length){
             $input.prop('checked', state);


### PR DESCRIPTION
This extends the functionality described in https://github.com/oat-sa/extension-tao-mp/pull/293 to choice interactions. 
Create a choice interaction and proceed as decribed in the above case.
https://oat-sa.atlassian.net/browse/TAO-3133