### PR TITLE
Tao 5490/qti assessment item xml lang attribute systematically overriden

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '10.9.2',
+    'version'     => '10.9.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/model/qti/Service.php
+++ b/model/qti/Service.php
@@ -133,7 +133,12 @@ class Service extends tao_models_classes_Service
     {
         $label = mb_substr($rdfItem->getLabel(), 0, 256, 'UTF-8');
         //set the current data lang in the item content to keep the integrity
-        $qtiItem->setAttribute('xml:lang', \common_session_SessionManager::getSession()->getDataLanguage());
+        if ($qtiItem->hasAttribute('xml:lang') && !empty($qtiItem->getAttributeValue('xml:lang'))) {
+            $lang = $qtiItem->getAttributeValue('xml:lang');
+        } else {
+            $lang = \common_session_SessionManager::getSession()->getDataLanguage();
+        }
+        $qtiItem->setAttribute('xml:lang', $lang);
         $qtiItem->setAttribute('label', $label);
         
         $directory = taoItems_models_classes_ItemsService::singleton()->getItemDirectory($rdfItem);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -473,7 +473,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('10.7.0');
         }
 
-        $this->skip('10.7.0', '10.9.2');
+        $this->skip('10.7.0', '10.9.3');
 
     }
 }


### PR DESCRIPTION
From now xml:lang attribute is not ommited when importing qti package with items/test;