### PR TITLE
Fix/tao 4142 self closing tags

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '7.0.2',
+    'version'     => '7.0.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=3.0.0',

--- a/model/qti/XIncludeLoader.php
+++ b/model/qti/XIncludeLoader.php
@@ -128,8 +128,8 @@ class XIncludeLoader
         }else{
             throw new ParsingException('cannot parse pci markup');
         }
-        
-        $customElement->setMarkup($xml->saveXML());
+
+        $customElement->setMarkup($xml->saveXML(null, LIBXML_NOEMPTYTAG));
         
         return $xincludes;
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -462,6 +462,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.19.0');
         }
 
-        $this->skip('6.19.0', '7.0.2');
+        $this->skip('6.19.0', '7.0.3');
     }
 }


### PR DESCRIPTION
This PR completes the fix on https://github.com/oat-sa/extension-tao-itemqti/commit/7811fa6abd547c201b6267dcb1963fdcf4168555

To test this, you need the new test runner activated.
1. create an item with a pci likert and leave the prompt empty (important)
2. create a test and compile it
3. during delivery check the markup : the prompt should remain empty and must not contain other elements