### PR TITLE
Fix/mathjax gitignore

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '20.2.2',
+    'version'     => '20.2.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -424,7 +424,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '20.2.2');
+        $this->skip('19.10.0', '20.2.3');
 
     }
 }

--- a/views/js/mathjax/.gitignore
+++ b/views/js/mathjax/.gitignore
@@ -1,6 +1,1 @@
-.DS_Store
-docs/build/html-mathjax-site
-config/local/*.js
-!config/local/local.js
-unpacked/config/local/*.js
-!unpacked/config/local/local.js
+*


### PR DESCRIPTION
I think something wrong happened in previous commits regarding mathJax's `.gitignore` file. If I'm not mistaken, It should be ignoring everything in that folder.