### PR TITLE
Feature/tao 7045 mediainteraction ready

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '17.1.0',
+    'version'     => '17.2.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=5.13.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -390,6 +390,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('16.0.0');
         }
 
-        $this->skip('16.0.0', '17.1.0');
+        $this->skip('16.0.0', '17.2.0');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -116,8 +116,6 @@ define([
 
                         $item.off('resize.gridEdit')
                             .on('resize.gridEdit', resize);
-
-                        resolve();
                     })
                     .on('ready', function() {
                        /**
@@ -128,6 +126,9 @@ define([
                         if (!canBePlayed() ) {
                             this.disable();
                         }
+
+                        // declare the item ready when player is ready to play.
+                        resolve();
                     })
                     .on('update', _.throttle(function(){
                         containerHelper.triggerResponseChangeEvent(interaction);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-7045

Simply reworks the ready state of the interaction, resolving the promise on the `ready` event instead of the `render` only. Regression testing is made by QA (QI-49).