### PR TITLE
TAO-4538 Fix 500 error at exporting metadata

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.11.0',
+    'version'     => '8.11.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/model/flyExporter/extractor/QtiExtractor.php
+++ b/model/flyExporter/extractor/QtiExtractor.php
@@ -20,6 +20,7 @@
  */
 
 namespace oat\taoQtiItem\model\flyExporter\extractor;
+use League\Flysystem\FileNotFoundException;
 use oat\taoQtiItem\model\qti\Service;
 
 /**
@@ -96,11 +97,15 @@ class QtiExtractor implements Extractor
      */
     private function loadXml(\core_kernel_classes_Resource $item)
     {
-
         $itemService = Service::singleton();
-        $xml = $itemService->getXmlByRdfItem($item);
-        if (empty($xml)) {
-            throw new ExtractorException('No content found for item ' . $item->getUri());
+
+        try {
+            $xml = $itemService->getXmlByRdfItem($item);
+            if (empty($xml)) {
+                throw new ExtractorException('No content found for item ' . $item->getUri());
+            }
+        } catch (FileNotFoundException $e) {
+            throw new ExtractorException('qti.xml file was not found for item '. $item->getUri() .'; The item might be empty.');
         }
 
         $this->dom   = new \DOMDocument();

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -509,7 +509,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.9.0');
         }
 
-        $this->skip('8.9.0', '8.11.0');
+        $this->skip('8.9.0', '8.11.1');
 
     }
 }


### PR DESCRIPTION
There was a 500 error at exporting of metadata when there was an empty item among the items to be exported.