### PR TITLE
Feature/tao 3725 move css cache buster

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,10 +29,10 @@ return array(
     'label' => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license' => 'GPL-2.0',
-    'version' => '6.11.1',
+    'version' => '6.12.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
-        'taoItems' => '>=2.25.0',
+        'taoItems' => '>=2.26.0',
         'tao'      => '>=7.42.0'
     ),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -452,7 +452,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $sharedLibRegistry->registerFromFile('OAT/mediaPlayer', $installBasePath . '/OAT/mediaPlayer.js');
             $this->setVersion('6.11.0');
         }
-        $this->skip('6.11.0', '6.11.1');
+        $this->skip('6.11.0', '6.12.0');
     }
 
 }

--- a/views/js/qtiCommonRenderer/helpers/itemStylesheetHandler.js
+++ b/views/js/qtiCommonRenderer/helpers/itemStylesheetHandler.js
@@ -46,25 +46,15 @@ define([
 
          // relative links with cache buster
         _(stylesheets).forEach(function(stylesheet){
-            var sep,
-                $link,
+            var $link,
                 href;
 
             //if the href is something
             if(stylesheet.attr('href')){
                 $link = $(stylesheet.render());
+
                 //get the resolved href once rendererd
                 href = $link.attr('href');
-
-                //bust cache only for network URLs
-                if(!/^data\:/.test(href)){
-                    sep = href.indexOf('?') > -1 ? '&' : '?';
-                    if(href.indexOf('/') === 0) {
-                        href = href.slice(1);
-                    }
-
-                    href +=  sep + (new Date().getTime()).toString();
-                }
 
                 //we need to set the href after the link is appended to the head (for our dear IE)
                 $link.removeAttr('href')

--- a/views/js/qtiCommonRenderer/renderers/config.js
+++ b/views/js/qtiCommonRenderer/renderers/config.js
@@ -31,7 +31,8 @@ define([
     var moduleConfig = module.config();
 
     //Create asset manager stack
-    var assetManager = assetManagerFactory([{
+    var assetManager = assetManagerFactory([
+        {
             name : 'theme',
             handle : function handleTheme(url){
                 if(itemThemes && url.path && (url.path === itemThemes.base || _.contains(_.pluck(itemThemes.available, 'path'), url.path))){
@@ -42,6 +43,7 @@ define([
         assetStrategies.taomedia,
         assetStrategies.external,
         assetStrategies.base64,
+        assetStrategies.itemCssNoCache,
         assetStrategies.baseUrl,
         portableAssetStrategy
     ], {baseUrl : ''});//baseUrl is not predefined in the config, but should be set upon renderer instantiating


### PR DESCRIPTION
Move the cache buster of item CSS from the renderer to the asset strategies. To be able to configure it.

Requires https://github.com/oat-sa/extension-tao-item/pull/256