### PR TITLE
Fix/tao 6072 order interaction cardinality

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '13.5.0',
+    'version'     => '13.5.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -543,7 +543,7 @@ class Updater extends \common_ext_ExtensionUpdater
             AclProxy::applyRule(new AccessRule('grant', TaoRoles::REST_PUBLISHER, array('ext'=>'taoQtiItem', 'mod' => 'RestQtiItem')));
             $this->setVersion('13.4.0');
         }
-      
-        $this->skip('13.4.0', '13.5.0');
+
+        $this->skip('13.4.0', '13.5.1');
     }
 }

--- a/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
@@ -32,9 +32,10 @@ define([
 
     var OrderInteractionStateQuestion = stateFactory.extend(Question);
 
-    OrderInteractionStateQuestion.prototype.initForm = function(updateCardinality){
+    OrderInteractionStateQuestion.prototype.initForm = function(){
 
-        var _widget = this.widget,
+        var  callbacks,
+            _widget = this.widget,
             $form = _widget.$form,
             interaction = _widget.element,
             $choiceArea = _widget.$container.find('.choice-area');
@@ -51,7 +52,7 @@ define([
         formElement.initWidget($form);
 
         //data change callbacks with the usual min/maxChoices
-        var callbacks = formElement.getMinMaxAttributeCallbacks(this.widget.$form, 'minChoices', 'maxChoices', {updateCardinality:updateCardinality});
+        callbacks = formElement.getMinMaxAttributeCallbacks(this.widget.$form, 'minChoices', 'maxChoices', {updateCardinality:false});
 
         //data change for shuffle
         callbacks.shuffle = formElement.getAttributeChangeCallback();
@@ -69,22 +70,6 @@ define([
         formElement.setChangeCallbacks($form, interaction, callbacks);
 
         interactionFormElement.syncMaxChoices(_widget);
-
-        //modify the checkbox/radio input appearances
-        _widget.on('attributeChange', function(data){
-
-            var $checkboxIcons = _widget.$container.find('.real-label > span');
-
-            if(data.element.serial === interaction.serial && data.key === 'maxChoices'){
-                if(parseInt(data.value) === 1){
-                    //radio
-                    $checkboxIcons.removeClass('icon-checkbox').addClass('icon-radio');
-                }else{
-                    //checkbox
-                    $checkboxIcons.removeClass('icon-radio').addClass('icon-checkbox');
-                }
-            }
-        });
 
         //adapt size
         if(_widget.element.attr('orientation') === 'horizontal') {


### PR DESCRIPTION
Per QTI standard: http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10283
> The orderInteraction must be bound to a response variable with a baseType of identifier and **ordered** cardinality only.

This bug has been introduced by https://github.com/oat-sa/extension-tao-itemqti/commit/e4a094cf1103b40a262bc676308480035ff2146d
This PR just restores the proper usage of the option `updateCardinality ` to ensure that the cardinality of order interaction is always `ordered`. This PR also removes some other useless radio button / checkbox styling code, that is there due to bad copy/paste.

Side note: the graphic order interaction is not suffering from the same bug as it is using this option properly.