### PR TITLE
version bump

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,11 +34,11 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '21.2.2',
+    'version'     => '21.3.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
-        'taoItems' => '>=9.0.0',
-        'tao'      => '>=37.9.0',
+        'taoItems' => '>=9.1.0',
+        'tao'      => '>=38.5.0',
         'generis'  => '>=8.1.3',
     ),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '21.2.2');
+        $this->skip('21.0.0', '21.3.0');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@oat-sa/tao-item-runner": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.3.0.tgz",
-      "integrity": "sha512-KTbHCl5e4+YlOz/GiC8U4/6FvxuAXrgChzKKLVhe61LGfE16HlW1mVM18Degw0wfh1TDPyfCvhRF134cJ/hAmQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.3.1.tgz",
+      "integrity": "sha512-HdrzR5+ZPjvhy0rqyyqdYGNzuJsPM9HDcKRd2Awal65iXKwb2tR5cdI7x3B2WMQJhYkRPz5vuzOpfKML2ypFTA=="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.3.1.tgz",
-      "integrity": "sha512-8HKDA2QCsuAFQw54h94lWIzLyre+Wjjxu2T2PQpwzDs06vJbkKavxC3xuWMBC2WwgYUmbJguiGibbzKY55TOxw=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.4.0.tgz",
+      "integrity": "sha512-6aRpQ34+d49G6gjPLUw+C5RCA9150x3qZ04X9sSEkiVDB6K6DBxqtwMJFAqn3UGruCijJO2rujr1FFM1Fajw0g=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/oat-sa/extension-tao-itemqti.git"
   },
   "dependencies": {
-    "@oat-sa/tao-item-runner": "0.3.0",
-    "@oat-sa/tao-item-runner-qti": "0.3.1"
+    "@oat-sa/tao-item-runner": "0.3.1",
+    "@oat-sa/tao-item-runner-qti": "0.4.0"
   }
 }


### PR DESCRIPTION
Update tao-item-runner-fe to 0.3.1  : 
 - align version with tao-core-libs-fe

Update tao-item-runner-qti-fe to 0.4.0  : 
 - align version with tao-core-libs-fe
 - use `core/modulLoader` to load QTI models in the renderer

Requires : 
 - [x] https://github.com/oat-sa/tao-core/pull/2243
 - [x] https://github.com/oat-sa/extension-tao-item/pull/375