### PR TITLE
Fix/tao 5701 broken state match interaction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '15.3.1',
+    'version'     => '15.3.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=4.2.4',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -544,6 +544,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('15.3.0');
         }
 
-        $this->skip('15.3.0', '15.3.1');
+        $this->skip('15.3.0', '15.3.2');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/MatchInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MatchInteraction.js
@@ -75,15 +75,15 @@ define([
      * @param {object} response
      */
     var setResponse = function(interaction, response){
-
+        var $container = containerHelper.get(interaction);
         response = _filterResponse(response);
 
         if(typeof response.list !== 'undefined' && typeof response.list.directedPair !== 'undefined'){
             _(response.list.directedPair).forEach(function(directedPair){
-                var x = $('th[data-identifier=' + directedPair[0] + ']').index() - 1;
-                var y = $('th[data-identifier=' + directedPair[1] + ']').parent().index();
+                var x = $('th[data-identifier=' + directedPair[0] + ']', $container).index() - 1;
+                var y = $('th[data-identifier=' + directedPair[1] + ']', $container).parent().index();
 
-                $('.matrix > tbody tr').eq(y).find('input[type=checkbox]').eq(x).attr('checked', true);
+                $('.matrix > tbody tr', $container).eq(y).find('input[type=checkbox]').eq(x).attr('checked', true);
             });
         }
 
@@ -160,10 +160,11 @@ define([
 
     var _inferValue = function(element){
         var $element = $(element);
+        var $container = $element.closest('.match-interaction-area');
         var y = $element.closest('tr').index();
         var x = $element.closest('td').index();
-        var firstId = $('.matrix > thead th').eq(x).data('identifier');
-        var secondId = $('.matrix > tbody th').eq(y).data('identifier');
+        var firstId = $('.matrix > thead th', $container).eq(x).data('identifier');
+        var secondId = $('.matrix > tbody th', $container).eq(y).data('identifier');
         return [firstId, secondId];
     };
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5701

Fix a state restore issue on `matchInteraction`. This issue occurs when the interaction is rendered aside other content that contains a data table.

Was due to a misconception in the DOM access (global queries).