### PR TITLE
Fix/tao 6044 keep media playing state

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '13.3.1',
+    'version'     => '13.3.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -536,6 +536,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('13.1.0');
         }
 
-        $this->skip('13.1.0', '13.3.1');
+        $this->skip('13.1.0', '13.3.2');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -283,18 +283,15 @@ define([
         var restorePlayerState = function restorePlayerState(playerState){
             if(playerState && interaction.mediaElement){
 
-                //Muted state
-                if(typeof playerState.muted !== 'undefined'){
-                    if(playerState.muted === true){
-                        interaction.mediaElement.mute();
-                    } else {
-                        interaction.mediaElement.unmute();
-                    }
-                }
-
                 //Volume
                 if(_.isNumber(playerState.volume)){
                     interaction.mediaElement.setVolume(playerState.volume);
+                }
+
+                //Muted state (always after the volume)
+                if(_.isBoolean(playerState.muted)){
+                    interaction.mediaElement.mute(playerState.muted);
+                    interaction.mediaElement.startMuted = playerState.muted;
                 }
 
                 //Position
@@ -314,14 +311,15 @@ define([
             }
 
             if (_.isPlainObject(state.player) && interaction.mediaElement) {
-                if(interaction.mediaElement.is('ready')){
-                    restorePlayerState(state.player);
-                } else {
+                //if(interaction.mediaElement.is('ready')){
+                    //restorePlayerState(state.player);
+                //} else {
                     interaction.mediaElement.on('ready.state', function(){
                         interaction.mediaElement.off('ready.state');
                         restorePlayerState(state.player);
+                        console.log('READY CALLED');
                     });
-                }
+                //}
             }
         }
     };

--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -13,12 +13,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2018 (original work) Open Assessment Technlogies SA
  *
  */
 
 /**
- * @author Martin for OAT S.A. <code@taotesting.com>
+ * Common renderer for the QTI media interaction.
+ *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
@@ -128,6 +129,9 @@ define([
                             this.disable();
                         }
                     })
+                    .on('update', _.throttle(function(){
+                        containerHelper.triggerResponseChangeEvent(interaction);
+                    }, 1000))
                     .on('ended', function() {
                         $container.data('timesPlayed', $container.data('timesPlayed') + 1);
                         containerHelper.triggerResponseChangeEvent(interaction);
@@ -267,10 +271,57 @@ define([
      * @param {Object} state - the interaction state
      */
     var setState  = function setState(interaction, state){
+
+        /**
+         * Restore the media player state
+         * @private
+         * @param {Object} [state]
+         * @param {Boolean} [state.muted] - is the player muted
+         * @param {Number} [state.volume] - the current volume
+         * @param {Number} [state.position] - the position to seek to
+         */
+        var restorePlayerState = function restorePlayerState(playerState){
+            if(playerState && interaction.mediaElement){
+
+                //Muted state
+                if(typeof playerState.muted !== 'undefined'){
+                    if(playerState.muted === true){
+                        interaction.mediaElement.mute();
+                    } else {
+                        interaction.mediaElement.unmute();
+                    }
+                }
+
+                //Volume
+                if(_.isNumber(playerState.volume)){
+                    interaction.mediaElement.setVolume(playerState.volume);
+                }
+
+                //Position
+                if(playerState.position && playerState.position > 0){
+                    interaction.mediaElement.seek(playerState.position);
+                    if(!interaction.attr('autostart')){
+                        interaction.mediaElement.pause();
+                    }
+                }
+            }
+        };
+
         if(_.isObject(state)){
             if(state.response){
                 interaction.resetResponse();
                 interaction.setResponse(state.response);
+            }
+
+            if (_.isPlainObject(state.player) && interaction.mediaElement) {
+                if(interaction.mediaElement.is('ready')){
+                    restorePlayerState(state.player);
+                } else {
+                    interaction.mediaElement.on('ready.state', function(){
+                        interaction.mediaElement.off('ready.state');
+                        restorePlayerState(state.player);
+                    });
+                }
             }
         }
     };
@@ -287,6 +338,15 @@ define([
 
         if(response){
             state.response = response;
+        }
+
+        //collect player's state
+        if(interaction.mediaElement) {
+            state.player = {
+                position : interaction.mediaElement.getPosition(),
+                muted    : interaction.mediaElement.is('muted'),
+                volume   : interaction.mediaElement.getVolume()
+            };
         }
         return state;
     };

--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -311,15 +311,14 @@ define([
             }
 
             if (_.isPlainObject(state.player) && interaction.mediaElement) {
-                //if(interaction.mediaElement.is('ready')){
-                    //restorePlayerState(state.player);
-                //} else {
+                if(interaction.mediaElement.is('ready')){
+                    restorePlayerState(state.player);
+                } else {
                     interaction.mediaElement.on('ready.state', function(){
                         interaction.mediaElement.off('ready.state');
                         restorePlayerState(state.player);
-                        console.log('READY CALLED');
                     });
-                //}
+                }
             }
         }
     };

--- a/views/js/test/qtiCommonRenderer/interactions/media/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/media/test.js
@@ -70,7 +70,7 @@ define([
     QUnit.asyncTest('audio renders correctly', function(assert){
         var $container;
 
-        QUnit.expect(14);
+        QUnit.expect(15);
 
         $container = $('#' + fixtureContainerId);
 
@@ -97,10 +97,139 @@ define([
                 assert.equal($container.find('.qti-mediaInteraction audio source').length, 1, 'the interaction contains an audio source tag');
                 assert.equal($container.find('.qti-mediaInteraction audio source').attr('src'), audioSampleUrl, 'the interaction has proper file attached');
                 assert.equal($container.find('.qti-mediaInteraction audio source').attr('type'), 'audio/mpeg', 'the interaction has proper file type');
+                assert.equal($container.find('.qti-mediaInteraction .control [data-control=play]').length, 1, 'the interaction has a play button');
 
                 //check DOM data
                 assert.equal($container.children('.qti-item').data('identifier'), 'i1429259831305858', 'the .qti-item node has the right identifier');
 
+                QUnit.start();
+            })
+            .assets(function(url){
+                if(/\.mp3$/.test(url.toString())){
+                    return audioSampleUrl;
+                }
+                return url.toString();
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.asyncTest('get state', function(assert){
+        var $container;
+
+        QUnit.expect(5);
+
+        $container = $('#' + fixtureContainerId);
+
+        assert.equal($container.find('.qti-mediaInteraction').length, 0, 'The media interaction is not yet rendered');
+
+        runner = qtiItemRunner('qti', audioItemData)
+            .on('init', function(){
+                var state = this.getState();
+
+                assert.deepEqual(state, {
+                    "RESPONSE": {
+                        response: {
+                            base: {
+                                integer: 0
+                            }
+                        },
+                        player: {
+                            position: 0,
+                            muted: false,
+                            volume: 100
+                        }
+                    }
+                }, 'The default state is correct');
+            })
+            .on('render', function(){
+                var self = this;
+                var $mediaInteraction = $container.find('.qti-mediaInteraction');
+                var $play = $('.control [data-control=play]', $mediaInteraction);
+
+                assert.equal($mediaInteraction.length, 1, 'The mediaInteraction is rendered');
+                assert.equal($play.length, 1, 'The play button is rendered');
+
+                setTimeout(function(){
+                    //the media player doesnt work properly in PhantomJS,
+                    //so we just skip the test :
+                    if($('.mediaplayer', $mediaInteraction).hasClass('error')){
+                        assert.ok(true, 'Skipping');
+                        QUnit.start();
+                    } else {
+                        $play.click();
+                    }
+                }, 250);
+
+                setTimeout(function(){
+                    var state = self.getState();
+                    assert.ok(state.RESPONSE.player.position > 0, 'The player position has changed');
+
+                    QUnit.start();
+                }, 1000);
+            })
+            .on('error', function(err){
+                assert.ok(false, err);
+                QUnit.start();
+            })
+            .assets(function(url){
+                if(/\.mp3$/.test(url.toString())){
+                    return audioSampleUrl;
+                }
+                return url.toString();
+            })
+            .init()
+            .render($container);
+    });
+
+
+    QUnit.asyncTest('set state', function(assert){
+        var $container;
+
+        QUnit.expect(3);
+
+        $container = $('#' + fixtureContainerId);
+
+        assert.equal($container.find('.qti-mediaInteraction').length, 0, 'The media interaction is not yet rendered');
+
+        runner = qtiItemRunner('qti', audioItemData)
+            .on('init', function(){
+                var state = this.setState({
+                    "RESPONSE": {
+                        response: {
+                            base: {
+                                integer: 0
+                            }
+                        },
+                        player: {
+                            position: 1.1,
+                            muted: false,
+                            volume: 90
+                        }
+                    }
+                });
+            })
+            .on('render', function(){
+                var self = this;
+                var $mediaInteraction = $container.find('.qti-mediaInteraction');
+                assert.equal($mediaInteraction.length, 1, 'The mediaInteraction is rendered');
+
+                setTimeout(function(){
+                    var state = self.getState();
+
+                    //the media player doesnt work properly in PhantomJS,
+                    //so we just skip the test :
+                    if($('.mediaplayer', $mediaInteraction).hasClass('error')){
+                        assert.ok(true, 'Skipping');
+                        QUnit.start();
+                    } else {
+                        assert.ok(state.RESPONSE.player.position > 0, 'The player position has changed');
+                        QUnit.start();
+                    }
+                }, 250);
+            })
+            .on('error', function(err){
+                assert.ok(false, err);
                 QUnit.start();
             })
             .assets(function(url){


### PR DESCRIPTION
This PR save and restore the media player state within the media interaction. The following values are saved : 
 - the position within the media, 
 - the volume
 - the mute status

Regarding the unit tests the mediaplayer isn't working on PhantomJS so the unit tests falls back in that case (as the mediaplayer unit test does...), but I've kept the test to at least run them in browsers.

To test that particular PR (alone), create a test with non linear test part that contains items with media interactions. Then navigate and play the medias.  
Without the PR the media restarts at it's beginning but with the PR the media restart where you left it.

Please note this PR brings only the state management.