### PR TITLE
Override metadata properties for each interaction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '20.2.6',
+    'version'     => '20.2.7',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/model/flyExporter/extractor/QtiExtractor.php
+++ b/model/flyExporter/extractor/QtiExtractor.php
@@ -268,7 +268,7 @@ class QtiExtractor implements Extractor
                 $interaction['choices'] = [];
                 $interaction['responses'] = [];
 
-                if ($parser['domInteraction'] == 'customInteraction') {
+                if ($parser['domInteraction'] === 'customInteraction') {
                     // figure out the proper type name of a custom interaction
                     $portableCustomNode = $this->xpath->query('./pci:portableCustomInteraction', $interactionNode->item($i));
                     if ($portableCustomNode->length) {

--- a/model/flyExporter/simpleExporter/ItemExporter.php
+++ b/model/flyExporter/simpleExporter/ItemExporter.php
@@ -174,11 +174,14 @@ class ItemExporter extends ConfigurableService implements SimpleExporter
 
                 $interactionData = is_array($value) && count($value) > 1 ? $value : $values;
 
-                if (array_values(array_intersect(array_keys($data[0]), array_keys($interactionData))) == array_keys($interactionData)) {
+                if (array_values(array_intersect(array_keys($data[0]), array_keys($interactionData))) === array_keys($interactionData)) {
                     $line = array_intersect_key($data[0], array_flip($this->headers));
                     $data[] = array_merge($line, $interactionData);
                 } else {
-                    $data[0] = array_merge($data[0], $interactionData);
+                    foreach ($data as &$piece) {
+                        $piece = array_merge($piece, $interactionData);
+                    }
+                    unset($piece);
                 }
 
                 $this->headers = array_unique(array_merge($this->headers, array_keys($interactionData)));

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -424,7 +424,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '20.2.6');
+        $this->skip('19.10.0', '20.2.7');
 
     }
 }

--- a/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
+++ b/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace oat\taoQtiItem\test\unit\model\flyExporter\simpleExporter;
+
+use PHPUnit\Framework\TestCase;
+use oat\taoQtiItem\model\flyExporter\simpleExporter\ItemExporter;
+
+class ItemExporterTest extends TestCase
+{
+    public function testGetDataByItem()
+    {
+        $extractor = $this->getMockBuilder(\oat\taoQtiItem\model\flyExporter\extractor\Extractor::class)
+            ->getMock();
+        $extractor2 = $this->getMockBuilder(\oat\taoQtiItem\model\flyExporter\extractor\Extractor::class)
+            ->getMock();
+
+        $extractor2->expects($this->once())->method('getData')->willReturn([
+            'foo' => 'bar',
+        ]);
+        $extractor->expects($this->once())->method('getData')->willReturn([
+            '5d1b29d040d15' => [
+                'type' => 'Choice',
+                'nb choice' => 3,
+            ],
+            '5d1b29d040daf' => [
+                'type' => 'Associate',
+                'nb choice' => 2,
+            ],
+        ]);
+
+        $exporter = new ItemExporter([
+            'extractors' => [
+                'QtiExtractor' => $extractor,
+                'MetaDataOntologyExtractor' => $extractor2,
+            ],
+            'fileLocation' => 'tmp',
+            'columns' => [
+                'choiceInteraction' => [
+                    'extractor' => 'QtiExtractor',
+                ],
+            ]
+        ]);
+        $item = new \core_kernel_classes_Resource('foo');
+        $data = $exporter->getDataByItem($item);
+        //both interactions have metadata
+        $this->assertEquals(array_column($data, 'foo'),['bar', 'bar']);
+    }
+
+
+}


### PR DESCRIPTION
Ticket is https://oat-sa.atlassian.net/browse/SD-44
Alternative https://oat-sa.atlassian.net/browse/SI-398

### What does it do?

In case when an item has several interactions it loops through them and applies metadata for each row.
Before it worked only with the first item.