### PR TITLE
Fix/tao 3598 mediaplayer can seek

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,11 +29,11 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.4.1',
+    'version'     => '8.4.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.1.0',
-        'tao'      => '>=10.6.0'
+        'tao'      => '>=10.7.0'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOItem.rdf'

--- a/manifest.php
+++ b/manifest.php
@@ -29,11 +29,11 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.4.0',
+    'version'     => '8.4.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.1.0',
-        'tao'      => '>=10.2.0'
+        'tao'      => '>=10.6.0'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOItem.rdf'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -498,6 +498,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.3.0');
         }
 
-        $this->skip('8.3.0', '8.4.0');
+        $this->skip('8.3.0', '8.4.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -498,6 +498,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.3.0');
         }
 
-        $this->skip('8.3.0', '8.4.1');
+        $this->skip('8.3.0', '8.4.2');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -96,7 +96,7 @@ define([
                     interaction.mediaElement = mediaplayer({
                         url: url && self.resolveUrl(url),
                         type: media.attr('type') || defaults.type,
-                        canPause: $container.hasClass('pause'),
+                        canPause: $container.hasClass('pause') || !!maxPlays,
                         maxPlays: maxPlays,
                         canSeek: !maxPlays,
                         width: media.attr('width'),

--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -96,7 +96,7 @@ define([
                     interaction.mediaElement = mediaplayer({
                         url: url && self.resolveUrl(url),
                         type: media.attr('type') || defaults.type,
-                        canPause: $container.hasClass('pause') || !!maxPlays,
+                        canPause: $container.hasClass('pause'),
                         maxPlays: maxPlays,
                         canSeek: !maxPlays,
                         width: media.attr('width'),

--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -98,6 +98,7 @@ define([
                         type: media.attr('type') || defaults.type,
                         canPause: $container.hasClass('pause'),
                         maxPlays: maxPlays,
+                        canSeek: !maxPlays,
                         width: media.attr('width'),
                         height: media.attr('height'),
                         volume: 100,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3598

Requires: https://github.com/oat-sa/tao-core/pull/1333

When the `maxPlays` option is set, the Media Interaction does not allow to seek a position within the media using the duration bar.