### PR TITLE
Fix/tao 4421 cannot select key after deselecting answer eliminator

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.4.4',
+    'version'     => '8.4.5',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -498,6 +498,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.3.0');
         }
 
-        $this->skip('8.3.0', '8.4.4');
+        $this->skip('8.3.0', '8.4.5');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -300,7 +300,7 @@ define([
         var $container = containerHelper.get(interaction);
 
         try{
-           _.forEach(pciResponse.unserialize(response, interaction), function(identifier){
+            _.forEach(pciResponse.unserialize(response, interaction), function(identifier){
                 var $input = $container.find('.real-label > input[value=' + identifier + ']').prop('checked', true);
                 $input.closest('.qti-choice').toggleClass('user-selected', true);
             });
@@ -327,6 +327,16 @@ define([
     };
 
     /**
+     * Check if a choice interaction is choice-eliminable
+     *
+     * @param {Object} interaction
+     * @returns {boolean}
+     */
+    var isEliminable = function isEliminable(interaction){
+        return (/\beliminable\b/).test(interaction.attr('class'));
+    };
+
+    /**
      * Set additional data to the template (data that are not really part of the model).
      * @param {Object} interaction - the interaction
      * @param {Object} [data] - interaction custom data
@@ -339,16 +349,6 @@ define([
             listStyle: listStyles.pop(),
             eliminable: isEliminable(interaction)
         });
-    };
-
-    /**
-     * Check if a choice interaction is choice-eliminable
-     *
-     * @param {Object} interaction
-     * @returns {boolean}
-     */
-    var isEliminable = function isEliminable(interaction){
-        return (/\beliminable\b/).test(interaction.attr('class'));
     };
 
     /**
@@ -412,9 +412,9 @@ define([
 
             //restore eliminated choices
             if(isEliminable(interaction) && _.isArray(state.eliminated) && state.eliminated.length){
-               _.forEach(state.eliminated, function(identifier){
+                _.forEach(state.eliminated, function(identifier){
                     $container.find('.qti-simpleChoice[data-identifier=' + identifier + ']').addClass('eliminated');
-                })
+                });
             }
         }
     };

--- a/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -57,7 +57,7 @@ define([
 
         $choiceBox.toggleClass('user-selected', state);
 
-        if($input[0].type === 'radio') {
+        if ($input[0] && $input[0].type === 'radio') {
             $choiceBox.siblings().filter('.user-selected').removeClass('user-selected');
         }
 

--- a/views/js/test/qtiCommonRenderer/interactions/choice/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/choice/test.js
@@ -3,9 +3,8 @@ define([
     'lodash',
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/space-shuttle.json',
-    'json!taoQtiItem/test/samples/json/space-shuttle-m.json',
-    'core/promise'
-], function($, _, qtiItemRunner, choiceData, multipleChoiceData, Promise){
+    'json!taoQtiItem/test/samples/json/space-shuttle-m.json'
+], function ($, _, qtiItemRunner, choiceData, multipleChoiceData) {
     'use strict';
 
     var runner;
@@ -21,9 +20,9 @@ define([
     });
 
     QUnit.asyncTest('renders correclty', function(assert){
-        QUnit.expect(17);
-
         var $container = $('#' + fixtureContainerId);
+
+        QUnit.expect(17);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
@@ -59,23 +58,22 @@ define([
 
 
     QUnit.asyncTest('enables to select a choice', function(assert){
-        QUnit.expect(8);
-
         var $container = $('#' + fixtureContainerId);
+
+        QUnit.expect(8);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
+                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
+
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
-
-                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
                 assert.equal($discovery.length, 1, 'the Discovery choice exists');
 
                 $discovery.trigger('click');
-
             })
             .on('statechange', function(state){
                 assert.ok(typeof state === 'object', 'The state is an object');
@@ -89,30 +87,28 @@ define([
 
 
     QUnit.asyncTest('enables to select a unique choice', function(assert){
-        QUnit.expect(11);
-
         var $container = $('#' + fixtureContainerId);
         var changes = 0;
+
+        QUnit.expect(11);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
+                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
+                var $challenger = $('.qti-choice[data-identifier="Challenger"]', $container);
+
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
-
-                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
                 assert.equal($discovery.length, 1, 'the Discovery choice exists');
-
-                var $challenger = $('.qti-choice[data-identifier="Challenger"]', $container);
                 assert.equal($discovery.length, 1, 'the Challenger choice exists');
 
                 $discovery.trigger('click');
                 _.delay(function(){
                     $challenger.trigger('click');
                 }, 200);
-
             })
             .on('statechange', function(state){
                 if(++changes === 2){
@@ -133,26 +129,24 @@ define([
     });
 
     QUnit.asyncTest('enables to select multiple choices', function(assert){
-        QUnit.expect(11);
-
         var $container = $('#' + fixtureContainerId);
         var changes = 0;
+
+        QUnit.expect(11);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', multipleChoiceData)
             .on('render', function(){
+                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
+                var $challenger = $('.qti-choice[data-identifier="Challenger"]', $container);
+
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
-
                 assert.equal($container.find('.qti-choiceInteraction .instruction-container').length, 1, 'the interaction contains an instruction box');
                 assert.equal($container.find('.qti-choiceInteraction .instruction-container').children().length, 2, 'the interaction has 2 instructions');
-
-                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
                 assert.equal($discovery.length, 1, 'the Discovery choice exists');
-
-                var $challenger = $('.qti-choice[data-identifier="Challenger"]', $container);
                 assert.equal($discovery.length, 1, 'the Challenger choice exists');
 
                 $discovery.trigger('click');
@@ -174,9 +168,9 @@ define([
 
 
     QUnit.asyncTest('set the default response', function(assert){
-        QUnit.expect(4);
-
         var $container = $('#' + fixtureContainerId);
+
+        QUnit.expect(4);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
@@ -197,28 +191,27 @@ define([
     });
 
     QUnit.asyncTest('destroys', function(assert){
-        QUnit.expect(5);
-
         var $container = $('#' + fixtureContainerId);
+
+        QUnit.expect(5);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
+                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
+                var interaction = this._item.getInteractions()[0];
                 var self = this;
 
                 //call destroy manually
-                var interaction = this._item.getInteractions()[0];
                 interaction.renderer.destroy(interaction);
 
-                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
                 assert.equal($discovery.length, 1, 'the Discovery choice exists');
 
                 $discovery.trigger('click');
 
                 _.delay(function(){
-
                     assert.deepEqual(self.getState(), {'RESPONSE': { response : { base : null } } }, 'Click does not trigger response once destroyed');
                     assert.equal($container.find('.qti-choiceInteraction .instruction-container').children().length, 0, 'there is no instructions anymore');
 
@@ -230,34 +223,33 @@ define([
     });
 
     QUnit.asyncTest('resets the response', function(assert){
-        QUnit.expect(7);
-
         var $container = $('#' + fixtureContainerId);
+
+        QUnit.expect(7);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', choiceData)
             .on('render', function(){
+                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
                 var self = this;
 
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
-
-                var $discovery = $('.qti-choice[data-identifier="Discovery"]', $container);
                 assert.equal($discovery.length, 1, 'the Discovery choice exists');
 
                 $discovery.trigger('click');
 
                 _.delay(function(){
+                    var interaction = self._item.getInteractions()[0];
+
                     assert.ok($('input', $discovery).prop('checked'), 'Discovery is now checked');
 
                     //call destroy manually
-                    var interaction = self._item.getInteractions()[0];
                     interaction.renderer.resetResponse(interaction);
 
                     _.delay(function(){
-
                         assert.ok( ! $('input', $discovery).prop('checked'), 'Discovery is not checked checked anymore');
 
                         QUnit.start();
@@ -269,21 +261,20 @@ define([
     });
 
     QUnit.asyncTest('restores order of shuffled choices', function(assert){
-        QUnit.expect(9);
-
         var $container = $('#' + fixtureContainerId);
+        var shuffled;
+
+        QUnit.expect(9);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         //hack the item data to set the shuffle attr to true
-        var shuffled = _.cloneDeep(choiceData);
+        shuffled = _.cloneDeep(choiceData);
         shuffled.body.elements.interaction_choiceinteraction_546cb89e04090230494786.attributes.shuffle = true;
 
         runner = qtiItemRunner('qti', shuffled)
             .on('render', function(){
-                var self = this;
-
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
 
@@ -404,16 +395,15 @@ define([
     module('Visual Test');
 
     QUnit.asyncTest('Display and play', function(assert){
-        QUnit.expect(4);
-
         var $container = $('#' + outsideContainerId);
+
+        QUnit.expect(4);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         qtiItemRunner('qti', choiceData)
             .on('render', function(){
-
                 assert.equal($container.find('.qti-interaction.qti-choiceInteraction').length, 1, 'the container contains a choice interaction .qti-choiceInteraction');
                 assert.equal($container.find('.qti-choiceInteraction .qti-choice').length, 5, 'the interaction has 5 choices');
 
@@ -423,4 +413,3 @@ define([
             .render($container);
     });
 });
-


### PR DESCRIPTION
[tao-4421](https://oat-sa.atlassian.net/browse/TAO-4421)

The fix is contained in [this commit](https://github.com/oat-sa/extension-tao-itemqti/commit/7a883449048845c709ea183d00bdf2c0d64d7f2a). Further changes were added for testing and eslint. 

@ssipasseuth, when updating the tests, I removed a number of redundant tests to, hopefully, improve readability.

For testing my solution, I ran into an unrelated issue. The error occurred in [taoQtiTest, line 54](https://github.com/oat-sa/extension-tao-testqti/blob/develop/models/classes/runner/config/QtiRunnerConfig.php#L54). A simple fix is to transform `$rawConfig` into an array (i.e. `$rawConfig = get_object_vars($rawConfig);`). I added [this pull request](https://github.com/oat-sa/extension-tao-testqti/pull/852) to fix the issue.