### PR TITLE
Update to QTI-SDK legacy 0.11.0 through lib-tao-qti.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "minimum-stability" : "dev",
     "require": {
-        "oat-sa/lib-tao-qti" : "~3.0.0",
+        "oat-sa/lib-tao-qti" : "~3.1.0",
         "oat-sa/oatbox-extension-installer": "dev-master"
     },
     "autoload" : {

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI item model',
     'description' => 'TAO QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '9.0.0',
+    'version'     => '9.1.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -536,6 +536,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('8.16.0');
         }
 
-        $this->skip('8.16.0', '9.0.0');
+        $this->skip('8.16.0', '9.1.0');
     }
 }


### PR DESCRIPTION
Here is a list of things that might be worth to test:

- After extension/composer update, previously created gapMatchInteraction still work.
- After extension/composer update, previously compiled delivery containing gapMatchInteractions still work.
- No other side effects...