### PR TITLE
Act 241 fail item comilation if xinclude missed

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '18.5.2',
+    'version'     => '18.5.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.3.0',

--- a/model/QtiItemCompiler.php
+++ b/model/QtiItemCompiler.php
@@ -299,7 +299,7 @@ class QtiItemCompiler extends taoItems_models_classes_ItemCompiler
 
          //loadxinclude
         $xincludeLoader = new XIncludeLoader($assetRetrievedQtiItem, $resolver);
-        $xincludeLoader->load(true);
+        $xincludeLoader->load(false);
 
         return $assetRetrievedQtiItem;
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -390,6 +390,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('16.0.0');
         }
 
-        $this->skip('16.0.0', '18.5.2');
+        $this->skip('16.0.0', '18.5.3');
     }
 }


### PR DESCRIPTION
Compilation of delivery should be failed in case if asset is missed.
Currently it silently suppresses the error and delivery compiles with corrupted item.