### PR TITLE
Tao 6133 missed item resources

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '13.7.2',
+    'version'     => '13.7.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/model/QtiItemCompiler.php
+++ b/model/QtiItemCompiler.php
@@ -237,8 +237,8 @@ class QtiItemCompiler extends taoItems_models_classes_ItemCompiler implements Se
 
                 /** @var QtiItemCompilerAssetBlacklist $blacklistService */
                 $blacklistService = $this->getServiceLocator()->get(QtiItemCompilerAssetBlacklist::SERVICE_ID);
-                if($blacklistService->isBlacklisted($assetUrl)){
-                    continue(2);
+                if ($blacklistService->isBlacklisted($assetUrl)) {
+                    continue;
                 }
 
                 $mediaAsset = $resolver->resolve($assetUrl);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -544,6 +544,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('13.4.0');
         }
 
-        $this->skip('13.4.0', '13.7.2');
+        $this->skip('13.4.0', '13.7.3');
     }
 }


### PR DESCRIPTION
The point is that assets are grouped by type (css, img ...) and if one of assets in group is blacklisted (for example it's base64 image) all the group will be skipped:
![image](https://user-images.githubusercontent.com/11025793/38018522-c656e22a-327d-11e8-80f2-1e7c169e7172.png)

You may find sample test attached to the Jira ticket: https://oat-sa.atlassian.net/browse/TAO-6133