### PR TITLE
Fix/multiple assets export

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '10.0.4',
+    'version'     => '10.0.5',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/model/Export/AbstractQTIItemExporter.php
+++ b/model/Export/AbstractQTIItemExporter.php
@@ -362,7 +362,8 @@ abstract class AbstractQTIItemExporter extends taoItems_models_classes_ItemExpor
         }
 
         // To check if replacement is to replace basename ???
-        $this->addFile($stream, $basePath . '/' . preg_replace( '/^(.\/)/', '',$baseName));
+        // Please check it seriously next time!
+        $this->addFile($stream, $basePath . '/' . preg_replace( '/^(.\/)/', '',$replacement));
         $stream->close();
         return $replacement;
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -439,6 +439,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('10.0.0');
         }
 
-        $this->skip('10.0.0', '10.0.4');
+        $this->skip('10.0.0', '10.0.5');
     }
 }


### PR DESCRIPTION
This PR aims at being able to export correctly items having multiple mediamanager-based assets **in a S3 storage**.

**To be released as hotfix version 9.11.4**