### PR TITLE
Fix/tao 3626 dont propagate choice navi

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '6.8.6',
+    'version' => '6.8.7',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.25.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -446,7 +446,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.8.2');
         }
 
-        $this->skip('6.8.2', '6.8.6');
+        $this->skip('6.8.2', '6.8.7');
     }
 
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -85,9 +85,11 @@ define([
 
             if (keyCode === KEY_CODE_UP || keyCode === KEY_CODE_LEFT){
                 e.preventDefault();
+                e.stopPropagation();
                 $qtiChoice.prev('.qti-choice').find('input:radio,input:checkbox').not('[disabled]').not('.disabled').focus();
             } else if (keyCode === KEY_CODE_DOWN || keyCode === KEY_CODE_RIGHT){
                 e.preventDefault();
+                e.stopPropagation();
                 $qtiChoice.next('.qti-choice').find('input:radio,input:checkbox').not('[disabled]').not('.disabled').focus();
             }
         });
@@ -97,6 +99,7 @@ define([
 
             if( keyCode === KEY_CODE_SPACE || keyCode === KEY_CODE_ENTER){
                 e.preventDefault();
+                e.stopPropagation();
                 _triggerInput($(this).closest('.qti-choice'));
             }
         });


### PR DESCRIPTION
On a choice interaction, with the themeSwitcher plugin and shortcuts activated : 
 - hit `tab`
 - open the theme switcher
 - play with  :arrow_down:, :arrow_up: and  :leftwards_arrow_with_hook:

The main issue was the incompatibility of the native event's `preventDefault` of `util/shortcut/registry` with jQuery's events of the render: you can prevent native events from jQuery handlers but not the other way. So I've prevented the bubbling into the renderer (those events  didn't have to bubble anyway).