### PR TITLE
Fix/tao 4465 destroy ir once

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.12.0',
+    'version'     => '8.12.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -509,6 +509,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.9.0');
         }
 
-        $this->skip('8.9.0', '8.12.0');
+        $this->skip('8.9.0', '8.12.1');
     }
 }

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -144,6 +144,8 @@ define([
                 if(this._renderer){
                     this._renderer.unload();
                 }
+
+                this._item = null;
             }
             done();
         },

--- a/views/js/test/runner/provider/test.js
+++ b/views/js/test/runner/provider/test.js
@@ -1,3 +1,25 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+/**
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
 define([
     'jquery',
     'lodash',
@@ -144,7 +166,7 @@ define([
     QUnit.asyncTest('Clear a rendered item', function(assert){
         var container = document.getElementById(containerId);
 
-        QUnit.expect(4);
+        QUnit.expect(6);
 
         assert.ok(container instanceof HTMLElement , 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
@@ -153,6 +175,7 @@ define([
 
         itemRunner('qti', itemData)
             .on('render', function(){
+                assert.equal(typeof this._item, 'object', 'the item instance is attached to the runner');
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 this.clear();
@@ -160,13 +183,13 @@ define([
             }).on('clear', function(){
 
                 assert.equal(container.children.length, 0, 'the container children are removed');
+                assert.equal(this._item, null, 'the item instance is also cleared');
 
                 QUnit.start();
             })
             .init()
             .render(container);
     });
-
 
 
     QUnit.module('Provider state', {


### PR DESCRIPTION
Issue discovered while testing the changes of TAO-4465
At the end of a test : 
 - the test runner performs and `unloaditem` -> `itemRunner.clear`
 - and then a `destroy` -> `itemRunner.clear`

Without this fix the `itemRunner` was destroying interactions already destroyed. I've discovered the issue with the Audio PCI as the last item of a test (it's destroy isn't idempotent /cc @no-chris). This fix the runner part and prevent unnecessary computation.