### PR TITLE
Fix/tao 3779 escape console response

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '12.7.0',
+    'version'     => '12.7.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '12.7.1',
+    'version'     => '12.7.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '12.7.2',
+    'version'     => '12.7.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -501,6 +501,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('12.6.0');
         }
 
-        $this->skip('12.6.0', '12.7.2');
+        $this->skip('12.6.0', '12.7.3');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -501,6 +501,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('12.6.0');
         }
 
-        $this->skip('12.6.0', '12.7.1');
+        $this->skip('12.6.0', '12.7.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -501,6 +501,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('12.6.0');
         }
 
-        $this->skip('12.6.0', '12.7.0');
+        $this->skip('12.6.0', '12.7.1');
     }
 }

--- a/views/js/QtiPreviewResultServerApi.js
+++ b/views/js/QtiPreviewResultServerApi.js
@@ -1,8 +1,28 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014 (original work) Open Assessment Technologies SA
+ *
+ */
 define([
     'jquery',
+    'lodash',
     'taoQtiItem/qtiCommonRenderer/helpers/PciResponse',
     'util/strPad'],
-    function($, pciResponse, strPad){
+    function($, _, pciResponse, strPad){
+    'use strict';
 
     function QtiPreviewResultServerApi(endpoint, itemUri){
         this.endpoint = endpoint;
@@ -26,7 +46,7 @@ define([
 
         for (variableIdentifier in responses) {
             previewConsole.trigger('updateConsole', [
-                'Submitted data', strPad(variableIdentifier + ': ', 15, ' ') + pciResponse.prettyPrint(responses[variableIdentifier])
+                'Submitted data', strPad(variableIdentifier + ': ', 15, ' ') + _.escape(pciResponse.prettyPrint(responses[variableIdentifier]))
             ]);
         }
 


### PR DESCRIPTION
To test this, create an item with an extended text interaction and/or text entry interaction.
In the preview console, try responding `<ok>` in them. Without this fix, they are displayed as empty because it is interpreted as html.