### PR TITLE
The warning message after setting 'Allowed choices' fixed

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '18.7.0',
+    'version'     => '18.7.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -390,6 +390,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('16.0.0');
         }
 
-        $this->skip('16.0.0', '18.7.0');
+        $this->skip('16.0.0', '18.7.1');
     }
 }

--- a/views/js/qtiCommonRenderer/helpers/instructions/instructionManager.js
+++ b/views/js/qtiCommonRenderer/helpers/instructions/instructionManager.js
@@ -182,7 +182,7 @@ define([
             }
 
             if(!minInstructionSet && min > 0 && (choiceCount === false || min < choiceCount)){
-                msg = (min <= 1) ? __('You must at least %d choice', min) : __('You must select at least %d choices', min);
+                if (min <= 1) msg = __('You must select at least %d choices', min);
                 self.appendInstruction(interaction, msg, function(){
                     if(getResponse(interaction).length >= min){
                         this.setLevel('success');

--- a/views/js/qtiCommonRenderer/helpers/instructions/instructionManager.js
+++ b/views/js/qtiCommonRenderer/helpers/instructions/instructionManager.js
@@ -182,7 +182,7 @@ define([
             }
 
             if(!minInstructionSet && min > 0 && (choiceCount === false || min < choiceCount)){
-                msg = __('You must select at least %d choices', min);
+                msg = (min <= 1) ? __('You must select at least %d choice', min) : __('You must select at least %d choices', min);
                 self.appendInstruction(interaction, msg, function(){
                     if(getResponse(interaction).length >= min){
                         this.setLevel('success');

--- a/views/js/qtiCommonRenderer/helpers/instructions/instructionManager.js
+++ b/views/js/qtiCommonRenderer/helpers/instructions/instructionManager.js
@@ -182,7 +182,7 @@ define([
             }
 
             if(!minInstructionSet && min > 0 && (choiceCount === false || min < choiceCount)){
-                if (min <= 1) msg = __('You must select at least %d choices', min);
+                msg = __('You must select at least %d choices', min);
                 self.appendInstruction(interaction, msg, function(){
                     if(getResponse(interaction).length >= min){
                         this.setLevel('success');


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-5073

Steps to reproduce:
1. Log in as admin.
2. Go to the item page, create an item, and go to authoring mode.
3. Add Hotspot Interaction and and choose an image file.
4. Define hotspot areas using the tools on the right. (for example 3 areas).
5. Set '1' for Min and '3' for Max in 'Allowed choices'.
6. Click 'Save'.
7. Click 'Preview'.
Actual result: The interaction is displayed with the message 'You must at least 1 choice'. (please, see attachment)
Expected result: The interaction is displayed with the message 'You must select at least 1 choice'.

The warning message after setting 'Allowed choices' fixed