### PR TITLE
TTD-18 missed extending.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '22.0.0',
+    'version'     => '22.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=9.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '22.0.0');
+        $this->skip('21.0.0', '22.0.1');
     }
 }

--- a/test/unit/model/Export/Extractor/Strategy/ColumnStrategyTest.php
+++ b/test/unit/model/Export/Extractor/Strategy/ColumnStrategyTest.php
@@ -3,7 +3,7 @@ namespace oat\taoQtiItem\test\unit\model\Export\Extractor\Strategy;
 
 use oat\taoQtiItem\model\Export\Extractor\HashEntry;
 use oat\taoQtiItem\model\Export\Extractor\Strategy\ColumnStrategy;
-use PHPUnit\Framework\TestCase;
+use oat\generis\test\TestCase;
 
 class ColumnStrategyTest extends TestCase
 {

--- a/test/unit/model/Export/Extractor/Strategy/DefaultStrategyTest.php
+++ b/test/unit/model/Export/Extractor/Strategy/DefaultStrategyTest.php
@@ -4,7 +4,7 @@ namespace oat\taoQtiItem\test\unit\model\Export\Extractor\Strategy;
 
 use oat\taoQtiItem\model\Export\Extractor\HashEntry;
 use oat\taoQtiItem\model\Export\Extractor\Strategy\DefaultStrategy;
-use PHPUnit\Framework\TestCase;
+use oat\generis\test\TestCase;
 
 class DefaultStrategyTest extends TestCase
 {

--- a/test/unit/model/Export/Extractor/Strategy/StrategyFactoryTest.php
+++ b/test/unit/model/Export/Extractor/Strategy/StrategyFactoryTest.php
@@ -6,7 +6,7 @@ use oat\taoQtiItem\model\Export\Extractor\Strategy\DefaultStrategy;
 use oat\taoQtiItem\model\Export\Extractor\Strategy\ColumnStrategy;
 use oat\taoQtiItem\model\Export\Extractor\Strategy\Strategy;
 use oat\taoQtiItem\model\Export\Extractor\Strategy\StrategyFactory;
-use PHPUnit\Framework\TestCase;
+use oat\generis\test\TestCase;
 
 class StrategyFactoryTest extends TestCase
 {

--- a/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
+++ b/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
@@ -2,7 +2,7 @@
 
 namespace oat\taoQtiItem\test\unit\model\flyExporter\simpleExporter;
 
-use PHPUnit\Framework\TestCase;
+use oat\generis\test\TestCase;
 use oat\taoQtiItem\model\flyExporter\simpleExporter\ItemExporter;
 
 class ItemExporterTest extends TestCase


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.