### PR TITLE
Feature/tao 8753/Add change tracker helper

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '21.1.1',
+    'version'     => '21.2.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '21.1.1');
+        $this->skip('21.0.0', '21.2.0');
     }
 }

--- a/views/js/qtiCreator/helper/changeTracker.js
+++ b/views/js/qtiCreator/helper/changeTracker.js
@@ -26,14 +26,16 @@ define([
     'i18n',
     'lib/uuid',
     'core/eventifier',
-    'ui/dialog'
+    'ui/dialog',
+    'taoQtiItem/qtiCreator/helper/saveChanges'
 ], function (
     $,
     _,
     __,
     uuid,
     eventifier,
-    dialog
+    dialog,
+    saveChanges
 ) {
     'use strict';
 
@@ -66,23 +68,6 @@ define([
 
         // are we in the middle of the confirm process ?
         let asking = false;
-
-        /**
-         * Save the changes in the item creator
-         * @returns {Promise}
-         */
-        const saveChanges = () => new Promise((resolve, reject) => {
-            itemCreator
-                .on('saved.silent', () => {
-                    itemCreator.off('.silent');
-                    resolve();
-                })
-                .on('error.silent', err => {
-                    itemCreator.off('.silent');
-                    reject(err);
-                })
-                .trigger('save', true);
-        });
 
         /**
          * @typedef {Object} changeTracker
@@ -217,7 +202,7 @@ define([
                         }],
                         autoRender: true,
                         autoDestroy: true,
-                        onSaveBtn: () => saveChanges().then(resolve).catch(reject),
+                        onSaveBtn: () => saveChanges(itemCreator).then(resolve).catch(reject),
                         onDontsaveBtn: resolve,
                         onCancelBtn: () => confirmDlg.hide()
                     })

--- a/views/js/qtiCreator/helper/changeTracker.js
+++ b/views/js/qtiCreator/helper/changeTracker.js
@@ -1,0 +1,259 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA ;
+ */
+/**
+ * Track the change within the itemCreator
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'i18n',
+    'lib/uuid',
+    'core/eventifier',
+    'ui/dialog'
+], function (
+    $,
+    _,
+    __,
+    uuid,
+    eventifier,
+    dialog
+) {
+    'use strict';
+
+    /**
+     * The messages asking to save
+     */
+    const messages = {
+        preview: __('The item needs to be saved before it can be previewed'),
+        leave: __('The item has unsaved changes, are you sure you want to leave ?'),
+        exit: __('The item has unsaved changes, would you like to save it ?')
+    };
+
+    /**
+     *
+     * @param {HTMLElement} container
+     * @param {itemCreator} itemCreator
+     * @param {String} [wrapperSelector]
+     * @returns {changeTracker}
+     * @fires stylechange when the item's style changed
+     */
+    function changeTrackerFactory(container, itemCreator, wrapperSelector = 'body') {
+        // internal namespace for global registered events
+        const eventNS = `.ct-${uuid(8, 16)}`;
+
+        // keep the value of the item before changes
+        let originalItem;
+
+        // does the item styles have changed
+        let styleChanges = false;
+
+        // are we in the middle of the confirm process ?
+        let asking = false;
+
+        /**
+         * Save the changes in the item creator
+         * @returns {Promise}
+         */
+        const saveChanges = () => new Promise((resolve, reject) => {
+            itemCreator
+                .on('saved.silent', () => {
+                    itemCreator.off('.silent');
+                    resolve();
+                })
+                .on('error.silent', err => {
+                    itemCreator.off('.silent');
+                    reject(err);
+                })
+                .trigger('save', true);
+        });
+
+        /**
+         * @typedef {Object} changeTracker
+         */
+        const changeTracker = eventifier({
+            /**
+             * Initialized the changed state
+             * @returns {changeTracker}
+             */
+            init() {
+                originalItem = this.getSerializedItem();
+                styleChanges = false;
+
+                return this;
+            },
+
+            /**
+             * Installs the change tracker, registers listeners
+             * @returns {changeTracker}
+             */
+            install() {
+                this.init();
+                asking = false;
+
+                // track style changes
+                $(window.document)
+                    .one('customcssloaded.styleeditor', () => this.init())
+                    .on(`stylechange${eventNS}`, (e, detail) => {
+                        if (!detail || !detail.initializing) {
+                            styleChanges = true;
+                            /**
+                             * Change in item style
+                             * @event stylechange
+                             */
+                            this.trigger('stylechange');
+                        }
+                    });
+
+                // add a browser popup to prevent leaving the browser
+                $(window)
+                    .on(`beforeunload${eventNS}`, () => {
+                        if (!asking && this.hasChanged()) {
+                            return messages.leave;
+                        }
+                    })
+                    // since we don't know how to prevent history based events, we just stop the handling
+                    .on('popstate', () => this.uninstall());
+
+                // every click outside the authoring
+                $(wrapperSelector)
+                    .on(`click${eventNS}`, e => {
+                        if (!$.contains(container, e.target) && this.hasChanged()) {
+                            e.stopImmediatePropagation();
+                            e.preventDefault();
+
+                            this.confirmBefore('exit')
+                                .then(() => {
+                                    this.uninstall();
+                                    e.target.click();
+                                })
+                                //do nothing but prevent uncaught error
+                                .catch(() => {});
+                        }
+                    });
+
+                itemCreator
+                    .on(`ready${eventNS} saved${eventNS}`, () => this.init())
+                    .before(`exit${eventNS}`, () => this.confirmBefore('exit').then(() => this.uninstall()))
+                    .before(`preview${eventNS}`, () => this.confirmBefore('preview'));
+
+                return this;
+            },
+
+            /**
+             * Uninstalls the change tracker, unregisters listeners
+             * @returns {changeTracker}
+             */
+            uninstall() {
+                // remove all global handlers
+                $(window.document).off(eventNS);
+                $(window).off(eventNS);
+                $(wrapperSelector).off(eventNS);
+                itemCreator.off(eventNS);
+
+                return this;
+            },
+
+            /**
+             * Displays a confirmation dialog,
+             * The "ok" button will save and resolve.
+             * The "cancel" button will reject.
+             *
+             * @param {String} message - the confirm message to display
+             * @returns {Promise} resolves once saved
+             */
+            confirmBefore(message) {
+                // if a key is given load the related message
+                message = messages[message] || message;
+
+                return new Promise((resolve, reject) => {
+                    if (asking) {
+                        return reject();
+                    }
+
+                    if (!this.hasChanged()) {
+                        return resolve();
+                    }
+
+                    asking = true;
+
+                    const confirmDlg = dialog({
+                        message: message,
+                        buttons: [{
+                            id: 'dontsave',
+                            type: 'regular',
+                            label: __('Don\'t save'),
+                            close: true
+                        }, {
+                            id: 'cancel',
+                            type: 'regular',
+                            label: __('Cancel'),
+                            close: true
+                        }, {
+                            id: 'save',
+                            type: 'info',
+                            label: __('Save'),
+                            close: true
+                        }],
+                        autoRender: true,
+                        autoDestroy: true,
+                        onSaveBtn: () => saveChanges().then(resolve).catch(reject),
+                        onDontsaveBtn: resolve,
+                        onCancelBtn: () => confirmDlg.hide()
+                    })
+                        .on('closed.modal', () => asking = false);
+                });
+            },
+
+            /**
+             * Does the item have changed?
+             * @returns {Boolean}
+             */
+            hasChanged() {
+                if (styleChanges) {
+                    return true;
+                }
+                const currentItem = this.getSerializedItem();
+                return originalItem !== currentItem || (null === currentItem && null === originalItem);
+            },
+
+            /**
+             * Get a string representation of the current item, used for comparison
+             * @returns {String} the item
+             */
+            getSerializedItem() {
+                let serialized = '';
+                try {
+                    // create a string from the item content
+                    serialized = JSON.stringify(itemCreator.getItem().toArray());
+
+                    // sometimes the creator strip spaces between tags, so we do the same
+                    serialized = serialized.replace(/ {2,}/g, ' ');
+                } catch (err) {
+                    serialized = null;
+                }
+                return serialized;
+            }
+        });
+
+        return changeTracker.install();
+    }
+
+    return changeTrackerFactory;
+});

--- a/views/js/qtiCreator/helper/changeTracker.js
+++ b/views/js/qtiCreator/helper/changeTracker.js
@@ -140,6 +140,10 @@ define([
 
                             this.confirmBefore('exit')
                                 .then(() => {
+                                    // @todo improve this:
+                                    // When clicking outside, and accepting the confirm dialog (one way or another),
+                                    // the tracker is disabled, and changes won't be detected anymore. So it could be
+                                    // an issue if the click was not triggering any move.
                                     this.uninstall();
                                     e.target.click();
                                 })

--- a/views/js/qtiCreator/helper/saveChanges.js
+++ b/views/js/qtiCreator/helper/saveChanges.js
@@ -1,0 +1,41 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define(function () {
+    'use strict';
+
+    /**
+     * Saves the changes in the itemCreator and wraps the response in a promise
+     * @param {itemCreator} itemCreator
+     * @returns {Promise}
+     */
+    return itemCreator => new Promise((resolve, reject) => {
+        itemCreator
+            .on('saved.saveChanges', () => {
+                itemCreator.off('.saveChanges');
+                resolve();
+            })
+            .on('error.saveChanges', err => {
+                itemCreator.off('.saveChanges');
+                reject(err);
+            })
+            .trigger('save', true);
+    });
+});

--- a/views/js/qtiCreator/plugins/content/changeTracker.js
+++ b/views/js/qtiCreator/plugins/content/changeTracker.js
@@ -1,4 +1,3 @@
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -23,26 +22,10 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'jquery',
-    'lodash',
-    'i18n',
     'core/plugin',
-    'core/promise',
-    'ui/dialog',
-], function($, _, __, pluginFactory, Promise, dialog){
+    'taoQtiItem/qtiCreator/helper/changeTracker'
+], function (pluginFactory, changeTrackerFactory) {
     'use strict';
-
-    //function to remove all global handlers
-    var removeChangeHandlers;
-
-    /**
-     * The messages asking to save
-     */
-    var messages = {
-        preview : __('The item needs to be saved before it can be previewed'),
-        leave   : __('The item has unsaved changes, are you sure you want to leave ?'),
-        exit    : __('The item has unsaved changes, would you like to save it ?')
-    };
 
     /**
      * Returns the configured plugin
@@ -50,195 +33,24 @@ define([
      */
     return pluginFactory({
 
-        name : 'changeTracker',
+        name: 'changeTracker',
 
         /**
          * Hook to the host's init
          */
-        init : function init(){
-
-            var itemCreator = this.getHost();
-            var $container  = this.getAreaBroker().getContainer();
-
-            //does the item styles have changed
-            var styleChanges = false;
-
-            //are we in the middle of the confirm process ?
-            var asking = false;
-
-            /**
-             * Get a string representation of the current item, used for comparison
-             * @returns {String} the item
-             */
-            var getSerializedItem = function getSerializedItem() {
-                var serialized = '';
-                try {
-                    //create a string from the item content
-                    serialized = JSON.stringify(itemCreator.getItem().toArray());
-
-                    //sometimes the creator strip spaces between tags, so we do the same
-                    serialized = serialized.replace(/ {2,}/g, ' ');
-                } catch(err){
-                    serialized = null;
-                }
-                return serialized;
-            };
-
-            //keep the value of the item before changes
-            var originalItem = getSerializedItem();
-
-            /**
-             * Does the item have changed ?
-             * @returns {Boolean}
-             */
-            var hasChanged  = function hasChanged(){
-                var currentItem;
-                if(styleChanges){
-                    return true;
-                }
-                currentItem = getSerializedItem();
-                return originalItem !== currentItem || (_.isNull(currentItem) && _.isNull(originalItem));
-            };
-
-            /**
-             * Save the current item, quietly (without popup notifications)
-             * @returns {Promise} resolves once saved
-             */
-            var silentSave = function silentSave(){
-                return new Promise(function(resolve){
-                    itemCreator
-                        .on('saved.silent', function(){
-                            this.off('saved.silent');
-                            resolve();
-                        })
-                        .trigger('save', true);
-                });
-            };
-
-            /**
-             * Display a confirmation dialog,
-             * The "ok" button will save and resolve.
-             * The "cancel" button will reject.
-             *
-             * @param {String} message - the confirm message to display
-             * @returns {Promise} resolves once saved
-             */
-            var confirmBefore = function confirmBefore(message){
-                return new Promise(function(resolve, reject){
-                    var confirmDlg;
-                    if(asking){
-                        return reject();
-                    }
-                    if(!hasChanged()){
-                        return resolve();
-                    }
-                    asking = true;
-                    confirmDlg = dialog({
-                        message: message,
-                        buttons:  [{
-                            id : 'dontsave',
-                            type : 'regular',
-                            label : __('Don\'t save'),
-                            close: true
-                        },{
-                            id : 'cancel',
-                            type : 'regular',
-                            label : __('Cancel'),
-                            close: true
-                        }, {
-                            id : 'save',
-                            type : 'info',
-                            label : __('Save'),
-                            close: true
-                        }],
-                        autoRender: true,
-                        autoDestroy: true,
-                        onSaveBtn : function onSaveBtn(){
-                            silentSave().then(resolve);
-                        },
-                        onDontsaveBtn : resolve,
-                        onCancelBtn : function onCancelBtn () {
-                            confirmDlg.hide();
-                        }
-                    })
-                    .on('closed.modal', function(){
-                        asking = false;
-                    });
-                });
-            };
-
-            /**
-             * Just unbind the different handlers
-             */
-            removeChangeHandlers = function removeHandlers(){
-                $(document).off('stylechange.qti-creator');
-                $('.content-wrap').off('.qti-creator');
-                $(window).off("beforeunload.qti-creator");
-            };
-
-            //also track style changes
-            $(document)
-                .one('customcssloaded.styleeditor', function(){
-                    originalItem = getSerializedItem();
-                    styleChanges = false;
-                })
-                .on('stylechange.qti-creator', function (e, detail) {
-                    if(!detail || !detail.initializing){
-                        styleChanges = true;
-                    }
-                });
-
-            $(window)
-                //add a browser popup to prevent leaving the browser
-                .on("beforeunload.qti-creator", function () {
-                    if(!asking && hasChanged()){
-                        return messages.leave;
-                    }
-                })
-                //since we don't know how to prevent history based events,
-                //we just stop the handling
-                .on('popstate', function(){
-                    removeChangeHandlers();
-                });
-
-            //every click outside the authoring
-            $('.content-wrap').on('click.qti-creator', function (e){
-                if(!$.contains($container.get(0), e.target) && hasChanged()){
-                    e.stopImmediatePropagation();
-                    e.preventDefault();
-
-                    confirmBefore(messages.exit)
-                        .then(function(){
-                            removeChangeHandlers();
-                            e.target.click();
-                        })
-                        .catch(_.noop); //do nothing but prevent uncatched error
-                }
-            });
-
-            itemCreator
-                .on('ready saved', function(){
-                    //reset the base item
-                    originalItem = getSerializedItem();
-                    styleChanges = false;
-                })
-                .before('exit', function(){
-                    return confirmBefore(messages.exit)
-                        .then(function(){
-                            removeChangeHandlers();
-                        });
-                })
-                .before('preview', function(){
-                    return confirmBefore(messages.preview);
-                });
+        init() {
+            const itemCreator = this.getHost();
+            const $container = this.getAreaBroker().getContainer();
+            this.changeTracker = changeTrackerFactory($container.get(0), itemCreator, '.content-wrap');
         },
 
         /**
          * Plugin destroy cycle
          */
-        destroy : function destroy(){
-            if(_.isFunction(removeChangeHandlers)){
-                removeChangeHandlers();
+        destroy() {
+            if (this.changeTracker) {
+                this.changeTracker.uninstall();
+                this.changeTracker = null;
             }
         }
     });

--- a/views/js/test/qtiCreator/helper/changeTracker/test.html
+++ b/views/js/test/qtiCreator/helper/changeTracker/test.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test - Change Tracker helper</title>
+        <base href="../../../../../../../tao/views/"/>
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" href="css/tao-main-style.css"/>
+        <link rel="stylesheet" href="css/tao-3.css"/>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiItem/test/qtiCreator/helper/changeTracker/test'], function () {
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="fixture-api"></div>
+            <div id="fixture-hasChanged"></div>
+            <div id="fixture-getSerializedItem"></div>
+            <div id="fixture-stylechange"></div>
+            <div id="fixture-confirmBefore">
+                <div class="editor"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/views/js/test/qtiCreator/helper/changeTracker/test.js
+++ b/views/js/test/qtiCreator/helper/changeTracker/test.js
@@ -156,13 +156,13 @@ define([
         assert.expect(5);
         assert.equal(instance.hasChanged(), false, 'No change yet');
 
-        $(window.document).trigger('stylechange');
+        $(window.document).trigger('stylechange.qti-creator');
         assert.equal(instance.hasChanged(), true, 'Style has changed');
 
         $(window.document).trigger('customcssloaded.styleeditor');
         assert.equal(instance.hasChanged(), false, 'Style is loaded');
 
-        $(window.document).trigger('stylechange', [{initializing: true}]);
+        $(window.document).trigger('stylechange.qti-creator', [{initializing: true}]);
         assert.equal(instance.hasChanged(), false, 'Style not changed');
 
         instance.uninstall();
@@ -204,7 +204,7 @@ define([
 
             // click outside, cancel confirm
             .then(() => new Promise(resolve => {
-                $(window.document).trigger('stylechange');
+                $(window.document).trigger('stylechange.qti-creator');
                 assert.equal(instance.hasChanged(), true, 'Style has changed');
 
                 $fixture
@@ -258,7 +258,7 @@ define([
             // click outside, save and confirm
             .then(() => new Promise(resolve => {
                 instance.install();
-                $(window.document).trigger('stylechange');
+                $(window.document).trigger('stylechange.qti-creator');
                 assert.equal(instance.hasChanged(), true, 'Style changed');
 
                 $fixture
@@ -308,7 +308,7 @@ define([
             // cancel exit
             .then(() => {
                 instance.install();
-                $(window.document).trigger('stylechange');
+                $(window.document).trigger('stylechange.qti-creator');
                 assert.equal(instance.hasChanged(), true, 'Style has changed');
 
                 itemCreator
@@ -365,7 +365,7 @@ define([
             // save and exit
             .then(() => new Promise(resolve => {
                 instance.install();
-                $(window.document).trigger('stylechange');
+                $(window.document).trigger('stylechange.qti-creator');
                 assert.equal(instance.hasChanged(), true, 'Style changed');
 
                 itemCreator
@@ -408,7 +408,7 @@ define([
 
             // cancel preview
             .then(() => {
-                $(window.document).trigger('stylechange');
+                $(window.document).trigger('stylechange.qti-creator');
                 assert.equal(instance.hasChanged(), true, 'Style has changed');
 
                 itemCreator

--- a/views/js/test/qtiCreator/helper/changeTracker/test.js
+++ b/views/js/test/qtiCreator/helper/changeTracker/test.js
@@ -1,0 +1,502 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'core/eventifier',
+    'taoQtiItem/qtiCreator/helper/changeTracker',
+    'json!taoQtiItem/test/samples/json/space-shuttle.json'
+], function ($, _, eventifier, changeTrackerFactory, itemData) {
+    'use strict';
+
+    function itemCreatorFactory(data = null) {
+        const item = _.defaults(data || _.cloneDeep(itemData), {
+            toArray() {
+                return this;
+            }
+        });
+        return eventifier({
+            getItem() {
+                return item;
+            }
+        });
+    }
+
+    QUnit.module('API');
+
+    QUnit.test('module', assert => {
+        const fixture = document.getElementById('fixture-api');
+        const itemCreator = itemCreatorFactory();
+        const instance1 = changeTrackerFactory(fixture, itemCreator);
+        const instance2 = changeTrackerFactory(fixture, itemCreator);
+        assert.expect(3);
+        assert.equal(typeof changeTrackerFactory, 'function', 'The module exposes a function');
+        assert.equal(typeof instance1, 'object', 'The factory produces an object');
+        assert.notStrictEqual(instance1, instance2, 'The factory provides a different object on each call');
+        instance1.uninstall();
+        instance2.uninstall();
+    });
+
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'before'},
+        {title: 'after'},
+        {title: 'trigger'},
+        {title: 'spread'}
+    ]).test('event API ', (data, assert) => {
+        const fixture = document.getElementById('fixture-api');
+        const itemCreator = itemCreatorFactory();
+        const instance = changeTrackerFactory(fixture, itemCreator);
+        assert.expect(1);
+        assert.equal(typeof instance[data.title], 'function', `The instance exposes a "${data.title}" function`);
+        instance.uninstall();
+    });
+
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'install'},
+        {title: 'uninstall'},
+        {title: 'confirmBefore'},
+        {title: 'hasChanged'},
+        {title: 'getSerializedItem'}
+    ]).test('helper API ', (data, assert) => {
+        const fixture = document.getElementById('fixture-api');
+        const itemCreator = itemCreatorFactory();
+        const instance = changeTrackerFactory(fixture, itemCreator);
+        assert.expect(1);
+        assert.equal(typeof instance[data.title], 'function', `The instance exposes a "${data.title}" function`);
+        instance.uninstall();
+    });
+
+    QUnit.module('Behavior');
+
+    QUnit.cases.init([{
+        title: 'not modified',
+        change: {},
+        expected: false
+    }, {
+        title: 'modified',
+        change: {
+            foo: 'bar'
+        },
+        expected: true
+    }, {
+        title: 'wrong item',
+        item: {
+            toArray: null
+        },
+        change: {},
+        expected: true
+    }]).test('hasChanged ', (data, assert) => {
+        const fixture = document.getElementById('fixture-hasChanged');
+        const itemCreator = itemCreatorFactory(data.item);
+        const instance = changeTrackerFactory(fixture, itemCreator);
+
+        Object.assign(itemCreator.getItem(), data.change);
+
+        assert.expect(1);
+        assert.equal(instance.hasChanged(), data.expected, 'The changes in item are properly detected');
+        instance.uninstall();
+    });
+
+    QUnit.cases.init([{
+        title: 'simple',
+        item: {
+            body: '<div>foo <span>bar</span></div>'
+        },
+        expected: '{"body":"<div>foo <span>bar</span></div>"}'
+    }, {
+        title: 'multiple spaces',
+        item: {
+            body: '<div>foo     <span>      bar       </span>      </div>'
+        },
+        expected: '{"body":"<div>foo <span> bar </span> </div>"}'
+    }, {
+        title: 'wrong item',
+        item: {
+            toArray: null
+        },
+        expected: null
+    }]).test('getSerializedItem ', (data, assert) => {
+        const fixture = document.getElementById('fixture-getSerializedItem');
+        const itemCreator = itemCreatorFactory(data.item);
+        const instance = changeTrackerFactory(fixture, itemCreator);
+
+        assert.expect(1);
+        assert.equal(instance.getSerializedItem(), data.expected, 'The item is serialized');
+        instance.uninstall();
+    });
+
+    QUnit.test('stylechange ', assert => {
+        const fixture = document.getElementById('fixture-stylechange');
+        const itemCreator = itemCreatorFactory();
+        const instance = changeTrackerFactory(fixture, itemCreator)
+            .on('stylechange', () => assert.ok(true, 'stylechange event emitted'));
+
+        assert.expect(5);
+        assert.equal(instance.hasChanged(), false, 'No change yet');
+
+        $(window.document).trigger('stylechange');
+        assert.equal(instance.hasChanged(), true, 'Style has changed');
+
+        $(window.document).trigger('customcssloaded.styleeditor');
+        assert.equal(instance.hasChanged(), false, 'Style is loaded');
+
+        $(window.document).trigger('stylechange', [{initializing: true}]);
+        assert.equal(instance.hasChanged(), false, 'Style not changed');
+
+        instance.uninstall();
+    });
+
+    QUnit.test('confirmBefore ', assert => {
+        const ready = assert.async();
+        const modalSelector = '.modal.opened';
+        const fixtureSelector = '#fixture-confirmBefore';
+        const $fixture = $(fixtureSelector);
+        const fixture = document.querySelector(`${fixtureSelector} .editor`);
+        const itemCreator = itemCreatorFactory();
+        const instance = changeTrackerFactory(fixture, itemCreator, fixtureSelector);
+
+        assert.expect(45);
+
+        Promise
+            .resolve()
+
+            // click outside, no change yet
+            .then(() => new Promise(resolve => {
+                assert.equal(instance.hasChanged(), false, 'No change yet');
+
+                $fixture
+                    .off('.test')
+                    .on('click.test', () => {
+                        assert.ok(true, 'The click event has been propagated');
+                    });
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    });
+
+                window.setTimeout(resolve, 200);
+                $fixture.click();
+            }))
+
+            // click outside, cancel confirm
+            .then(() => new Promise(resolve => {
+                $(window.document).trigger('stylechange');
+                assert.equal(instance.hasChanged(), true, 'Style has changed');
+
+                $fixture
+                    .off('.test')
+                    .on('click.test', () => {
+                        assert.ok(false, 'The click event should not be propagated');
+                    });
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    });
+
+                window.setTimeout(() => {
+                    assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - cancel click');
+                    $(modalSelector).find('.cancel').click();
+                    assert.equal($(modalSelector).length, 0, 'The confirm dialog is canceled');
+                    window.setTimeout(resolve, 200);
+                }, 200);
+
+                $fixture.click();
+            }))
+
+            // click outside, confirm without change
+            .then(() => new Promise(resolve => {
+                assert.equal(instance.hasChanged(), true, 'Changes not saved yet');
+
+                $fixture
+                    .off('.test')
+                    .on('click.test', () => {
+                        assert.ok(true, 'The click event should be propagated');
+                    });
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    });
+
+                window.setTimeout(() => {
+                    assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - confirm click without save');
+                    $(modalSelector).find('.dontsave').click();
+                    assert.equal($(modalSelector).length, 0, 'The confirm dialog is closed without save');
+                    window.setTimeout(resolve, 200);
+                }, 200);
+
+                $fixture.click();
+            }))
+
+            // click outside, save and confirm
+            .then(() => new Promise(resolve => {
+                instance.install();
+                $(window.document).trigger('stylechange');
+                assert.equal(instance.hasChanged(), true, 'Style changed');
+
+                $fixture
+                    .off('.test')
+                    .on('click.test', () => {
+                        assert.ok(true, 'The click event should be propagated');
+                    });
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(true, 'The save event has been emitted');
+                        itemCreator.trigger('saved');
+                    })
+                    .after('saved.test', () => {
+                        assert.equal(instance.hasChanged(), false, 'Changes saved');
+                        resolve();
+                    });
+
+                window.setTimeout(() => {
+                    assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - save and confirm click');
+                    $(modalSelector).find('.save').click();
+                    assert.equal($(modalSelector).length, 0, 'The confirm dialog is closed with save');
+                    window.setTimeout(resolve, 200);
+                }, 200);
+
+                $fixture.click();
+            }))
+
+            // exit, no change yet
+            .then(() => new Promise(resolve => {
+                instance.install();
+                assert.equal(instance.hasChanged(), false, 'No change yet');
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    })
+                    .on('exit.test', () => {
+                        assert.ok(true, 'The exit event is emitted');
+                        resolve();
+                    })
+                    .trigger('exit');
+            }))
+
+            // cancel exit
+            .then(() => {
+                instance.install();
+                $(window.document).trigger('stylechange');
+                assert.equal(instance.hasChanged(), true, 'Style has changed');
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    });
+
+                const race = Promise.race([
+                    new Promise(resolve => {
+                        itemCreator
+                            .before('exit.test', () => {
+                                assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - cancel exit');
+                                $(modalSelector).find('.cancel').click();
+                                assert.equal($(modalSelector).length, 0, 'The confirm dialog is canceled');
+                                window.setTimeout(resolve, 200);
+                            });
+                    }),
+                    new Promise(resolve => {
+                        itemCreator
+                            .on('exit.test', () => {
+                                assert.ok(false, 'The exit event should not be emitted');
+                                resolve();
+                            });
+                    })
+                ]);
+
+                itemCreator.trigger('exit');
+
+                return race;
+            })
+
+            // exit without save
+            .then(() => new Promise(resolve => {
+                assert.equal(instance.hasChanged(), true, 'Style still changed');
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    })
+                    .before('exit.test', () => {
+                        assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - exit without save');
+                        $(modalSelector).find('.dontsave').click();
+                        assert.equal($(modalSelector).length, 0, 'The confirm dialog is closed without save');
+                    })
+                    .on('exit.test', () => {
+                        assert.ok(true, 'The exit event has been emitted');
+                        resolve();
+                    })
+                    .trigger('exit');
+            }))
+
+            // save and exit
+            .then(() => new Promise(resolve => {
+                instance.install();
+                $(window.document).trigger('stylechange');
+                assert.equal(instance.hasChanged(), true, 'Style changed');
+
+                itemCreator
+                    .off('.test')
+                    .before('exit.test', () => {
+                        assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - save and exit');
+                        $(modalSelector).find('.save').click();
+                        assert.equal($(modalSelector).length, 0, 'The confirm dialog is closed with save');
+                    })
+                    .on('exit.test', () => {
+                        assert.ok(true, 'The exit event has been emitted');
+                    })
+                    .on('save.test', () => {
+                        assert.ok(true, 'The save event has been emitted');
+                        itemCreator.trigger('saved');
+                    })
+                    .after('saved.test', () => {
+                        assert.equal(instance.hasChanged(), false, 'Changes saved');
+                        resolve();
+                    })
+                    .trigger('exit');
+            }))
+
+            // preview, no change yet
+            .then(() => new Promise(resolve => {
+                instance.install();
+                assert.equal(instance.hasChanged(), false, 'No change yet');
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    })
+                    .on('preview.test', () => {
+                        assert.ok(true, 'The preview event is emitted');
+                        resolve();
+                    })
+                    .trigger('preview');
+            }))
+
+            // cancel preview
+            .then(() => {
+                $(window.document).trigger('stylechange');
+                assert.equal(instance.hasChanged(), true, 'Style has changed');
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    });
+
+                const race = Promise.race([
+                    new Promise(resolve => {
+                        itemCreator
+                            .before('preview.test', () => {
+                                assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - cancel preview');
+                                $(modalSelector).find('.cancel').click();
+                                assert.equal($(modalSelector).length, 0, 'The confirm dialog is canceled');
+                                window.setTimeout(resolve, 200);
+                            });
+                    }),
+                    new Promise(resolve => {
+                        itemCreator
+                            .on('preview.test', () => {
+                                assert.ok(false, 'The preview event should not be emitted');
+                                resolve();
+                            });
+                    })
+                ]);
+
+                itemCreator.trigger('preview');
+
+                return race;
+            })
+
+            // preview without save
+            .then(() => new Promise(resolve => {
+                assert.equal(instance.hasChanged(), true, 'Style still changed');
+
+                itemCreator
+                    .off('.test')
+                    .on('save.test', () => {
+                        assert.ok(false, 'The save event should not be emitted');
+                    })
+                    .before('preview.test', () => {
+                        assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - preview without save');
+                        $(modalSelector).find('.dontsave').click();
+                        assert.equal($(modalSelector).length, 0, 'The confirm dialog is closed without save');
+                    })
+                    .on('preview.test', () => {
+                        assert.ok(true, 'The preview event has been emitted');
+                        resolve();
+                    })
+                    .trigger('preview');
+            }))
+
+            // save and preview
+            .then(() => new Promise(resolve => {
+                assert.equal(instance.hasChanged(), true, 'Style still changed');
+
+                itemCreator
+                    .off('.test')
+                    .before('preview.test', () => {
+                        assert.equal($(modalSelector).length, 1, 'The confirm dialog is open - save and preview');
+                        $(modalSelector).find('.save').click();
+                        assert.equal($(modalSelector).length, 0, 'The confirm dialog is closed with save');
+                    })
+                    .on('preview.test', () => {
+                        assert.ok(true, 'The preview event has been emitted');
+                    })
+                    .on('save.test', () => {
+                        assert.ok(true, 'The save event has been emitted');
+                        itemCreator.trigger('saved');
+                    })
+                    .after('saved.test', () => {
+                        assert.equal(instance.hasChanged(), false, 'Changes saved');
+                        resolve();
+                    })
+                    .trigger('preview');
+            }))
+
+            .catch(err => {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(() => {
+                instance.uninstall();
+                ready();
+            });
+    });
+});

--- a/views/js/test/qtiCreator/helper/saveChanges/test.html
+++ b/views/js/test/qtiCreator/helper/saveChanges/test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test - Save Changes helper</title>
+        <base href="../../../../../../../tao/views/"/>
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" href="css/tao-main-style.css"/>
+        <link rel="stylesheet" href="css/tao-3.css"/>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiItem/test/qtiCreator/helper/saveChanges/test'], function () {
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/qtiCreator/helper/saveChanges/test.js
+++ b/views/js/test/qtiCreator/helper/saveChanges/test.js
@@ -1,0 +1,70 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'core/eventifier',
+    'taoQtiItem/qtiCreator/helper/saveChanges',
+], function (eventifier, saveChanges) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module', assert => {
+        assert.expect(2);
+        assert.equal(typeof saveChanges, 'function', 'The module exposes a function');
+        assert.equal(saveChanges(eventifier()) instanceof Promise, true, 'The factory produces a promise');
+    });
+
+    QUnit.module('Behavior');
+
+    QUnit.test('save success', assert => {
+        const ready = assert.async();
+        const itemCreator = eventifier();
+
+        assert.expect(1);
+        itemCreator.on('save', () => itemCreator.trigger('saved'));
+        saveChanges(itemCreator)
+            .then(() => {
+                assert.ok(true, 'The item is saved');
+            })
+            .catch(() => {
+                assert.ok(false, 'The process should not fail');
+            })
+            .then(ready);
+    });
+
+    QUnit.test('save failure', assert => {
+        const ready = assert.async();
+        const itemCreator = eventifier();
+        const error = new Error('TEST');
+
+        assert.expect(1);
+        itemCreator.on('save', () => itemCreator.trigger('error', error));
+        saveChanges(itemCreator)
+            .then(() => {
+                assert.ok(false, 'The item should not be saved');
+            })
+            .catch(err => {
+                assert.equal(err, error, 'The process must fail');
+            })
+            .then(ready);
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8753

Extract the behavior from the `changeTracker` plugin and place it into shareable helpers.
The purpose is to ease the integration of the `itemCreator` in another context, keeping the changes tracker feature. The original code was converted to ES6, and has also been a little refactored to be more reachable, but the feature should work the same. The plugin is already unit tested, no regression should be added. 

Added unit tests:
- `/taoQtiItem/views/js/test/qtiCreator/helper/changeTracker/test.html`
- `/taoQtiItem/views/js/test/qtiCreator/helper/saveChanges/test.html`

To run the unit tests:
```
cd tao/views/build
npx grunt connect:dev taoqtiitemtest
```

To test in situation, go to the Item Authoring, in the back office. Modify the item, and then try to exit or preview.

Note: there is a known limitation with the change tracker, when you click outside the editor and confirm the exit. If you click again nothing will happen as the tracker has been disabled. This is something that was already present on the former implementation.