### PR TITLE
Fix/tao 6073 extended text empty response

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '13.5.0',
+    'version'     => '13.5.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/model/qti/templates/qti.responseDeclaration.tpl.php
+++ b/model/qti/templates/qti.responseDeclaration.tpl.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  *
  */

--- a/model/qti/templates/qti.responseDeclaration.tpl.php
+++ b/model/qti/templates/qti.responseDeclaration.tpl.php
@@ -4,19 +4,19 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *               
- * 
+ *
+ * Copyright (c) 2013-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
  */
 $correctResponses = get_data('correctResponses');
 $defaultValues = get_data('defaultValue');
@@ -28,20 +28,14 @@ $areaMapping = get_data('areaMapping');
     <?php if(is_array($defaultValues) && count($defaultValues) > 0):?>
 	<defaultValue>
 	    <?php foreach($defaultValues as $value):?>
-	        <?php /** @var oat\taoQtiItem\model\qti\Value $value*/ ?>
-	        <?php if ($value->getValue() !== ''): ?>
 	        <value<?php foreach($value->getAttributeValues() as $attrName => $attrValue):?> <?=$attrName?>="<?=$attrValue?>"<?php endforeach;?>><![CDATA[<?= $value ?>]]></value>
-	        <?php endif; ?>
 	    <?php endforeach?>
 	</defaultValue>
     <?php endif?>
     <?php if(is_array($correctResponses) && count($correctResponses) > 0):?>
 	<correctResponse>
 	    <?php foreach($correctResponses as $value):?>
-	        <?php /** @var oat\taoQtiItem\model\qti\Value $value*/ ?>
-	        <?php if ($value->getValue() !== ''): ?>
 	        <value<?php foreach($value->getAttributeValues() as $attrName => $attrValue):?> <?=$attrName?>="<?=$attrValue?>"<?php endforeach;?>><![CDATA[<?= $value ?>]]></value>
-	        <?php endif; ?>
 	    <?php endforeach?>
 	</correctResponse>
     <?php endif?>

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -543,7 +543,7 @@ class Updater extends \common_ext_ExtensionUpdater
             AclProxy::applyRule(new AccessRule('grant', TaoRoles::REST_PUBLISHER, array('ext'=>'taoQtiItem', 'mod' => 'RestQtiItem')));
             $this->setVersion('13.4.0');
         }
-      
-        $this->skip('13.4.0', '13.5.0');
+
+        $this->skip('13.4.0', '13.5.1');
     }
 }

--- a/test/model/qti/ResponseDeclarationTest.php
+++ b/test/model/qti/ResponseDeclarationTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoQtiItem\test\model\qti\asset;
+
+use oat\tao\test\TaoPhpUnitTestRunner;
+use oat\taoQtiItem\model\qti\ResponseDeclaration;
+use oat\taoQtiItem\model\qti\Value;
+use oat\taoQtiItem\model\qti\Parser;
+
+class ResponseDeclarationTest extends TaoPhpUnitTestRunner
+{
+
+    public function testToQti(){
+        $responseDeclaration = new ResponseDeclaration([
+            'identifier' => 'RESPONSE',
+            'cardinality' => 'single',
+        ]);
+        $correctValue = new Value();
+        $correctValue->setValue('');
+        $responseDeclaration->setCorrectResponses([
+            $correctValue
+        ]);
+
+        $this->assertXmlStringEqualsXmlString('<responseDeclaration  identifier="RESPONSE" cardinality="single">
+        	<correctResponse>
+	    	        <value><![CDATA[]]></value>
+	    	</correctResponse>
+            </responseDeclaration>', $responseDeclaration->toQti());
+    }
+
+    public function testXmlParsingAndSerialization(){
+        $file = dirname(__FILE__).'/samples/xml/responseDeclarationTest.xml';
+
+        $qtiParser = new Parser($file);
+        $item = $qtiParser->load();
+
+        $this->assertXmlStringEqualsXmlString($this->normalizeXml(file_get_contents($file)), $this->normalizeXml($item->toXML()));
+    }
+
+    /**
+     * Normalize the xml string for comparison
+     * @param $xml
+     * @return string
+     */
+    protected function normalizeXml($xml)
+    {
+        $xml = preg_replace('/toolVersion="[0-9a-zA-Z-\.]+"/', '', $xml);
+
+        //work around DOMNode C14N error : "Relative namespace UR is invalid here"
+        $xml = str_replace('xmlns:html5="html5"', 'xmlns:html5="http://www.imsglobal.org/xsd/html5"', $xml);
+
+        //replace media url by a fixed uri
+        $xml = preg_replace('/taomedia:\/\/mediamanager\/([a-zA-Z0-9_]+)/', 'taomedia://mediamanager/ASSET_URI', $xml);
+
+        return $xml;
+    }
+}

--- a/test/model/qti/ResponseDeclarationTest.php
+++ b/test/model/qti/ResponseDeclarationTest.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
  *
  */
 
@@ -25,9 +25,14 @@ use oat\taoQtiItem\model\qti\ResponseDeclaration;
 use oat\taoQtiItem\model\qti\Value;
 use oat\taoQtiItem\model\qti\Parser;
 
+/**
+ * Test Response Declaration Object
+ */
 class ResponseDeclarationTest extends TaoPhpUnitTestRunner
 {
-
+    /**
+     * Test that model to QTI serialization is correct
+     */
     public function testToQti(){
         $responseDeclaration = new ResponseDeclaration([
             'identifier' => 'RESPONSE',
@@ -46,6 +51,9 @@ class ResponseDeclarationTest extends TaoPhpUnitTestRunner
             </responseDeclaration>', $responseDeclaration->toQti());
     }
 
+    /**
+     * Test that the parsing and serialization leave the xml unchanged
+     */
     public function testXmlParsingAndSerialization(){
         $file = dirname(__FILE__).'/samples/xml/responseDeclarationTest.xml';
 
@@ -57,7 +65,7 @@ class ResponseDeclarationTest extends TaoPhpUnitTestRunner
 
     /**
      * Normalize the xml string for comparison
-     * @param $xml
+     * @param string $xml
      * @return string
      */
     protected function normalizeXml($xml)

--- a/test/model/qti/samples/xml/responseDeclarationTest.xml
+++ b/test/model/qti/samples/xml/responseDeclarationTest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd" identifier="i15215613459567145" title="Item 15" label="Item 15" xml:lang="en-US" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="3.3.0-sprint72-½">
+    <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="string">
+        <correctResponse>
+            <value><![CDATA[]]></value>
+        </correctResponse>
+    </responseDeclaration>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <stylesheet href="style/custom/tao-user-styles.css" type="text/css" media="all" title=""/>
+    <itemBody>
+        <div class="grid-row">
+            <div class="col-12">
+                <extendedTextInteraction responseIdentifier="RESPONSE" base="10" minStrings="0" format="plain">
+    </extendedTextInteraction>
+            </div>
+        </div>
+    </itemBody>
+    <responseProcessing template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/>
+</assessmentItem>


### PR DESCRIPTION
Fix TAO-6073: the QTI model should not reinterpret the values. If it has been set as empty in the model or from the source xml, the output xml should be the same.
So this fix consist in removing this value interpretation: empty value in correct response declaration is no longer removed.
The unit test has been added to ensure that input xml = output xml.