### PR TITLE
Feature/nex 410 backport updates qti sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "~4.4.1",
+        "oat-sa/lib-tao-qti": "~4.5.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/composer-npm-bridge": "^0.3.0",
         "naneau/semver": "~0.0.7"

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '21.3.11',
+    'version'     => '21.4.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=9.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '21.3.11');
+        $this->skip('21.0.0', '21.4.0');
     }
 }


### PR DESCRIPTION
This PR aims at updating to QTI-SDK legacy 0.18.0 via lib-tao-qti

**Depends on https://github.com/oat-sa/lib-tao-qti/pull/64** and its release 4.5.0