### PR TITLE
Fix/tao 3074 background image ratio

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.4.0',
+    'version'     => '8.4.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -498,6 +498,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.3.0');
         }
 
-        $this->skip('8.3.0', '8.4.0');
+        $this->skip('8.3.0', '8.4.1');
     }
 }

--- a/views/js/qtiCreator/widgets/interactions/helpers/bgImage.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/bgImage.js
@@ -23,8 +23,9 @@
  */
 define([
     'util/url',
+    'util/image',
     'ui/mediasizer'
-], function (url) {
+], function (url, imageUtil) {
     'use strict';
 
     /**
@@ -141,10 +142,16 @@ define([
         callbacks = callbacks || {};
         callbacks.data = function (interaction, value) {
             interaction.object.attr('data', url.encodeAsXmlAttr(value));
-            widget.rebuild({
-                ready: function (widget) {
-                    widget.changeState('question');
+            imageUtil.getSize(widget.options.assetManager.resolve(value), function (size) {
+                if (size) {
+                    interaction.object.attr('width', size.width);
+                    interaction.object.attr('height', size.height);
                 }
+                widget.rebuild({
+                    ready: function (widgetReady) {
+                        widgetReady.changeState('question');
+                    }
+                });
             });
         };
         callbacks.width = function (interaction, value) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3074

Fix the size and aspect ratio issue occurring when the image path is directly input instead of using the asset manager.

Steps to reproduce:
- Go to Item page
- Create New Item
- Click Authoring
- Add Graphic Interaction to canvas (e.g. Hotspot Interaction). The resource manager will be open.
- Upload background image using resource manager. Note that the image displays correctly.
- Copy address (URL) of another image with different aspect ratio
- Paste image address into the field for the file path (to the right of the canvas). Note that the new image displays incorrectly.