### PR TITLE
added converter of the apip accessibility data (from xml to array)

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '22.1.0',
+    'version'     => '23.0.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=10.1.0',

--- a/manifest.php
+++ b/manifest.php
@@ -37,8 +37,8 @@ return array(
     'version'     => '22.1.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
-        'taoItems' => '>=9.1.0',
-        'tao'      => '>=38.5.0',
+        'taoItems' => '>=10.1.0',
+        'tao'      => '>=40.3.0',
         'generis'  => '>=12.5.0',
     ),
     'models' => array(

--- a/model/QtiJsonItemCompiler.php
+++ b/model/QtiJsonItemCompiler.php
@@ -145,9 +145,12 @@ class QtiJsonItemCompiler extends QtiItemCompiler
      */
     protected function convertXmlAttributes($data) {
 
-        if (is_array($data) && array_key_exists('core', $data)
-            && array_key_exists('apipAccessibility', $data['core'])) {
-
+        if (
+            is_array($data)
+            && array_key_exists('core', $data)
+            && is_array($data['core'])
+            && array_key_exists('apipAccessibility', $data['core'])
+        ) {
             $data['core']['apipAccessibility'] = tao_helpers_Xml::to_array($data['core']['apipAccessibility']);
         }
 

--- a/model/QtiJsonItemCompiler.php
+++ b/model/QtiJsonItemCompiler.php
@@ -140,7 +140,7 @@ class QtiJsonItemCompiler extends QtiItemCompiler
     /**
      * Convert internal parameters to json if needed
      * @param $data
-     * @return array
+     * @return mixed
      * @throws common_exception_Error
      */
     protected function convertXmlAttributes($data) {

--- a/model/qti/AssetParser.php
+++ b/model/qti/AssetParser.php
@@ -112,7 +112,11 @@ class AssetParser
     {
         if (property_exists($this->item, 'apipAccessibility')) {
             try {
-                $assets = tao_helpers_Xml::extractElements('fileHref', $this->item->getApipAccessibility(), 'http://www.imsglobal.org/xsd/apip/apipv1p0/imsapip_qtiv1p0');
+                $assets = tao_helpers_Xml::extractElements(
+                    'fileHref',
+                    $this->item->getApipAccessibility(),
+                    'http://www.imsglobal.org/xsd/apip/apipv1p0/imsapip_qtiv1p0'
+                );
                 foreach ($assets as $asset) {
                     $this->addAsset('apip', $asset);
                 }

--- a/model/qti/AssetParser.php
+++ b/model/qti/AssetParser.php
@@ -21,14 +21,13 @@
 
 namespace oat\taoQtiItem\model\qti;
 
+use common_exception_Error;
 use oat\oatbox\filesystem\Directory;
-use oat\taoQtiItem\model\portableElement\model\PortableModelRegistry;
 use oat\taoQtiItem\model\qti\container\Container;
-use oat\taoQtiItem\model\qti\QtiObject;
 use oat\taoQtiItem\model\qti\interaction\CustomInteraction;
 use oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction;
-use oat\taoQtiItem\model\qti\interaction\ImsPortableCustomInteraction;
 use \SimpleXMLElement;
+use tao_helpers_Xml;
 
 /**
  * Parse and Extract all assets of an item.
@@ -105,7 +104,20 @@ class AssetParser
                 $this->extractXinclude($element);
             }
         }
+        $this->extractApipAccessibilityAssets();
         return $this->assets;
+    }
+
+    private function extractApipAccessibilityAssets()
+    {
+        if (property_exists($this->item, 'apipAccessibility')) {
+            try {
+                $assets = tao_helpers_Xml::extractElements('fileHref', $this->item->getApipAccessibility(), 'http://www.imsglobal.org/xsd/apip/apipv1p0/imsapip_qtiv1p0');
+                foreach ($assets as $asset) {
+                    $this->addAsset('apip', $asset);
+                }
+            } catch (common_exception_Error $e) {}
+        }
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '22.1.0');
+        $this->skip('21.0.0', '23.0.0');
     }
 }

--- a/test/unit/model/QtiJsonItemCompilerTest.php
+++ b/test/unit/model/QtiJsonItemCompilerTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019  (original work) Open Assessment Technologies SA;
+ *
+ * @author Oleksandr Zagovorychev <zagovorichev@gmail.com>
+ */
+namespace oat\taoQtiItem\test\unit\model;
+
+use core_kernel_classes_Resource;
+use Exception;
+use oat\generis\test\TestCase;
+use oat\tao\model\service\ServiceFileStorage;
+use oat\taoQtiItem\model\QtiJsonItemCompiler;
+use PHPUnit_Framework_TestResult;
+use ReflectionClass;
+use ReflectionException;
+
+class QtiJsonItemCompilerTest extends TestCase
+{
+
+    /**
+     * @return array
+     */
+    public function xmlAttributesData()
+    {
+        return [
+            // simple data returns as it is
+            [
+                [
+                    [
+                        'data'
+                    ]
+                ],
+                ['data'],
+            ],
+            [
+                [
+                    '<p>text</p>'
+                ],
+                '<p>text</p>'
+            ],
+            // xml parsed
+            [
+                [
+                    [
+                        'core' => [
+                            'apipAccessibility' => '<p>text</p>',
+                        ],
+                    ]
+                ],
+                [
+                    'core' => [
+                        'apipAccessibility' => [
+                            'text'
+                        ],
+                    ]
+                ]
+            ],
+            // empty tags left on their place
+            [
+                [
+                    [
+                        'core' => [
+                            'apipAccessibility' => '<div><p>text</p><p></p><br/><a> </a></div>',
+                        ],
+                    ]
+                ],
+                [
+                    'core' => [
+                        'apipAccessibility' => [
+                            'p' => [
+                                'text',
+                                []
+                            ],
+                            'br' => [],
+                            'a' => [' ']
+                        ],
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function xmlBadAttributesData()
+    {
+        return [
+            // xml validation
+            [
+                [
+                    [
+                        'core' => [
+                            'apipAccessibility' => 'just a string',
+                        ]
+                    ]
+                ],
+                [
+                    'exception' => [
+                        'class' => Exception::class,
+                        'message' => 'Start tag expected, \'<\' not found [1]'
+                    ]
+                ]
+            ],
+            // no root element
+            [
+                [
+                    [
+                        'core' => [
+                            'apipAccessibility' => '<p>text</p><p></p><br/><a> </a>',
+                        ],
+                    ]
+                ],
+                [
+                    'exception' => [
+                        'class' => Exception::class,
+                        'message' => 'Extra content at the end of the document [1]'
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @return mixed|PHPUnit_Framework_TestResult
+     * @throws ReflectionException
+     */
+    protected function invokeMethod($data)
+    {
+        $class = new ReflectionClass(QtiJsonItemCompiler::class);
+        $method = $class->getMethod('convertXmlAttributes');
+        $method->setAccessible(true);
+        /** @var core_kernel_classes_Resource $resource */
+        $resource = $this->createMock(core_kernel_classes_Resource::class);
+        /** @var ServiceFileStorage $storage */
+        $storage = $this->createMock(ServiceFileStorage::class);
+        $obj = new QtiJsonItemCompiler($resource, $storage);
+        return $method->invokeArgs($obj, $data);
+    }
+
+    /**
+     * @dataProvider xmlAttributesData
+     * @param $data
+     * @param $expected
+     * @throws ReflectionException
+     */
+    public function testConvertXmlAttributes($data, $expected)
+    {
+        $result = $this->invokeMethod($data);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider xmlBadAttributesData
+     * @param $data
+     * @param $expected
+     */
+    public function testExceptionsConvertXmlAttributes($data, $expected)
+    {
+        try {
+            $this->invokeMethod($data);
+        } catch (Exception $e) {
+            $this->assertSame($expected['exception']['class'], get_class($e));
+            $this->assertSame($expected['exception']['message'], $e->getMessage());
+        }
+    }
+}

--- a/test/unit/model/QtiJsonItemCompilerTest.php
+++ b/test/unit/model/QtiJsonItemCompilerTest.php
@@ -20,6 +20,7 @@
  */
 namespace oat\taoQtiItem\test\unit\model;
 
+use common_exception_Error;
 use core_kernel_classes_Resource;
 use Exception;
 use oat\generis\test\TestCase;
@@ -112,7 +113,7 @@ class QtiJsonItemCompilerTest extends TestCase
                 ],
                 [
                     'exception' => [
-                        'class' => Exception::class,
+                        'class' => common_exception_Error::class,
                         'message' => 'Start tag expected, \'<\' not found [1]'
                     ]
                 ]
@@ -128,7 +129,7 @@ class QtiJsonItemCompilerTest extends TestCase
                 ],
                 [
                     'exception' => [
-                        'class' => Exception::class,
+                        'class' => common_exception_Error::class,
                         'message' => 'Extra content at the end of the document [1]'
                     ]
                 ]


### PR DESCRIPTION
### Pull request summary
 
*Related to*: https://oat-sa.atlassian.net/browse/TAO-9799
 
Correct compilation of the APIP items with attached files.
 
#### How to test

Create delivery from the test that has APIP items with media files attached. Make sure that JSON has correct data provided and all media files were copied to the compiled delivery.

Requires :
 - [x] https://github.com/oat-sa/tao-core/pull/2353
 - [x] https://github.com/oat-sa/extension-tao-item/pull/384