### PR TITLE
Fix/tao 7667/tooltips cover one another rollback n n tooltip

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '18.7.9',
+    'version'     => '18.7.10',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -391,6 +391,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('16.0.0');
         }
 
-        $this->skip('16.0.0', '18.7.9');
+        $this->skip('16.0.0', '18.7.10');
     }
 }

--- a/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -36,29 +36,34 @@ define([
     'use strict';
 
     /**
-     * Delete the text input tooltip
+     * Hide the tooltip for the text input
      * @param {jQuery} $input
      */
-    var deleteTooltip = function deleteTooltip($input){
+    var hideTooltip = function hideTooltip($input){
         if ($input.data('$tooltip')){
-            $input.data('$tooltip').dispose();
-            $input.removeData('$tooltip');
+            $input.data('$tooltip').hide();
         }
     };
 
     /**
-     * Prepare the feedback tooltip for the text input
+     * Create/Show tooltip for the text input
      * @param {jQuery} $input
      * @param {String} theme
      * @param {String} message
      */
-    var createTooltip = function createTooltip($input, theme, message){
-        var textEntryTooltip = tooltip.create($input, message, {
-            theme: theme,
-            trigger: 'manual'
-        });
+    var showTooltip = function showTooltip($input, theme, message){
+        if ($input.data('$tooltip')){
+            $input.data('$tooltip').updateTitleContent(message);
+        } else {
+            var textEntryTooltip = tooltip.create($input, message, {
+                theme: theme,
+                trigger: 'manual'
+            });
 
-        $input.data('$tooltip', textEntryTooltip);
+            $input.data('$tooltip', textEntryTooltip);
+        }
+
+        $input.data('$tooltip').show();
     };
 
     /**
@@ -96,8 +101,6 @@ define([
                 var count = $input.val().length;
                 var message, messageType;
 
-                deleteTooltip($input);
-
                 if(count){
                     message = __('%d/%d', count, maxChars);
                 }else{
@@ -112,8 +115,7 @@ define([
                     messageType = 'info';
                 }
 
-                createTooltip($input, messageType , message);
-                $input.data('$tooltip').show();
+                showTooltip($input, messageType , message);
             };
 
             $input
@@ -126,21 +128,20 @@ define([
                     containerHelper.triggerResponseChangeEvent(interaction);
                 })
                 .on('blur.commonRenderer', function(){
-                    deleteTooltip($input);
+                    hideTooltip($input);
                 });
         }else if(attributes.patternMask){
 
             updatePatternMaskTooltip = function updatePatternMaskTooltip() {
                 var regex = new RegExp(attributes.patternMask);
 
-                deleteTooltip($input);
+                hideTooltip($input);
 
                 if ($input.val().length && regex.test($input.val())) {
                     $input.removeClass('invalid');
                 } else {
                     $input.addClass('invalid');
-                    createTooltip($input, 'error', __('This is not a valid answer'));
-                    $input.data('$tooltip').show();
+                    showTooltip($input, 'error', __('This is not a valid answer'));
                 }
             };
 
@@ -153,7 +154,7 @@ define([
                     containerHelper.triggerResponseChangeEvent(interaction);
                 })
                 .on('blur.commonRenderer', function(){
-                    deleteTooltip($input);
+                    hideTooltip($input);
                 });
         }else{
             $input.on('keyup.commonRenderer', function(){
@@ -213,7 +214,7 @@ define([
             attributes = interaction.getAttributes(),
             baseType = interaction.getResponseDeclaration().attr('baseType'),
             numericBase = attributes.base || 10;
-        
+
         if($input.hasClass('invalid') || (attributes.placeholderText && $input.val() === attributes.placeholderText)){
             //invalid response or response equals to the placeholder text are considered empty
             value = '';
@@ -233,6 +234,15 @@ define([
     };
 
     var destroy = function destroy(interaction){
+
+        $("input.qti-interaction.qti-inlineInteraction.qti-textEntryInteraction").each(function(index, el) {
+            var $input = $(el);
+            if ($input.data('$tooltip')){
+                $input.data('$tooltip').dispose();
+                $input.removeData('$tooltip');
+            }
+        });
+
         //remove event
         $(document).off('.commonRenderer');
         containerHelper.get(interaction).off('.commonRenderer');

--- a/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -235,7 +235,7 @@ define([
 
     var destroy = function destroy(interaction){
 
-        $("input.qti-interaction.qti-inlineInteraction.qti-textEntryInteraction").each(function(index, el) {
+        $("input.qti-textEntryInteraction").each(function(index, el) {
             var $input = $(el);
             if ($input.data('$tooltip')){
                 $input.data('$tooltip').dispose();

--- a/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -98,16 +98,21 @@ define([
 
                 deleteTooltip($input);
 
+                if(count){
+                    message = __('%d/%d', count, maxChars);
+                }else{
+                    message = __('%d characters allowed', maxChars);
+                }
+
                 if(count >= maxChars){
                     $input.addClass('maxed');
+                    createTooltip($input, 'warning', message);
                 }else{
                     $input.removeClass('maxed');
 
-                    message = __('%d characters allowed' ,maxChars);
-
                     createTooltip($input, 'info', message);
-                    $input.data('$tooltip').show();
                 }
+                $input.data('$tooltip').show();
             };
 
             $input
@@ -126,13 +131,14 @@ define([
 
             updatePatternMaskTooltip = function updatePatternMaskTooltip() {
                 var regex = new RegExp(attributes.patternMask);
+
+                deleteTooltip($input);
+
                 if ($input.val().length && regex.test($input.val())) {
                     $input.removeClass('invalid');
-                    deleteTooltip($input);
                 } else {
                     $input.addClass('invalid');
-                    deleteTooltip($input);
-                    createTooltip($input, 'error', __('This is not a valid answer.'));
+                    createTooltip($input, 'error', __('This is not a valid answer'));
                     $input.data('$tooltip').show();
                 }
             };

--- a/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -94,7 +94,7 @@ define([
 
             updateMaxCharsTooltip = function updateMaxCharsTooltip(){
                 var count = $input.val().length;
-                var message;
+                var message, messageType;
 
                 deleteTooltip($input);
 
@@ -106,22 +106,23 @@ define([
 
                 if(count >= maxChars){
                     $input.addClass('maxed');
-                    createTooltip($input, 'warning', message);
+                    messageType = 'warning';
                 }else{
                     $input.removeClass('maxed');
-
-                    createTooltip($input, 'info', message);
+                    messageType = 'info';
                 }
+
+                createTooltip($input, messageType , message);
                 $input.data('$tooltip').show();
             };
 
             $input
                 .attr('maxlength', maxChars)
                 .on('focus.commonRenderer', function(){
-                    _.defer(updateMaxCharsTooltip);
+                    updateMaxCharsTooltip();
                 })
                 .on('keyup.commonRenderer', function(){
-                    _.defer(updateMaxCharsTooltip);
+                    updateMaxCharsTooltip();
                     containerHelper.triggerResponseChangeEvent(interaction);
                 })
                 .on('blur.commonRenderer', function(){
@@ -145,10 +146,10 @@ define([
 
             $input
                 .on('focus.commonRenderer', function(){
-                    _.defer(updatePatternMaskTooltip);
+                    updatePatternMaskTooltip();
                 })
                 .on('keyup.commonRenderer', function(){
-                    _.defer(updatePatternMaskTooltip);
+                    updatePatternMaskTooltip();
                     containerHelper.triggerResponseChangeEvent(interaction);
                 })
                 .on('blur.commonRenderer', function(){

--- a/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -118,10 +118,10 @@ define([
             $input
                 .attr('maxlength', maxChars)
                 .on('focus.commonRenderer', function(){
-                    updateMaxCharsTooltip();
+                    _.defer(updateMaxCharsTooltip);
                 })
                 .on('keyup.commonRenderer', function(){
-                    updateMaxCharsTooltip();
+                    _.defer(updateMaxCharsTooltip);
                     containerHelper.triggerResponseChangeEvent(interaction);
                 })
                 .on('blur.commonRenderer', function(){
@@ -145,10 +145,10 @@ define([
 
             $input
                 .on('focus.commonRenderer', function(){
-                    updatePatternMaskTooltip();
+                    _.defer(updatePatternMaskTooltip);
                 })
                 .on('keyup.commonRenderer', function(){
-                    updatePatternMaskTooltip();
+                    _.defer(updatePatternMaskTooltip);
                     containerHelper.triggerResponseChangeEvent(interaction);
                 })
                 .on('blur.commonRenderer', function(){

--- a/views/js/test/qtiCommonRenderer/interactions/textEntry/test.html
+++ b/views/js/test/qtiCommonRenderer/interactions/textEntry/test.html
@@ -24,7 +24,10 @@
 <body>
 <div id="qunit"></div>
 <div id="qunit-fixture">
-    <div id="item-container"></div>
+    <div id="fixture-length-constraint"></div>
+    <div id="pattern-constraint-incorrect"></div>
+    <div id="pattern-constraint-correct"></div>
+    <div id="set-get-response"></div>
 </div>
 
 <div id="outside-container"></div>

--- a/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -57,18 +57,18 @@ define([
 
                 $input.val('123');
                 $input.keyup();
-                assert.equal(getTooltipContent($input), __('3/5'), 'the instruction message is correct');
+                assert.equal(getTooltipContent($input), __('%d/%d', 3, 5), 'the instruction message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
 
                 $input.val('12345');
                 $input.keyup();
-                assert.equal(getTooltipContent($input), __('5/5'), 'the warning message is correct');
+                assert.equal(getTooltipContent($input), __('%d/%d', 5, 5), 'the warning message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'warning tooltip is visible');
                 assert.ok($input.hasClass('maxed'), 'has state maxed');
 
                 $input.val('1234');
                 $input.keyup();
-                assert.equal(getTooltipContent($input), __('4/5'), 'the instruction message is correct');
+                assert.equal(getTooltipContent($input), __('%d/%d', 4, 5), 'the instruction message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
                 assert.ok(!$input.hasClass('maxed'), 'has state maxed removed');
 

--- a/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -127,7 +127,7 @@ define([
                 QUnit.start();
             }).on('responsechange', function(){
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
-                assert.equal(getTooltip($input), undefined, 'the error tooltip is hidden after a correct response');
+                assert.equal(getTooltipContent($input), __('This is not a valid answer'), 'the error tooltip is hidden after a correct response');
             })
             .init()
             .render($container);

--- a/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -1,11 +1,12 @@
 define([
     'jquery',
     'lodash',
+    'i18n',
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/text-entry-noconstraint.json',
     'json!taoQtiItem/test/samples/json/text-entry-length.json',
     'json!taoQtiItem/test/samples/json/text-entry-pattern.json'
-], function ($, _, qtiItemRunner, textEntryData, textEntryLengthConstrainedData, textEntryPatternConstrainedData) {
+], function ($, _, __, qtiItemRunner, textEntryData, textEntryLengthConstrainedData, textEntryPatternConstrainedData) {
     'use strict';
 
     var runner;
@@ -51,7 +52,7 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.equal(getTooltipContent($input), '5 characters allowed', 'the instruction message is correct');
+                assert.equal(getTooltipContent($input), __('%d characters allowed', 5), 'the instruction message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
 
                 $input.val('123');
@@ -93,16 +94,15 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.equal(getTooltipContent($input), undefined);
+                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
 
                 $input.val('123');
                 $input.keyup();
 
-            }).on('responsechange', function(state){
+            }).on('responsechange', function(){
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
-                assert.equal(getTooltipContent($input), 'This is not a valid answer', 'the error message is correct');
+                assert.equal(getTooltipContent($input), __('This is not a valid answer'), 'the error message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'the error tooltip is visible after an invalid response');
-                QUnit.start();
             })
             .init()
             .render($container);
@@ -125,15 +125,14 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.equal(getTooltipContent($input), undefined);
+                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
 
                 $input.val('PARIS');
                 $input.keyup();
 
-            }).on('responsechange', function(state){
+            }).on('responsechange', function(){
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
                 assert.equal(getTooltip($input), undefined, 'the error tooltip is hidden after a correct response');
-                QUnit.start();
             })
             .init()
             .render($container);
@@ -150,7 +149,6 @@ define([
         runner = qtiItemRunner('qti', textEntryData)
             .on('render', function(){
                 QUnit.start();
-
 
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
 

--- a/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -10,16 +10,6 @@ define([
     'use strict';
 
     var runner;
-    var fixtureContainerId = 'item-container';
-    var outsideContainerId = 'outside-container';
-
-    module('Text Entry Interaction', {
-        teardown: function () {
-            if (runner) {
-                runner.clear();
-            }
-        }
-    });
 
     function getTooltipContent($input){
         var content = getTooltip($input);
@@ -35,17 +25,23 @@ define([
         }
     }
 
-    QUnit.asyncTest('Lenght constraint', function (assert) {
+    QUnit.module('Text Entry Interaction', {
+        teardown: function () {
+            if (runner) {
+                runner.clear();
+            }
+        }
+    });
 
-        var $container = $('#' + fixtureContainerId);
+    QUnit.asyncTest('Length constraint', function (assert) {
+
+        var $container = $('#fixture-length-constraint');
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', textEntryLengthConstrainedData)
             .on('render', function () {
-                QUnit.start();
-
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
 
                 assert.equal($input.length, 1, 'the container contains a text entry interaction .qti-textEntryInteraction');
@@ -72,6 +68,7 @@ define([
                 assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
                 assert.ok(!$input.hasClass('maxed'), 'has state maxed removed');
 
+                QUnit.start();
             })
             .init()
             .render($container);
@@ -79,15 +76,13 @@ define([
 
     QUnit.asyncTest('Pattern constraint - incorrect', function (assert) {
 
-        var $container = $('#' + fixtureContainerId);
+        var $container = $('#pattern-constraint-incorrect');
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', textEntryPatternConstrainedData)
             .on('render', function () {
-                QUnit.start();
-
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
 
                 assert.equal($input.length, 1, 'the container contains a text entry interaction .qti-textEntryInteraction');
@@ -99,6 +94,7 @@ define([
                 $input.val('123');
                 $input.keyup();
 
+                QUnit.start();
             }).on('responsechange', function(){
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
                 assert.equal(getTooltipContent($input), __('This is not a valid answer'), 'the error message is correct');
@@ -110,15 +106,13 @@ define([
 
     QUnit.asyncTest('Pattern constraint - correct', function (assert) {
 
-        var $container = $('#' + fixtureContainerId);
+        var $container = $('#pattern-constraint-correct');
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', textEntryPatternConstrainedData)
             .on('render', function () {
-                QUnit.start();
-
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
 
                 assert.equal($input.length, 1, 'the container contains a text entry interaction .qti-textEntryInteraction');
@@ -130,6 +124,7 @@ define([
                 $input.val('PARIS');
                 $input.keyup();
 
+                QUnit.start();
             }).on('responsechange', function(){
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
                 assert.equal(getTooltip($input), undefined, 'the error tooltip is hidden after a correct response');
@@ -140,7 +135,7 @@ define([
 
     QUnit.asyncTest('set/get response', function(assert){
 
-        var $container = $('#' + fixtureContainerId);
+        var $container = $('#set-get-response');
         var state = {"RESPONSE":{response:{"base":{"string":"PARIS"}}}};
 
         assert.equal($container.length, 1, 'the item container exists');
@@ -148,8 +143,6 @@ define([
 
         runner = qtiItemRunner('qti', textEntryData)
             .on('render', function(){
-                QUnit.start();
-
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
 
                 assert.equal($input.length, 1, 'the container contains a text entry interaction .qti-textEntryInteraction');
@@ -158,15 +151,13 @@ define([
                 this.setState(state);
 
                 assert.equal($input.val(), 'PARIS', 'the text input has been correctly set');
-
                 assert.deepEqual(this.getState(state), state, 'state is correct');
 
                 $input.keyup();//trigger the response changed event
 
+                QUnit.start();
             }).on('statechange', function(retrivedState){
-
                 assert.deepEqual(retrivedState, state, 'statechange state is correct');
-
             })
             .init()
             .render($container);
@@ -175,16 +166,15 @@ define([
     module('Visual Test');
 
     QUnit.asyncTest('Display and play', function (assert) {
-        QUnit.expect(3);
+        var $container = $('#outside-container');
 
-        var $container = $('#' + outsideContainerId);
+        QUnit.expect(3);
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         qtiItemRunner('qti', textEntryLengthConstrainedData)
             .on('render', function () {
-
                 assert.equal($container.find('.qti-interaction.qti-textEntryInteraction').length, 1, 'the container contains a text entry interaction .qti-textEntryInteraction');
 
                 QUnit.start();

--- a/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -156,8 +156,8 @@ define([
                 $input.keyup();//trigger the response changed event
 
                 QUnit.start();
-            }).on('statechange', function(retrivedState){
-                assert.deepEqual(retrivedState, state, 'statechange state is correct');
+            }).on('statechange', function(retrievedState){
+                assert.deepEqual(retrievedState, state, 'statechange state is correct');
             })
             .init()
             .render($container);

--- a/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/views/js/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -57,18 +57,18 @@ define([
 
                 $input.val('123');
                 $input.keyup();
-                assert.equal(getTooltipContent($input), '3/5', 'the instruction message is correct');
+                assert.equal(getTooltipContent($input), __('3/5'), 'the instruction message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
 
                 $input.val('12345');
                 $input.keyup();
-                assert.equal(getTooltipContent($input), '5/5', 'the warning message is correct');
+                assert.equal(getTooltipContent($input), __('5/5'), 'the warning message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'warning tooltip is visible');
                 assert.ok($input.hasClass('maxed'), 'has state maxed');
 
                 $input.val('1234');
                 $input.keyup();
-                assert.equal(getTooltipContent($input), '4/5', 'the instruction message is correct');
+                assert.equal(getTooltipContent($input), __('4/5'), 'the instruction message is correct');
                 assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
                 assert.ok(!$input.hasClass('maxed'), 'has state maxed removed');
 


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/TAO-7667
- rollback  the changed behavior (adding n/n tooltip);
- fix the actual bug.

Unit test: `/taoQtiItem/views/js/test/qtiCommonRenderer/interactions/textEntry/test.html`