### PR TITLE
fix for Response Processing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "minimum-stability" : "dev",
     "require": {
-        "oat-sa/lib-tao-qti" : "~4.3.0",
+        "oat-sa/lib-tao-qti" : "~4.4.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
 		"naneau/semver" : "~0.0.7"
     },

--- a/config/default/ImportService.conf.php
+++ b/config/default/ImportService.conf.php
@@ -3,4 +3,6 @@
  * Default config header created during install
  */
 
-return new oat\taoQtiItem\model\qti\ImportService();
+return new oat\taoQtiItem\model\qti\ImportService([
+    \oat\taoQtiItem\model\qti\ImportService::CONFIG_VALIDATE_RESPONSE_PROCESSING => false
+]);

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '19.9.1',
+    'version'     => '19.10.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -74,6 +74,11 @@ class ImportService extends ConfigurableService
 
     const SERVICE_ID = 'taoQtiItem/ImportService';
 
+    /**
+     * Checks that setOutcomeValue declared in the outcomeDeclaration
+     */
+    const CONFIG_VALIDATE_RESPONSE_PROCESSING = 'validateResponseProcessing';
+
     const PROPERTY_QTI_ITEM_IDENTIFIER = 'http://www.tao.lu/Ontologies/TAOItem.rdf#QtiItemIdentifier';
 
     /**
@@ -468,8 +473,9 @@ class ImportService extends ConfigurableService
 
                 $qtiModel = $this->createQtiItemModel($qtiFile);
 
-                if (!$this->validResponseProcessing($qtiModel)) {
-                    return common_report_Report::createFailure(__('The IMS QTI Item referenced as "%s" in the IMS Manifest file has incorrect Response Processing and outcomeDeclaration definitions.', $resourceIdentifier));
+                if ($this->getOption(self::CONFIG_VALIDATE_RESPONSE_PROCESSING) && !$this->validResponseProcessing($qtiModel)) {
+                    return common_report_Report::createFailure(
+                        __('The IMS QTI Item referenced as "%s" in the IMS Manifest file has incorrect Response Processing and outcomeDeclaration definitions.', $resourceIdentifier));
                 }
 
                 if ($guardian !== false && $itemMustBeOverwritten) {

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -48,7 +48,14 @@ use oat\taoQtiItem\model\qti\metadata\MetadataGuardianResource;
 use oat\taoQtiItem\model\qti\metadata\MetadataService;
 use oat\taoQtiItem\model\qti\parser\ValidationException;
 use oat\taoQtiItem\model\event\ItemImported;
+use qtism\data\QtiComponentCollection;
+use qtism\data\rules\ResponseCondition;
+use qtism\data\rules\SetOutcomeValue;
+use qtism\data\storage\xml\XmlDocument;
 use qtism\data\storage\xml\XmlStorageException;
+use qtism\runtime\processing\ResponseProcessingEngine;
+use qtism\runtime\tests\AssessmentItemSession;
+use qtism\runtime\tests\SessionManager;
 use tao_helpers_File;
 use taoItems_models_classes_ItemsService;
 use oat\oatbox\event\EventManager;
@@ -460,6 +467,11 @@ class ImportService extends ConfigurableService
                 common_Logger::i('file :: ' . $qtiItemResource->getFile());
 
                 $qtiModel = $this->createQtiItemModel($qtiFile);
+
+                if (!$this->validResponseProcessing($qtiModel)) {
+                    return common_report_Report::createFailure(__('The IMS QTI Item referenced as "%s" in the IMS Manifest file has incorrect Response Processing and outcomeDeclaration definitions.', $resourceIdentifier));
+                }
+
                 if ($guardian !== false && $itemMustBeOverwritten) {
                     \common_Logger::d('Resource "' . $resourceIdentifier . '" will overwrite item with URI ' . $guardian->getUri());
                     $rdfItem = $guardian;
@@ -600,6 +612,66 @@ class ImportService extends ConfigurableService
 
         return $report;
 
+    }
+
+    protected function validResponseProcessing(Item $qtiModel)
+    {
+        // <outcomeDeclaration> from the items qti
+        $outcomes = $this->getOutcomesIds($qtiModel);
+        // <setOutcomeValue> from the responseProcessing (template or body) also items qti
+        $rules = $this->getSetOutcomeValueIds($qtiModel);
+
+        return count(array_diff($outcomes, $rules)) === 0 && count(array_diff($rules, $outcomes)) === 0;
+    }
+
+    protected function getOutcomesIds(Item $qtiModel)
+    {
+        $declaredIds = [];
+        /** @var OutcomeDeclaration $outcomeDeclaration */
+        foreach ($qtiModel->getOutcomes() as $outcomeDeclaration) {
+            $declaredIds[] = $outcomeDeclaration->getIdentifier();
+        }
+
+        return $declaredIds;
+    }
+
+    protected function getSetOutcomeValueIds($qtiModel)
+    {
+        $rules = $this->getResponseProcessingRules($qtiModel);
+        $ids = [];
+        foreach ($rules as $rule) {
+            /** @var ResponseCondition $condition */
+            foreach ($rule as $condition) {
+                /** @var QtiComponentCollection $collection */
+                $collection = $condition->getComponentsByClassName(SetOutcomeValue::CLASS_NAME);
+                while ($collection->valid()) {
+                    /** @var SetOutcomeValue $setOutcomeValue */
+                    $setOutcomeValue = $collection->current();
+                    $ids[] = $setOutcomeValue->getIdentifier();
+                    $collection->next();
+                }
+            }
+        }
+
+        return array_unique($ids);
+    }
+
+    protected function getResponseProcessingRules(Item $qtiModel)
+    {
+        $rules = [];
+        $qti = $qtiModel->toQTI();
+        $qtiXmlDoc = new XmlDocument();
+        $qtiXmlDoc->loadFromString($qti);
+        $itemSession = new AssessmentItemSession($qtiXmlDoc->getDocumentComponent(), new SessionManager());
+        $responseProcessing = $itemSession->getAssessmentItem()->getResponseProcessing();
+
+        // Some items (especially to collect information) have no response processing!
+        if ($responseProcessing !== null && ($responseProcessing->hasTemplate() === true || $responseProcessing->hasTemplateLocation() === true || count($responseProcessing->getResponseRules()) > 0)) {
+            $engine = new ResponseProcessingEngine($responseProcessing, $itemSession);
+            $rules = $engine->getResponseProcessingRules();
+        }
+
+        return $rules;
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -415,6 +415,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.5.0');
         }
 
-        $this->skip('19.5.0', '19.9.1');
+        $this->skip('19.5.0', '19.10.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -415,6 +415,13 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.5.0');
         }
 
-        $this->skip('19.5.0', '19.10.0');
+        $this->skip('19.5.0', '19.9.1');
+
+        if ($this->isVersion('19.9.1')) {
+            $importService = $this->getServiceManager()->get(ImportService::SERVICE_ID);
+            $importService->setOption(ImportService::CONFIG_VALIDATE_RESPONSE_PROCESSING, false);
+            $this->getServiceManager()->register(ImportService::SERVICE_ID, $importService);
+            $this->setVersion('19.10.0');
+        }
     }
 }


### PR DESCRIPTION
all `<setOutcomeValue>` elements from the `<responseProcessing>` elements needs to be used in the `<outcomeDeclaration>` elements.

- [x] depends on https://github.com/oat-sa/qti-sdk/pull/135 