### PR TITLE
Fix/Transpiler issue with math keyword

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '21.0.0',
+    'version'     => '21.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,8 +434,10 @@ class Updater extends \common_ext_ExtensionUpdater
             $clientLibRegistry->register('taoQtiItem/qtiItem', $taoQtiItemNpmDist . 'qtiItem');
             $clientLibRegistry->register('taoQtiItem/qtiRunner', $taoQtiItemNpmDist . 'qtiRunner');
             $clientLibRegistry->register('taoQtiItem/runner', $taoQtiItemNpmDist . 'runner');
-            $clientLibRegistry->register('taoQtiItem/scoring', $taoQtiItemNpmDist . 'scoring');    
+            $clientLibRegistry->register('taoQtiItem/scoring', $taoQtiItemNpmDist . 'scoring');
             $this->setVersion('21.0.0');
         }
+
+        $this->skip('21.0.0', '21.0.1');
     }
 }

--- a/views/js/qtiCreator/model/Math.js
+++ b/views/js/qtiCreator/model/Math.js
@@ -1,3 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014-2019 Open Assessment Technologies SA
+ */
 define([
     'lodash',
     'taoQtiItem/qtiCreator/model/mixin/editable',

--- a/views/js/qtiCreator/model/Math.js
+++ b/views/js/qtiCreator/model/Math.js
@@ -2,7 +2,7 @@ define([
     'lodash',
     'taoQtiItem/qtiCreator/model/mixin/editable',
     'taoQtiItem/qtiItem/core/Math'
-], function(_, editable, Math){
+], function(_, editable, mathModel){
     "use strict";
     var methods = {};
     _.extend(methods, editable);
@@ -14,5 +14,5 @@ define([
             this.getNamespace();
         }
     });
-    return Math.extend(methods);
+    return mathModel.extend(methods);
 });


### PR DESCRIPTION
Fix an issue occurring with the Math model when transpiling the source code. `Math` is reserved, and using this name for a variable will conflict with global context when transpiling.