### PR TITLE
Fix/tao 4412 assets resolver

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,10 +29,10 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.4.6',
+    'version'     => '8.4.7',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
-        'taoItems' => '>=4.1.0',
+        'taoItems' => '>=4.2.4',
         'tao'      => '>=10.7.0'
     ),
     'models' => array(

--- a/model/pack/QtiItemPacker.php
+++ b/model/pack/QtiItemPacker.php
@@ -133,9 +133,7 @@ class QtiItemPacker extends ItemPacker
     protected function resolveAsset($assets, ItemMediaResolver $resolver)
     {
         foreach ($assets as &$asset) {
-            $mediaAsset = $resolver->resolve($asset);
-            $mediaSource = $mediaAsset->getMediaSource();
-            $asset = $mediaSource->getBaseName($mediaAsset->getMediaIdentifier());
+            $asset = $resolver->resolve($asset);
         }
         return $assets;
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -497,6 +497,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.3.0');
         }
 
-        $this->skip('8.3.0', '8.4.6');
+        $this->skip('8.3.0', '8.4.7');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4412

Requires: https://github.com/oat-sa/extension-tao-item/pull/277

List instances of `MediaAssets` instead of directly trying to resolve them to identifiers.