### PR TITLE
fix css selector for table

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '19.9.1',
+    'version'     => '19.9.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -415,6 +415,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.5.0');
         }
 
-        $this->skip('19.5.0', '19.9.1');
+        $this->skip('19.5.0', '19.9.2');
     }
 }

--- a/views/js/qtiCreator/editor/targetFinder.js
+++ b/views/js/qtiCreator/editor/targetFinder.js
@@ -7,7 +7,7 @@ define([
     'use strict';
 
     var _qtiHtmlEditableTypes = {
-        'itemBody' : '.widget-textBlock > [data-html-editable], .widget-table > [data-html-editable]',
+        'itemBody' : '.widget-textBlock > [data-html-editable], .widget-textBlock .widget-table table[data-html-editable]',
         'prompt' : '.qti-prompt[data-html-editable]',
         'choice' : '.qti-choice [data-html-editable]'
     };


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8091
 
Css selector for table was changed: only for tables inside widget textBlock.

How to test:
1. create Item
2. add textBlock
3. insert table in textBlock
4. add Hottext
5. insert table in Hottext
6. drag and drop Inline Choice or textEntry or EndAttempt in textBlock table (caption or cell)
7. try drag and drop Inline Choice or textEntry or EndAttempt in Hottext table (caption or cell)