### PR TITLE
Fix/tao 8798/gap match pair scoring

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '21.2.1',
+    'version'     => '21.2.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '21.2.1');
+        $this->skip('21.0.0', '21.2.2');
     }
 }

--- a/views/js/qtiCreator/widgets/interactions/helpers/pairScoringForm.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/pairScoringForm.js
@@ -9,9 +9,9 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/forms/response/pairScoreForm',
     'taoQtiItem/qtiCreator/widgets/interactions/helpers/answerState',
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
-    'ui/tooltipster',
+    'ui/tooltip',
     'ui/selecter'
-], function($, _, __, formTpl, pairTpl, answerStateHelper, formElementHelper, tooltipster, selecter){
+], function($, _, __, formTpl, pairTpl, answerStateHelper, formElementHelper, tooltip, selecter){
     'use strict';
 
     //to bind html element to a pair, we use this separator to replace spaces in the pair name.
@@ -95,7 +95,7 @@ define([
 
                     //initialize UI componenets manually
                     selecter($popup);
-                    tooltipster($popup);
+                    tooltip.lookup($popup);
                     deleter($popup);
                     adder($popup);
                 }

--- a/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Map.js
+++ b/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Map.js
@@ -35,8 +35,8 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/forms/response/graphicScoreMappingForm',
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'ui/deleter',
-    'ui/tooltipster'
-], function($, _, __, stateFactory, Map, commonRenderer, instructionMgr, graphicHelper, PciResponse, answerStateHelper, grahicScorePopup, mappingFormTpl, formElement, deleter, tooltipster){
+    'ui/tooltip'
+], function($, _, __, stateFactory, Map, commonRenderer, instructionMgr, graphicHelper, PciResponse, answerStateHelper, grahicScorePopup, mappingFormTpl, formElement, deleter, tooltip){
 
     'use strict';
 
@@ -171,8 +171,8 @@ define([
 
         //set up ui components used by the form
         deleter($container);
-        tooltipster($container);
-        
+        tooltip.lookup($container);
+
         interaction.paper.getById('bg-image-' + interaction.serial).click(function(){
             $('.mapping-editor', $container).hide();
         });


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8798

**Cause of the bug:** misuse of the `ui/tooltip` module from when it was migrated to from `tooltipster`.
**Fix:** use the right syntax and phase out `ui/tooltipster` alias.
**Test:** the map response tooltip overlay can now be opened, used and closed without errors.
**Bonus:** fix applied not just in GapMatch map response mode, but also in Hotspot map response (the only 2 uses of `tooltipster` in the extension).
