### PR TITLE
Feature/tao 6458 scorer get qti variables

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,10 +33,10 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '18.4.0',
+    'version'     => '18.5.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
-        'taoItems' => '>=6.0.0',
+        'taoItems' => '>=6.3.0',
         'tao'      => '>=21.0.0',
         'generis'  => '>=7.3.0',
     ),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -390,6 +390,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('16.0.0');
         }
 
-        $this->skip('16.0.0', '18.4.0');
+        $this->skip('16.0.0', '18.5.0');
     }
 }

--- a/views/js/scoring/provider/qti.js
+++ b/views/js/scoring/provider/qti.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2015-2018 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -54,7 +54,7 @@ define([
 
         var state = {};
 
-          //load responses variables
+        //load responses variables
         _.forEach(itemData.responses, function(response){
             var responseValue;
             var identifier      = response.attributes.identifier;
@@ -116,7 +116,7 @@ define([
                         outcomeVariable.value = 0;
                     }
                 } else {
-                   outcomeVariable.value = outcomeVariable.defaultValue;
+                    outcomeVariable.value = outcomeVariable.defaultValue;
                 }
             }
 
@@ -181,11 +181,12 @@ define([
      */
     var pciRecordToVariable = function pciRecordToVariable(record){
         var variableObject = {};
-        _.each(record, function(value){
+        _.forEach(record, function(value){
+            var ret = {};
+            var valueObject;
             if(value) {
 
-                var valueObject = value.base || value.list || null;
-                var ret = {};
+                valueObject = value.base || value.list || null;
 
                 if (valueObject) {
                     _.forOwn(valueObject, function (actualValue, baseType) {
@@ -203,7 +204,7 @@ define([
             }
         });
         return variableObject;
-    }
+    };
 
     /**
      * Reformat the mapping/areaMapping from a flat list to a structured object to anticipate changes in the serializer.
@@ -315,12 +316,12 @@ define([
 
                     //run the engine...
                     ruleEngine.execute(itemData.responseProcessing.responseRules);
-                    done(stateToPci(state));
+                    done(stateToPci(state), state);
                 });
 
             } else {
                 errorHandler.throw('scoring', new Error('The item ' + itemData.identifier + ' has not responseProcessing'));
-                done(stateToPci(state));
+                done(stateToPci(state), state);
             }
 
         }

--- a/views/js/scoring/provider/qti.js
+++ b/views/js/scoring/provider/qti.js
@@ -76,7 +76,7 @@ define([
             };
 
             //support both old an new mapping format
-            if(response.mapping && response.mapping.qtiClass === 'mapping' || response.mapping.qtiClass === 'areaMapping'){
+            if(response.mapping && (response.mapping.qtiClass === 'mapping' || response.mapping.qtiClass === 'areaMapping')){
                 state[identifier].mapping = response.mapping;
             } else {
                 state[identifier].mapping = reFormatMapping(response);

--- a/views/js/test/scoring/provider/test.js
+++ b/views/js/test/scoring/provider/test.js
@@ -1,3 +1,21 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015-2018 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ *
+ */
 define([
     'lodash',
     'taoItems/scoring/api/scorer',
@@ -16,19 +34,19 @@ define([
     'json!taoQtiItem/test/samples/json/customrp/andAnd.json',
     'json!taoQtiItem/test/samples/json/customrp/custom_record.json'
 ], function(_, scorer, qtiScoringProvider,
-            singleCorrectData,
-            multipleCorrectData,
-            multipleMapData,
-            singleMapPointData,
-            customChoiceMultipleData,
-            customTextEntryNumericData,
-            customChoiceMultipleData2,
-            customChoiceSingleData,
-            orderData,
-            multipleResponseCorrectData,
-            embedConditionsData,
-            andAndData,
-            customRecordData
+    singleCorrectData,
+    multipleCorrectData,
+    multipleMapData,
+    singleMapPointData,
+    customChoiceMultipleData,
+    customTextEntryNumericData,
+    customChoiceMultipleData2,
+    customChoiceSingleData,
+    orderData,
+    multipleResponseCorrectData,
+    embedConditionsData,
+    andAndData,
+    customRecordData
 ){
     'use strict';
 
@@ -69,8 +87,6 @@ define([
     });
 
     QUnit.asyncTest('default outcomes', function(assert){
-        QUnit.expect(5);
-
         var responses =   {
             "RESPONSE": {
                 "base": {
@@ -80,6 +96,9 @@ define([
         };
 
         var noRulesItemData = _.cloneDeep(singleCorrectData);
+
+        QUnit.expect(10);
+
         noRulesItemData.responseProcessing.responseRules = [];
 
         scorer.register('qti', qtiScoringProvider);
@@ -88,7 +107,7 @@ define([
             .on('error', function(err){
                 assert.ok(false, 'Got an error : ' + err);
             })
-            .on('outcome', function(outcomes){
+            .on('outcome', function(outcomes, state){
 
                 assert.ok(typeof outcomes === 'object', "the outcomes are an object");
                 assert.ok(typeof outcomes.RESPONSE === 'object', "the outcomes contains the response");
@@ -96,15 +115,34 @@ define([
                 assert.ok(typeof outcomes.SCORE === 'object', "the outcomes contains the score");
                 assert.deepEqual(outcomes.SCORE, { base : { integer : 0 } }, "the score has the default value");
 
+                assert.ok(typeof state === 'object', "the state is an object");
+                assert.ok(typeof state.RESPONSE === 'object', "the state contains the RESPONSE variable");
+                assert.deepEqual(state.RESPONSE, {
+                    cardinality: "single",
+                    baseType: "identifier",
+                    correctResponse: ["Atlantis"],
+                    defaultValue: undefined,
+                    mapping: undefined,
+                    value: "Discovery"
+                }, "the RESPONSE variable matches");
+                assert.ok(typeof state.SCORE === 'object', "the state contains the SCORE variable");
+                assert.deepEqual(state.SCORE, {
+                    cardinality: "single",
+                    baseType: "integer",
+                    defaultValue: "0",
+                    value: 0
+                }, "the SCORE variable matches");
+
                 QUnit.start();
             })
             .process(responses, noRulesItemData);
     });
 
     QUnit.asyncTest('No responseProcessing', function(assert){
+        var noRPItemData = _.cloneDeep(singleCorrectData);
+
         QUnit.expect(3);
 
-        var noRPItemData = _.cloneDeep(singleCorrectData);
         assert.equal(noRPItemData.identifier, 'space-shuttle-30-years-of-adventure', 'The item has the expected identifier');
         delete noRPItemData.responseProcessing;
 
@@ -187,7 +225,7 @@ define([
                 .on('error', function(err){
                     assert.ok(false, 'Got an error : ' + err);
                 })
-                .on('outcome', function(outcomes){
+                .on('outcome', function(outcomes, state){
 
                     assert.ok(typeof outcomes === 'object', "the outcomes are an object");
                     assert.ok(typeof outcomes.RESPONSE === 'object', "the outcomes contains the response");

--- a/views/js/test/scoring/provider/test.js
+++ b/views/js/test/scoring/provider/test.js
@@ -160,83 +160,163 @@ define([
     QUnit.module('Provider process correct template', {
         teardown : function(){
             //reset the provides
-            scorer.providers = undefined;
+            delete scorer.providers;
         }
     });
 
-    var tplDataProvider = [{
+
+    QUnit.cases([{
         title   : 'match correct single identifier',
         item    : singleCorrectData,
-        resp    : { base : { identifier: "Atlantis" } },
-        score   : { base : { integer : 1 } }
+        outcomes : {
+            RESPONSE : { base : { identifier: "Atlantis" } },
+            SCORE    : { base : { integer : 1 } },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "single",
+                "baseType": "identifier",
+                "value": "Atlantis"
+            },
+            SCORE: { value: 1 }
+        }
     }, {
         title   : 'match incorrect single identifier',
         item    : singleCorrectData,
-        resp    : { base : { identifier: "Discovery" } },
-        score   : { base : { integer : 0 } }
+        outcomes : {
+            RESPONSE : { base : { identifier: "Discovery" } },
+            SCORE    : { base : { integer : 0 } },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "single",
+                "baseType": "identifier",
+                "value": "Discovery"
+            },
+            SCORE: { value: 0 }
+        }
     }, {
         title   : 'match correct multiple identifier',
         item    : multipleCorrectData,
-        resp    : { list : { identifier: ["Pathfinder", "Atlantis"] } },
-        score   : { base : { integer : 1 } }
+        outcomes : {
+            RESPONSE : { list : { identifier: ["Pathfinder", "Atlantis"]   } },
+            SCORE    : { base : { integer : 1 } },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "multiple",
+                "baseType": "identifier",
+                "value": ["Pathfinder", "Atlantis"]
+            },
+            SCORE: { value: 1 }
+        }
     }, {
         title   : 'match incorrect multiple identifier',
         item    : multipleCorrectData,
-        resp    : { list : { identifier: ["Atlantis", "Discovery"] } },
-        score   : { base : { integer : 0 } }
+        outcomes : {
+            RESPONSE : { list : { identifier:  ["Atlantis", "Discovery"] } },
+            SCORE    : { base : { integer : 0 } },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "multiple",
+                "baseType": "identifier",
+                "value": ["Atlantis", "Discovery"]
+            },
+            SCORE: { value: 0 }
+        }
     }, {
         title   : 'map response multiple directedPair',
         item    : multipleMapData,
-        resp    : { list : { directedPair:  [['C', 'R'], ['D', 'M']] } },
-        score   : { base : { float : 1.5 } }
+        outcomes : {
+            RESPONSE : { list : { directedPair:  [['C', 'R'], ['D', 'M']] } },
+            SCORE    : { base : { float : 1.5 } },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "multiple",
+                "baseType": "directedPair",
+                "value": [ ["C", "R"], ["D", "M"] ]
+            },
+            SCORE: { value: 1.5 }
+        }
     }, {
         title   : 'incorrect map response multiple directedPair',
         item    : multipleMapData,
-        resp    : { list : { directedPair:  [['M', 'D'], ['R', 'M']] } },
-        score   : { base : { float : 0 } }
-    }, {
-        title   : 'incorrect map response multiple directedPair',
-        item    : multipleMapData,
-        resp    : { list : { directedPair:  [['M', 'D'], ['R', 'M']] } },
-        score   : { base : { float : 0 } }
+        outcomes : {
+            RESPONSE : { list : { directedPair:  [['M', 'D'], ['R', 'M']] } },
+            SCORE    : { base : {  float : 0} },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "multiple",
+                "baseType": "directedPair",
+                "value": [['M', 'D'], ['R', 'M']]
+            },
+            SCORE: { value: 0 }
+        }
     }, {
         title   : 'map response  point inside',
         item    : singleMapPointData,
-        resp    : { base : { point:  [102, 113] } },
-        score   : { base : { float : 1 } }
+        outcomes : {
+            RESPONSE : { base : { point:  [102, 113]  } },
+            SCORE    : { base : { float : 1 } },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "single",
+                "baseType": "point",
+                "value": [102, 113]
+            },
+            SCORE: { value: 1 }
+        }
     }, {
         title   : 'map response  point outside',
         item    : singleMapPointData,
-        resp    : { base : { point:  [145, 190] } },
-        score   : { base : { float : 0 } }
-    }];
+        outcomes : {
+            RESPONSE : { base : { point:  [145, 190]  } },
+            SCORE    : { base : { float : 0 } },
+        },
+        state : {
+            RESPONSE: {
+                "cardinality": "single",
+                "baseType": "point",
+                "value": [145, 190]
+            },
+            SCORE: { value: 0 }
+        }
+    }]).asyncTest('process ', function(data, assert){
 
-    QUnit
-        .cases(tplDataProvider)
-        .asyncTest('process ', function(data, assert){
+        QUnit.expect(8);
 
-            var responses = {
-                'RESPONSE' : data.resp
-            };
+        scorer.register('qti', qtiScoringProvider);
 
-            scorer.register('qti', qtiScoringProvider);
+        scorer('qti')
+            .on('error', function(err){
+                assert.ok(false, 'Got an error : ' + err);
+            })
+            .on('outcome', function(outcomes, state){
 
-            scorer('qti')
-                .on('error', function(err){
-                    assert.ok(false, 'Got an error : ' + err);
-                })
-                .on('outcome', function(outcomes, state){
+                assert.deepEqual(outcomes, data.outcomes, 'Generated outcomes matche');
 
-                    assert.ok(typeof outcomes === 'object', "the outcomes are an object");
-                    assert.ok(typeof outcomes.RESPONSE === 'object', "the outcomes contains the response");
-                    assert.deepEqual(outcomes.RESPONSE, responses.RESPONSE, "the response is the same");
-                    assert.ok(typeof outcomes.SCORE === 'object', "the outcomes contains the score");
-                    assert.deepEqual(outcomes.SCORE, data.score, "the score has the correct value");
+                assert.ok(typeof state === 'object', 'The generated state is an object');
 
-                    QUnit.start();
-                })
-                .process(responses, data.item);
-        });
+                //check RESPONSE variable cardinality, baseType and value
+                assert.ok(typeof state.RESPONSE === 'object', 'The generated state contains a RESPONSE variable');
+                assert.equal(state.RESPONSE.cardinality, data.state.RESPONSE.cardinality, 'The RESPONSE cardinality is correct');
+                assert.equal(state.RESPONSE.baseType, data.state.RESPONSE.baseType, 'The RESPONSE baseType is correct');
+                assert.deepEqual(state.RESPONSE.value, data.state.RESPONSE.value, 'The RESPONSE value is correct');
+
+                //check only SCORE value
+                assert.ok(typeof state.SCORE === 'object', 'The generated state contains a SCORE variable');
+                assert.equal(state.SCORE.value, data.state.SCORE.value, 'The score matches the expected value');
+
+                QUnit.start();
+            })
+            .process({
+                RESPONSE : data.outcomes.RESPONSE
+            }, data.item);
+    });
 
     QUnit.asyncTest('process multiple responses', function(assert){
 


### PR DESCRIPTION
In the mobile app we use the scoring library to compute the item outcomes. 
By default the outcomes were produced in the PCI format, for example 
```js
{ RESPONSE : {  list : { identifier: ['choice_1', 'choice_2'] } } }
```
But to comply with the Result API we need information like cardinality or baseType, so we expose the state variable with the outcome.
This PR add the current state to the `outcome event`
The unit tests can be used to check the feature.

Requires https://github.com/oat-sa/extension-tao-item/pull/336