### PR TITLE
Fix/tao 7842 too much greedy empty check

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '20.2.4',
+    'version'     => '20.2.5',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/model/QtiJsonItemCompiler.php
+++ b/model/QtiJsonItemCompiler.php
@@ -88,7 +88,7 @@ class QtiJsonItemCompiler extends QtiItemCompiler
             $qtiItem = $this->retrieveAssets($item, $language, $publicDirectory);
 
             if (count($qtiItem->getBody()->getElements()) === 0) {
-                return new common_report_Report(common_report_Report::TYPE_ERROR, 'The item has an empty body.');
+                //return new common_report_Report(common_report_Report::TYPE_ERROR, 'The item has an empty body.');
             }
 
             $this->compileItemIndex($item->getUri(), $qtiItem, $language);

--- a/model/QtiJsonItemCompiler.php
+++ b/model/QtiJsonItemCompiler.php
@@ -87,9 +87,10 @@ class QtiJsonItemCompiler extends QtiItemCompiler
         try {
             $qtiItem = $this->retrieveAssets($item, $language, $publicDirectory);
 
-            if (count($qtiItem->getBody()->getElements()) === 0) {
-                //return new common_report_Report(common_report_Report::TYPE_ERROR, 'The item has an empty body.');
-            }
+            // @todo find a better solution to eliminate empty items.
+            /*if (count($qtiItem->getBody()->getElements()) === 0) {
+                return new common_report_Report(common_report_Report::TYPE_ERROR, 'The item has an empty body.');
+            }*/
 
             $this->compileItemIndex($item->getUri(), $qtiItem, $language);
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -424,7 +424,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '20.2.4');
+        $this->skip('19.10.0', '20.2.5');
 
     }
 }


### PR DESCRIPTION
This PR aims at deactivating the emptiness check we did for TAO-7842. Unfortunately, it prevents information items (e.g. Items with only some texts) to be compiled.

You can check the compilation failure by using QTI Test Package https://github.com/oat-sa/extension-tao-testqti/blob/master/test/samples/archives/QTI%202.1/routing/FromOutcomeProcessing.zip.

**To reproduce:**

- Import the test as a QTI Test Package
- Compile it as a delivery. You will receive error reports about some items having "an empty item body".

**Expected behaviour:**

The test compiles properly with all the items involved.
