### PR TITLE
TAO-3640

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '6.8.6',
+    'version' => '6.9.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=2.25.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -446,7 +446,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.8.2');
         }
 
-        $this->skip('6.8.2', '6.8.6');
+        $this->skip('6.8.2', '6.9.0');
     }
 
 }

--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -79,6 +79,9 @@ define([
             interaction.toggleClass('eliminable', this.checked);
             // current visual
             _widget.$original.toggleClass('eliminable', this.checked);
+
+            // indicate whether this has been unchecked on purpose
+            interaction.toggleClass('eliminability-deselected', !this.checked);
         });
 
         formElement.initWidget($form);


### PR DESCRIPTION
Related to https://github.com/oat-sa/extension-tao-nbce/pull/2
This feature is currently only used in NBCE TAO-3640. It stores in the item when eliminability has been deselected on purpose. 

1. create an item
2. add two choice interactions
3. uncheck 'Allow elimination' for one of them and save
4. check qti.xml where the one that you have deselected has the class "eliminability-deselected"