### PR TITLE
Fix/tao 5544 prevent code exec

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '11.1.0',
+    'version'     => '11.1.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -473,7 +473,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('10.7.0');
         }
 
-        $this->skip('10.7.0', '11.1.0');
+        $this->skip('10.7.0', '11.1.1');
 
     }
 }

--- a/views/js/qtiCreator/model/mixin/editable.js
+++ b/views/js/qtiCreator/model/mixin/editable.js
@@ -140,8 +140,9 @@ define([
                     'value' : entity.encode(value)
                 });
             }
-            return entity.decode(ret);
+            return _.isString(ret) ? entity.decode(ret) : ret;
         },
+
         removeAttr : function(key){
             var ret = this._super(key);
             $(document).trigger('attributeChange.qti-widget', {'element' : this, 'key' : key, 'value' : null});

--- a/views/js/qtiCreator/model/mixin/editable.js
+++ b/views/js/qtiCreator/model/mixin/editable.js
@@ -19,25 +19,27 @@
 define([
     'lodash',
     'jquery',
+    'core/encoder/entity',
     'taoQtiItem/qtiItem/core/Element',
     'taoQtiItem/qtiCreator/model/helper/event',
-    'taoQtiItem/qtiCreator/model/helper/invalidator',
-    'util/url'
-], function(_, $, Element, event, invalidator, url){
+    'taoQtiItem/qtiCreator/model/helper/invalidator'
+], function(_, $, entity, Element, event, invalidator){
     "use strict";
 
     var _removeSelf = function(element){
 
-        var removed = false,
-            related = element.getRootElement();
+        var removed = false;
+        var related = element.getRootElement();
+        var found;
+        var parent;
 
         if(related){
 
-            var found = related.find(element.getSerial());
+            found = related.find(element.getSerial());
 
             if(found){
 
-                var parent = found.parent;
+                parent = found.parent;
                 if(Element.isA(parent, 'interaction')){
 
                     if(element.qtiClass === 'gapImg'){
@@ -73,19 +75,18 @@ define([
                     event.deleted(element, parent);
                 }
             }
-        }else{
-            throw 'no related item found';
+        } else {
+            throw new Error('no related item found');
         }
 
         return removed;
     };
 
     var _removeElement = function(element, containerPropName, eltToBeRemoved){
+        var targetSerial = '',
+            targetElt;
 
         if(element[containerPropName]){
-
-            var targetSerial = '',
-                targetElt;
 
             if(typeof (eltToBeRemoved) === 'string'){
                 targetSerial = eltToBeRemoved;
@@ -107,14 +108,13 @@ define([
 
     var methods = {
         init : function(serial, attributes){
+            var attr = {};
 
             //init call in the format init(attributes)
             if(typeof (serial) === 'object'){
                 attributes = serial;
                 serial = '';
             }
-
-            var attr = {};
 
             if(_.isFunction(this.getDefaultAttributes)){
                 _.extend(attr, this.getDefaultAttributes());
@@ -123,12 +123,24 @@ define([
 
             this._super(serial, attr);
         },
+
+        /**
+         * Get or set an attribute
+         * @param {String} key - the attribute name
+         * @param {String} [value] - only to set the new value, let empty for a get
+         * @returns {String} the attribute value
+         */
         attr : function(key, value){
             var ret = this._super(key, value);
-            if(key !== undefined && value !== undefined){
-                $(document).trigger('attributeChange.qti-widget', {'element' : this, 'key' : key, 'value' : value});
+
+            if(typeof key !== 'undefined' && typeof value !== 'undefined'){
+                $(document).trigger('attributeChange.qti-widget', {
+                    'element' : this,
+                    'key' : key,
+                    'value' : entity.encode(value)
+                });
             }
-            return url.encodeAsXmlAttr(ret);
+            return entity.decode(ret);
         },
         removeAttr : function(key){
             var ret = this._super(key);
@@ -141,7 +153,7 @@ define([
             }else if(arguments.length === 2){
                 return _removeElement(this, arguments[0], arguments[1]);
             }else{
-                throw 'invalid number of argument given';
+                throw new Error('invalid number of argument given');
             }
         }
     };

--- a/views/js/qtiCreator/plugins/content/title.js
+++ b/views/js/qtiCreator/plugins/content/title.js
@@ -24,9 +24,10 @@
  */
 define([
     'jquery',
+    'lodash',
     'i18n',
     'core/plugin'
-], function($, __, pluginFactory){
+], function($, _, __, pluginFactory){
     'use strict';
 
     /**
@@ -42,8 +43,12 @@ define([
          */
         init : function init(){
             var config = this.getHost().getConfig();
+            var item   = this.getHost().getItem();
 
-            if(config && config.properties && config.properties.label){
+            if(item && !_.isEmpty(item.attr('title'))){
+                this.title = item.attr('title');
+            }
+            else if(config && config.properties && config.properties.label){
                 this.title = config.properties.label;
             }
         },

--- a/views/js/qtiCreator/widgets/item/states/Active.js
+++ b/views/js/qtiCreator/widgets/item/states/Active.js
@@ -17,28 +17,19 @@
  *
  */
 define([
+    'lodash',
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/states/Active',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/item',
     'taoQtiItem/qtiCreator/widgets/helpers/formElement'
-], function(stateFactory, Active, formTpl, formElement){
-    
+], function(_, stateFactory, Active, formTpl, formElement){
     'use strict';
-    
-    var ItemStateActive = stateFactory.create(Active, function(){
 
-        this.initForm();
-
-    }, function(){
-
-    });
-
-    ItemStateActive.prototype.initForm = function(){
-
-        var _widget = this.widget,
-            item = _widget.element,
-            $form = _widget.$form,
-            areaBroker = this.widget.getAreaBroker();
+    var ItemStateActive = stateFactory.create(Active, function enterActiveState(){
+        var _widget = this.widget;
+        var item = _widget.element;
+        var $form = _widget.$form;
+        var areaBroker = this.widget.getAreaBroker();
 
         //build form:
         $form.html(formTpl({
@@ -47,7 +38,7 @@ define([
             title : item.attr('title'),
             timeDependent : !!item.attr('timeDependent')
         }));
-        
+
         //init widget
         formElement.initWidget($form);
 
@@ -56,11 +47,12 @@ define([
             identifier : formElement.getAttributeChangeCallback(),
             title : function titleChange(i, title){
                 item.attr('title', title);
-                areaBroker.getTitleArea().html(title);
+                areaBroker.getTitleArea().text(item.attr('title'));
             },
             timeDependent : formElement.getAttributeChangeCallback()
         });
-    };
+
+    }, _.noop);
 
     return ItemStateActive;
 });


### PR DESCRIPTION
Open the authoring and  try a simple code injection  in the "title" field : 
 - add the following string in the title field : `<script>alert('hijack')</script>`

Fortunately the value was encoded  at saving time which prevents the XSS (but leads to a bad UX).

All attributes where previously encoded using "URL encoding". Since the target is XML, I've replaced the encoding by "entity encoding". 

@ssipasseuth please check if the change of encoding is suitable.