### PR TITLE
Fix/allow to compile pci from new amd config

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '18.7.2',
+    'version'     => '18.7.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -390,6 +390,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('16.0.0');
         }
 
-        $this->skip('16.0.0', '18.7.2');
+        $this->skip('16.0.0', '18.7.3');
     }
 }

--- a/views/build/grunt/portableelement.js
+++ b/views/build/grunt/portableelement.js
@@ -16,6 +16,8 @@ module.exports = function (grunt) {
     var root = grunt.option('root');
     var requirejs = grunt.option('requirejsModule');
     var ext = require(root + '/tao/views/build/tasks/helpers/extensions')(grunt, root);
+    var amdConfig = require(root + '/tao/views/build/config/requirejs.build.json');
+
     var portableModels = [
         {
             type : 'PCI',
@@ -54,19 +56,19 @@ module.exports = function (grunt) {
                 skipPragmas: true,
                 generateSourceMaps: true,
                 removeCombined: true,
-                baseUrl: '../js',
-                mainConfigFile: './config/requirejs.build.js',
+                baseUrl: amdConfig.baseUrl,
+                shim : amdConfig.shim,
                 excludeShallow: ['mathJax'],
                 exclude: ['qtiCustomInteractionContext', 'qtiInfoControlContext']
                     .concat(ext.getExtensionSources('taoQtiItem', ['views/js/qtiItem/**/*.js', 'views/js/qtiCreator/**/*.js'], true))
                     .concat(ext.getExtensionSources('taoItems', ['views/js/**/*.js'], true)),
-                paths: {
+                paths: Object.assign({
                     'taoItems': root + '/taoItems/views/js',
                     'taoItemsCss': root + '/taoItems/views/css',
                     'taoQtiItem': root + '/taoQtiItem/views/js',
                     'qtiCustomInteractionContext': root + '/taoQtiItem/views/js/runtime/qtiCustomInteractionContext',
                     'qtiInfoControlContext': root + '/taoQtiItem/views/js/runtime/qtiInfoControlContext'
-                }
+                }, amdConfig.paths)
             }
         }
     });


### PR DESCRIPTION
The build AMD configuration was deduplicated and has been moved to `tao/views/js/build/config/requirejs.config.json` (to be included by the bundling and the unit tests)
The `portableelement` task was included the removed file.

How to test : 
```
cd ta/views/build
npx grunt portableelement -e=qtiItemPci
```