### PR TITLE
Fix/tao 8716/template parsing issue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '21.0.0',
+    'version'     => '21.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -437,5 +437,8 @@ class Updater extends \common_ext_ExtensionUpdater
             $clientLibRegistry->register('taoQtiItem/scoring', $taoQtiItemNpmDist . 'scoring');    
             $this->setVersion('21.0.0');
         }
+
+        $this->skip('21.0.0', '21.0.1');
+
     }
 }

--- a/views/js/qtiCreator/editor/styleEditor/styleEditor.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleEditor.js
@@ -237,7 +237,6 @@ define([
 
         var fileName,
             link,
-            stylesheets = [],
             listEntry,
             parser,
             loadStylesheet = function(link, stylesheet, isLocal, isValid) {
@@ -254,10 +253,8 @@ define([
                         editLabelTxt: isInvalidLocal ? common.isInValidLocalTxt : common.editLabelTxt
                     };
 
-                stylesheets.push(tplData);
-
                 // create list entry
-                listEntry = $(cssTpl({ stylesheets: stylesheets }));
+                listEntry = $(cssTpl(tplData));
 
                 listEntry.data('stylesheetObj', stylesheet);
 

--- a/views/js/qtiCreator/tpl/toolbars/cssToggler.tpl
+++ b/views/js/qtiCreator/tpl/toolbars/cssToggler.tpl
@@ -1,5 +1,5 @@
-{{#each stylesheets}}
-<li data-css-res="{{path}}">
+{{!-- no newline between #each and first tag, to prevent jQuery parse error --}}
+{{#each stylesheets}}<li data-css-res="{{path}}">
     <span class="icon-preview style-sheet-toggler" title="{{title}}"></span>
     <span class="file-label truncate" title="{{editLabelTxt}}">{{label}}</span>
     <input type="text" class="style-sheet-label-editor" value="{{label}}">

--- a/views/js/qtiCreator/tpl/toolbars/cssToggler.tpl
+++ b/views/js/qtiCreator/tpl/toolbars/cssToggler.tpl
@@ -1,9 +1,7 @@
-{{!-- no newline between #each and first tag, to prevent jQuery parse error --}}
-{{#each stylesheets}}<li data-css-res="{{path}}">
+<li data-css-res="{{path}}">
     <span class="icon-preview style-sheet-toggler" title="{{title}}"></span>
     <span class="file-label truncate" title="{{editLabelTxt}}">{{label}}</span>
     <input type="text" class="style-sheet-label-editor" value="{{label}}">
     <span class="icon-bin" title="{{deleteTxt}}" data-role="css-delete"></span>
     <span class="icon-download" title="{{downloadTxt}}" data-role="css-download"></span>
 </li>
-{{/each}}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8716

There was an error in production mode only, caused by jQuery mis-parsing a template with whitespace at the beginning (handlebars compiled templates?)

I could not see any way in the function `addStylesheet()` that the array `stylesheets` would ever contain more than one value. So simply removed it, passed that one value into the template and removed the `{{#each}}`. The template file is not used anywhere else. Functionality seems unchanged and now no error.

Please let me know if you see some intended functionality I am breaking here.

I also checked the rest of taoCE and couldn't find another instance of code where this behaviour could occur.

**To test**: author an Item and add a custom CSS file (production mode).