### PR TITLE
Fix/tao 6142/creator image dimensions fix

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '13.8.0',
+    'version'     => '13.8.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -544,6 +544,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('13.4.0');
         }
 
-        $this->skip('13.4.0', '13.8.0');
+        $this->skip('13.4.0', '13.8.1');
     }
 }

--- a/views/js/qtiCreator/widgets/static/img/Widget.js
+++ b/views/js/qtiCreator/widgets/static/img/Widget.js
@@ -66,8 +66,26 @@ define([
             height: this.element.attr('height')
         });
         if (this.$original[0]) {
-            this.$original[0].setAttribute('width', '100%');
-            this.$original[0].setAttribute('height', '100%');
+
+            //previously it looked like
+            //this.$original[0].setAttribute('width', '100%');
+            //this.$original[0].setAttribute('height', '100%');
+            //it was changed to that state to fix the problem
+            //when we have images inside item look like 100% width,
+            //and no matter was it changed to lower value or not
+
+            var width = this.$original[0].getAttribute('width');
+            if (typeof width === typeof undefined || width.indexOf('%') === -1) {
+                width = '100%';
+            }
+
+            var height = this.$original[0].getAttribute('width');
+            if (typeof height === typeof undefined || height.indexOf('%') === -1) {
+                height = '100%';
+            }
+
+            this.$original[0].setAttribute('width', width);
+            this.$original[0].setAttribute('height', height);
         }
 
         return this;

--- a/views/js/qtiCreator/widgets/static/img/Widget.js
+++ b/views/js/qtiCreator/widgets/static/img/Widget.js
@@ -75,12 +75,12 @@ define([
             //and no matter was it changed to lower value or not
 
             var width = this.$original[0].getAttribute('width');
-            if (typeof width === typeof undefined || width.indexOf('%') === -1) {
+            if (isNaN(width) && width.indexOf('%') === -1) {
                 width = '100%';
             }
 
             var height = this.$original[0].getAttribute('width');
-            if (typeof height === typeof undefined || height.indexOf('%') === -1) {
+            if (isNaN(height) && height.indexOf('%') === -1) {
                 height = '100%';
             }
 


### PR DESCRIPTION
Images width in creator is now looks like it should be - if image width is set to 10% it will look like 10% of width - not like previously when 10% images looked like 100% of width.