### PR TITLE
wrong handling of class 'user-selected'

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.1.0',
+    'version'     => '8.1.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -472,5 +472,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->runExtensionScript(SetItemModel::class);
             $this->setVersion('8.1.0');
         }
+
+        $this->skip('8.1.0', '8.1.1');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -51,12 +51,15 @@ define([
 
         var $input = $choiceBox.find('input:radio,input:checkbox').not('[disabled]').not('.disabled');
 
-
         if(!_.isBoolean(state)) {
             state = !$input.prop('checked');
         }
 
         $choiceBox.toggleClass('user-selected', state);
+
+        if($input[0].type === 'radio') {
+            $choiceBox.siblings().filter('.user-selected').removeClass('user-selected');
+        }
 
         if($input.length){
             $input.prop('checked', state);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-4330

The underlying problem is that in [ChoiceInteraction.js](https://github.com/oat-sa/extension-tao-itemqti/blob/master/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js#L59) the class `user-selected` is added but never removed on the other inputs. For checkboxes this is the desired behaviour but not for radio buttons.

As the problem has technically nothing to do with NBCE it can be tested anywhere. On NBCE it has just the most visible impact.

- Install NBCE
- create an item with two choice interactions, set for one of them max responses to 1
- check and uncheck them in a test