### PR TITLE
Fix/tao 4473 enable new pci

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '8.13.0',
+    'version'     => '8.13.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/model/portableElement/PortableElementService.php
+++ b/model/portableElement/PortableElementService.php
@@ -75,6 +75,10 @@ class PortableElementService implements ServiceLocatorAwareInterface
         $this->validate($object, $source, $validationGroup);
 
         $registry = $object->getModel()->getRegistry();
+
+        //enable portable element immediately when registering it
+        $object->enable();
+
         $registry->register($object, $source);
 
         return true;
@@ -119,9 +123,6 @@ class PortableElementService implements ServiceLocatorAwareInterface
         $parser = $this->getPortableFactory()->getModel($type)->getPackageParser();
         $source = $parser->extract($zipFile);
         $object = $parser->getModel()->createDataObject($parser->getManifestContent($zipFile));
-
-        //enable portable element immediately after adding it
-        $object->enable();
 
         $this->registerModel($object, $source);
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -522,5 +522,7 @@ class Updater extends \common_ext_ExtensionUpdater
             }
             $this->setVersion('8.13.0');
         }
+
+        $this->skip('8.13.0', '8.13.1');
     }
 }


### PR DESCRIPTION
Fix a bug introduced by https://github.com/oat-sa/extension-tao-itemqti/pull/956
New install TAO had all PCI disabled by default.
With this fix, they are enabled by default.
To test this, just make a fresh install and look the list of custom interactions.