### PR TITLE
Fix/tao 8389/hide qticreator error tooltip

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '20.0.2',
+    'version'     => '20.0.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -424,7 +424,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '20.0.2');
+        $this->skip('19.10.0', '20.0.3');
 
     }
 }

--- a/views/js/qtiCreator/widgets/Widget.js
+++ b/views/js/qtiCreator/widgets/Widget.js
@@ -177,14 +177,12 @@ define([
 
             if(currentState){
                 // hide widget tooltips when interaction leaves response mapping ('map') state:
-                if (this.serial.match(/^interaction/)) {
-                    if (currentState.name === 'map' && state.name !== 'map') {
-                        $(self.$container)
-                            .find('[data-has-tooltip]')
-                            .each(function(j, el) {
-                                $(el).data('$tooltip').hide();
-                            });
-                    }
+                if (this.serial.match(/^interaction/) && currentState.name === 'map' && state.name !== 'map') {
+                    this.$container
+                        .find('[data-has-tooltip]')
+                        .each(function(j, el) {
+                            $(el).data('$tooltip').hide();
+                        });
                 }
 
                 if(currentState.name === state.name){

--- a/views/js/qtiCreator/widgets/Widget.js
+++ b/views/js/qtiCreator/widgets/Widget.js
@@ -176,6 +176,16 @@ define([
             }
 
             if(currentState){
+                // hide widget tooltips when interaction leaves response mapping ('map') state:
+                if (this.serial.match(/^interaction/)) {
+                    if (currentState.name === 'map' && state.name !== 'map') {
+                        $(self.$container)
+                            .find('[data-has-tooltip]')
+                            .each(function(j, el) {
+                                $(el).data('$tooltip').hide();
+                            });
+                    }
+                }
 
                 if(currentState.name === state.name){
                     return this;

--- a/views/js/qtiCreator/widgets/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/helpers/formElement.js
@@ -124,6 +124,16 @@ define([
             spinner($form);
             tooltip.lookup($form);
             select2($form);
+
+            // When the widget template changes:
+            // (event will reach this widget after being forwarded from document listener)
+            $(document)
+                .off('responseTemplateChange.qti-widget')
+                .on('responseTemplateChange.qti-widget', function(options) {
+                    console.warn(options);
+                    // hide all the tooltips
+                    $('.tooltip', '.qti-interaction').hide();
+                });
         },
 
         /**

--- a/views/js/qtiCreator/widgets/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/helpers/formElement.js
@@ -81,6 +81,11 @@ define([
             container: validatorOptions.$container[0]
         });
 
+        if ($input.data('$tooltip')) {
+            $input.data('$tooltip').dispose();
+            $input.removeData('$tooltip');
+        }
+
         $input.data('$tooltip', formElementTooltip);
         $input.attr('data-has-tooltip',true);
     };
@@ -124,16 +129,6 @@ define([
             spinner($form);
             tooltip.lookup($form);
             select2($form);
-
-            // When the widget template changes:
-            // (event will reach this widget after being forwarded from document listener)
-            $(document)
-                .off('responseTemplateChange.qti-widget')
-                .on('responseTemplateChange.qti-widget', function(options) {
-                    console.warn(options);
-                    // hide all the tooltips
-                    $('.tooltip', '.qti-interaction').hide();
-                });
         },
 
         /**

--- a/views/js/qtiCreator/widgets/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/helpers/formElement.js
@@ -39,7 +39,7 @@ define([
      * Update response declaration
      * @param {Object} interaction
      * @param {Number} maxChoice
-     * @param {Boolean} [updateCardinality = true]
+     * @param {Boolean} [updateCardinality=true]
      * @throws {Error} if the element is not an interaction
      */
     var updateResponseDeclaration = function updateResponseDeclaration(interaction, maxChoice, updateCardinality) {
@@ -47,7 +47,7 @@ define([
         var correct = [];
 
         if (! Element.isA(interaction, 'interaction') ) {
-            throw new Error('Tthe first argument must be an interaction, the current element is ' + interaction.qtiClass);
+            throw new Error('The first argument must be an interaction, the current element is ' + interaction.qtiClass);
         }
 
         updateCardinality = (typeof updateCardinality === 'undefined') ? true : !!updateCardinality;
@@ -72,6 +72,7 @@ define([
     /**
      * Create a tooltip for the given input
      * @param {jQueryElement} $input
+     * @param {Object} validatorOptions
      *
      */
     var createTooltip = function createTooltip($input, validatorOptions) {
@@ -82,7 +83,6 @@ define([
 
         $input.data('$tooltip', formElementTooltip);
         $input.attr('data-has-tooltip',true);
-
     };
     /**
      * Validation callback, used as a groupvalidator callback
@@ -106,7 +106,7 @@ define([
                     type: 'failure'
                 })[0];
                 if (rule && rule.data.message && !$('#mediaManager').children('.opened').length) {
-                    $input.data('$tooltip').updateTitleContent(rule.data.message)
+                    $input.data('$tooltip').updateTitleContent(rule.data.message);
                     //only show it when the file manager is hidden
                     $input.data('$tooltip').show();
                 }
@@ -132,8 +132,9 @@ define([
          * @param {Object} $form - the jQuery form element
          * @param {Object} element - a js qti element (see qtiCreator/model)
          * @param {Object} attributes - key value attributeName:callback, e.g. {identifier:function(element, value, attrName){ element.attr(attrName, value); }}
-         * @param {Boolean} [options.validateOnInit = false] - define if the validation should be trigger immediately after the callbacks have been set
-         * @param {Boolean} [options.invalidate = false] - define if the validation set the valid/invalidate state to the widget of the element
+         * @param {Object} options
+         * @param {Boolean} [options.validateOnInit=false] - define if the validation should be trigger immediately after the callbacks have been set
+         * @param {Boolean} [options.invalidate=false] - define if the validation set the valid/invalidate state to the widget of the element
          */
         setChangeCallbacks: function setChangeCallbacks($form, element, attributes, options) {
 
@@ -197,7 +198,7 @@ define([
 
         /**
          * Unbind the data change callbacks
-         * @param {jQueryElement} $formk
+         * @param {jQueryElement} $form
          */
         removeChangeCallback: function removeChangeCallback($form) {
             $form.off('.databinding');
@@ -208,9 +209,9 @@ define([
         /**
          * the simplest form of save callback used in setChangeCallbacks()
          * @param {boolean} allowEmpty
+         * @returns {function} - the callback function to be called elsewhere
          */
         getAttributeChangeCallback: function getAttributeChangeCallback(allowEmpty) {
-
             return function(element, value, name) {
                 if (!allowEmpty && value === '') {
                     element.removeAttr(name);
@@ -249,7 +250,6 @@ define([
             callbacks[attributeNameMin] = function(element, value, name) {
 
                 var isActualNumber;
-                var max;
 
                 value = options.floatVal ? parseFloat(value) : parseInt(value, 10);
                 isActualNumber = !isNaN(value);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8389

There were 2 bugs relating to tooltip management in the item authoring.
1. The same error tooltip was being duplicated 1,2,3...10 times or more, preventing it from ever being hidden. This made it seem like negative values were considered invalid (even though they were always valid, and could be saved as such).
2. Error tooltips were remaining on the page after Response Mapping mode was exited.

Both errors are fixed, by:
1. Checking if a form element already has a tooltip and removing it before assigning a new one.
2. Checking on a widget's state change, if it is an interaction leaving the 'map' state. If so, hiding its tooltips.

Background information on QTI widget states: https://hub.taotesting.com/articles/qti/qti-item-creator

To test: go into item authoring and play with changing the response processing mode, and setting invalid (non-numeric) values and negative values in the inputs (negatives are valid!)