### PR TITLE
Fix/TAO-7216/Timer doesn't start after the audio is fully loaded when the connection is slow

### DIFF
--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -133,8 +133,9 @@ define([
                         return userModules.load().then(done);
 
                     }).catch(function(err){
+                        done(); // the second solution - in case of postRendering issue, we are also done (timer will start after timeout run out)
                         self.trigger('error', 'Error in post rendering : ' + err instanceof Error ? err.message : err);
-                        self.clear(elt);
+                        // self.clear(elt); // the first solution - destroy item after timeout run out
                     });
                 } catch(err){
                     self.trigger('error', 'Error in post rendering : ' + err.message);

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -134,6 +134,7 @@ define([
 
                     }).catch(function(err){
                         self.trigger('error', 'Error in post rendering : ' + err instanceof Error ? err.message : err);
+                        self.clear(elt);
                     });
                 } catch(err){
                     self.trigger('error', 'Error in post rendering : ' + err.message);
@@ -166,12 +167,15 @@ define([
                         }
 
                         self._item = null;
+                        return;
                     })
                     .then(done)
                     .catch(function(err) {
                         self.trigger('error', 'Something went wrong while destroying an interaction: ' + err.message);
                     });
 
+            } else {
+                done();
             }
         },
 


### PR DESCRIPTION
**DRAFT PR!!!**

Related to: https://oat-sa.atlassian.net/browse/TAO-7216

**Description of the problem:**
In case when the user has a slow connection loading audio can take more than 30sec (default timeout). And Error will be triggered.
https://github.com/oat-sa/extension-tao-itemqti/blob/ebbe0cfe7f62bf42f7b49527b66abfd5a77419cb/views/js/runner/provider/qti.js#L136
But audio will be successfully loaded after error. And will be available for the user.
Next button will be enabled on Test Runner level
https://github.com/oat-sa/extension-tao-testqti/blob/f0a409e7cf9e9b96849263742d4c5786a588c4f8/views/js/runner/provider/qti.js#L628-L634
The timer will not start because of function done was not called.
 
**First solution:**
If an error appears in postRender - clean item. 
The timer will not start. 
Next Button will be enabled. 
But the user will be not able to submit a response.

**Second solution:**
If an error appears in postRender - call done function. 
Like in 
https://github.com/oat-sa/extension-tao-itemqti/blob/ebbe0cfe7f62bf42f7b49527b66abfd5a77419cb/views/js/qtiRunner/core/QtiRunner.js#L187-L188
and
https://github.com/oat-sa/extension-tao-itemqti/blob/ebbe0cfe7f62bf42f7b49527b66abfd5a77419cb/views/js/qtiRunner/modalFeedback/inlineRenderer.js#L317-L318
In this case 
 
 
#### Steps to reproduce
 - Create a test with an audio media interaction and Maximum Duration set.
 - Slow down connection and download speeds (e.g. 512 kB/s, 256 kB/s)
 - Run the test
 - Wait until audio is fully loaded