### PR TITLE
do not create a new browser history entry when leaving authoring, but…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '12.1.0',
+    'version'     => '12.1.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -486,7 +486,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('11.4.0');
         }
 
-        $this->skip('11.4.0', '12.1.0');
+        $this->skip('11.4.0', '12.1.1');
 
     }
 }

--- a/views/js/qtiCreator/plugins/navigation/back.js
+++ b/views/js/qtiCreator/plugins/navigation/back.js
@@ -28,9 +28,8 @@ define([
     'i18n',
     'core/plugin',
     'ui/hider',
-    'layout/section',
     'tpl!taoQtiItem/qtiCreator/plugins/button'
-], function($, __, pluginFactory, hider, section, buttonTpl){
+], function($, __, pluginFactory, hider, buttonTpl){
     'use strict';
 
     /**
@@ -49,13 +48,7 @@ define([
             var itemCreator = this.getHost();
 
             itemCreator.on('exit', function(){
-                var itemSection = section.get('manage_items');
-
-                if(itemSection){
-                    itemSection.activate();
-                } else{
-                    window.history.back();
-                }
+                window.history.back();
             });
 
             this.$element = $(buttonTpl({


### PR DESCRIPTION
Problem:
- go to items
- open the authoring
- hit the "manage items" buttons
- notice that a new history entry has been created.

Expected behavior would be that the "manage items" buttons would work like the browser "back" button. Without this fix, clicking back moves back to authoring, and forward is not available.