### PR TITLE
fix/TAO-9085/minChoices and maxChoices can be equal to the size of choices

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '21.3.8',
+    'version'     => '21.3.9',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=9.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '21.3.8');
+        $this->skip('21.0.0', '21.3.9');
     }
 }

--- a/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/Widget.js
@@ -83,9 +83,9 @@ define([
             var $orderList  = $('ul.block-listing', this.$original);
 
             //calculate the number of orderer to display
-            if(max > 0 && max < size){
+            if(max > 0 && max <= size){
                 size = max;
-            } else if(min > 0 && min < size){
+            } else if(min > 0 && min <= size){
                size = min;
             }
     

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-HdrzR5+ZPjvhy0rqyyqdYGNzuJsPM9HDcKRd2Awal65iXKwb2tR5cdI7x3B2WMQJhYkRPz5vuzOpfKML2ypFTA=="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.4.4.tgz",
-      "integrity": "sha512-Y39mIpIv2hdj/evKoe/yOiGARC1TRuWE0yK5lZ30J9LEuouJf+8RT+R1aseD0a7ZYkEyWSBPaWkBAurkGZKG6A=="
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.4.5.tgz",
+      "integrity": "sha512-b9Da9BhcEg5GV2iIoOeEUDXOR95paGf2oosMyY5htlc3bycMMcPy4IzsgpzYEoZfuLmKVVKCIUr/1lcqZiggUA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.3.1",
-    "@oat-sa/tao-item-runner-qti": "0.4.4"
+    "@oat-sa/tao-item-runner-qti": "0.4.5"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9085

**Should be merged after PR: https://github.com/oat-sa/tao-item-runner-qti-fe/pull/22**

The issue:  if `maxChoices = size of choices` then condition `if (max > 0 && max < size) {` didn't match and  `} else if (min > 0 && min < size) {
        size = min;
 }` So the size set in minChoices
https://github.com/oat-sa/tao-item-runner-qti-fe/blob/f7d7bb46f3d9e579dd8011215a942454709d07a7/src/qtiCommonRenderer/renderers/interactions/GraphicOrderInteraction.js#L115-L126
https://github.com/oat-sa/extension-tao-itemqti/blob/02b6cd67f00ffe5e2ca9d1ee2403a2e351e94023/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/Widget.js#L78-L90

Fix:
In calculation, minChoices and maxChoices can be equal to the size of choices.
**Changes in 2 files in `tao-item-runner-qti-fe` and `extension-tao-itemqti`**

How to test:

1. Create an item
2. Drag and Drop a Graphic Order Interaction to the canvas
3. Select the BG
4. Create 2 figures
5. Check the Min and Max choices in "Allowed choices", on the right side, so that Max=1, Min=1
6. In Response mode, choose first figure - figure gets digit 1, second figure - max choices warning
7. In Question mode, modify Max to 2 
8. In Response mode, try to choose one more figure