### PR TITLE
Hotfix/tao 8952/Allow to drag and scroll on associate interaction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '20.4.3',
+    'version'     => '20.4.4',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -424,6 +424,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '20.4.3');
+        $this->skip('19.10.0', '20.4.4');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8952

Allows to drag and scroll on the associate interaction.

To test, compile a test that contains an associate interaction (like the QTI Example).
Execute the delivery, and play with the associate interaction, making sure the layout have a scrollbar, then try to drag and go beyond the boundaries.
Without the fix, nothing should happen.
With the fix, the page should scroll automatically.