### PR TITLE
Feature/tao 6458 add uri to compiled metadata

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '18.2.1',
+    'version'     => '18.3.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.0.0',

--- a/model/QtiJsonItemCompiler.php
+++ b/model/QtiJsonItemCompiler.php
@@ -140,6 +140,7 @@ class QtiJsonItemCompiler extends QtiItemCompiler
     }
 
     /**
+     * Get the item properties as compiled metadata
      * @return array
      */
     private function getMetadataProperties()
@@ -149,6 +150,8 @@ class QtiJsonItemCompiler extends QtiItemCompiler
         foreach ($triples as $triple){
             $properties[$triple->predicate] = $triple->object;
         }
+        //we also include a shortcut to the item URI
+        $properties['@uri'] = $this->getResource()->getUri();
         return $properties;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -390,6 +390,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('16.0.0');
         }
 
-        $this->skip('16.0.0', '18.2.1');
+        $this->skip('16.0.0', '18.3.0');
     }
 }


### PR DESCRIPTION
 Add a shortcut to the item URI into the compiled metadata in order to have it in static deliveries and the mobile app.

How to test this PR : 
 - compile a delivery and check the content of the created `metadataElements.json` files contains the item URI