### PR TITLE
Tao 4996/shared stimulus images not displayed at delivery time when no media manager

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '10.9.2',
+    'version'     => '10.9.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/model/qti/ParserFactory.php
+++ b/model/qti/ParserFactory.php
@@ -84,9 +84,13 @@ class ParserFactory
     protected $item = null;
     protected $attributeMap = array('lang' => 'xml:lang');
 
-    public function __construct(DOMDocument $data){
+    protected $additionalPath = null;
+
+    public function __construct(DOMDocument $data, $additionalPath = null){
         $this->data = $data;
         $this->xpath = new DOMXPath($data);
+
+        $this->additionalPath = $additionalPath;
     }
 
     /**
@@ -425,6 +429,10 @@ class ParserFactory
         $options = array();
         foreach($data->attributes as $attr){
             if($attr->nodeName === 'xsi:schemaLocation'){
+                continue;
+            }
+            if ($attr->nodeName === 'src' && !empty($this->additionalPath) && false === strpos($this->additionalPath, 'mediamanager')) {
+                $options[isset($this->attributeMap[$attr->nodeName]) ? $this->attributeMap[$attr->nodeName] : $attr->nodeName] = $this->additionalPath . (string) $attr->nodeValue;
                 continue;
             }
             $options[isset($this->attributeMap[$attr->nodeName]) ? $this->attributeMap[$attr->nodeName] : $attr->nodeName] = (string) $attr->nodeValue;

--- a/model/qti/XIncludeLoader.php
+++ b/model/qti/XIncludeLoader.php
@@ -43,6 +43,8 @@ class XIncludeLoader
     protected $qtiItem = null;
     protected $resolver = null;
 
+    protected $additionalPath = null;
+
     public function __construct(Item $qtiItem, ItemMediaResolver $resolver){
         $this->qtiItem = $qtiItem;
         $this->resolver = $resolver;
@@ -67,6 +69,13 @@ class XIncludeLoader
                 try {
                     $asset = $this->resolver->resolve($href);
                     $filePath = $asset->getMediaSource()->download($asset->getMediaIdentifier());
+
+                    $explodedPath = explode('/', $href);
+                    if (count($explodedPath) > 2) {
+                        unset($explodedPath[count($explodedPath) - 1], $explodedPath[0]);
+                        $this->additionalPath = implode('/', $explodedPath) . '/';
+                    }
+
                     $this->loadXInclude($xinclude, $filePath);
                 } catch (\tao_models_classes_FileNotFoundException $exception) {
                     if ($removeUnfoundHref) {
@@ -148,7 +157,7 @@ class XIncludeLoader
         $node = $xml->documentElement;
         if($loadSuccess && !is_null($node)){
             //parse the href content
-            $parser = new ParserFactory($xml);
+            $parser = new ParserFactory($xml, $this->additionalPath);
             $parser->loadContainerStatic($node, $xinclude->getBody());
         }else{
             throw new XIncludeException('Cannot load the XInclude DOM XML', $xinclude);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -473,7 +473,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('10.7.0');
         }
 
-        $this->skip('10.7.0', '10.9.2');
+        $this->skip('10.7.0', '10.9.3');
 
     }
 }


### PR DESCRIPTION
Reused "copy"-part of code in QtiItemCompiler just to make sure images from shared stimulus xincludes are copied to public folder;
ParserFactory now has additionalPath not mandatory param (a string with path) as it is needed to be passed to XIncludeLoader to load XIncludeImages from right paths;