### PR TITLE
Fix/tao 5505/tts  cannot click to speak choice content

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '12.7.1',
+    'version'     => '12.7.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -501,6 +501,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('12.6.0');
         }
 
-        $this->skip('12.6.0', '12.7.1');
+        $this->skip('12.6.0', '12.7.2');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -380,10 +380,15 @@ define([
 
             // Point & click handlers
 
-            interact($container.selector).on('tap', function() {
+            interact($container.selector).on('tap', function(e) {
                 //if tts component is loaded and click-to-speak function is activated - we should prevent this listener to go further
                 if ($(e.currentTarget).closest('.qti-item').hasClass('prevent-click-handler')) {
+                    isDragAndDropEnabled = false;
                     return;
+                } else {
+                    if (self.getOption && self.getOption("enableDragAndDrop") && self.getOption("enableDragAndDrop").associate) {
+                        isDragAndDropEnabled = self.getOption("enableDragAndDrop").associate;
+                    }
                 }
 
                 _resetSelection();
@@ -394,7 +399,12 @@ define([
 
                 //if tts component is loaded and click-to-speak function is activated - we should prevent this listener to go further
                 if ($target.closest('.qti-item').hasClass('prevent-click-handler')) {
+                    isDragAndDropEnabled = false;
                     return;
+                } else {
+                    if (self.getOption && self.getOption("enableDragAndDrop") && self.getOption("enableDragAndDrop").associate) {
+                        isDragAndDropEnabled = self.getOption("enableDragAndDrop").associate;
+                    }
                 }
 
                 e.stopPropagation();
@@ -407,7 +417,12 @@ define([
 
                 //if tts component is loaded and click-to-speak function is activated - we should prevent this listener to go further
                 if ($target.closest('.qti-item').hasClass('prevent-click-handler')) {
+                    isDragAndDropEnabled = false;
                     return;
+                } else {
+                    if (self.getOption && self.getOption("enableDragAndDrop") && self.getOption("enableDragAndDrop").associate) {
+                        isDragAndDropEnabled = self.getOption("enableDragAndDrop").associate;
+                    }
                 }
 
                 e.stopPropagation();
@@ -418,7 +433,12 @@ define([
             interact(binSelector).on('tap', function (e) {
                 //if tts component is loaded and click-to-speak function is activated - we should prevent this listener to go further
                 if ($(e.currentTarget).closest('.qti-item').hasClass('prevent-click-handler')) {
+                    isDragAndDropEnabled = false;
                     return;
+                } else {
+                    if (self.getOption && self.getOption("enableDragAndDrop") && self.getOption("enableDragAndDrop").associate) {
+                        isDragAndDropEnabled = self.getOption("enableDragAndDrop").associate;
+                    }
                 }
 
                 e.stopPropagation();


### PR DESCRIPTION
Fix for bug with click-to-speak and associate interactions (drag&drop was enabled but not released on clicking at answer when click-to-speak was activated)