### PR TITLE
INV-43: fixed Tooltip issue in the textReaderInteraction for multiline case

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.0.4.1',
+    'version'     => '23.0.4.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.0.4.1');
+        $this->skip('21.0.0', '23.0.4.2');
     }
 }

--- a/views/js/portableLib/OAT/util/tooltip.js
+++ b/views/js/portableLib/OAT/util/tooltip.js
@@ -30,25 +30,11 @@ define([
                 var $target = $(this),
                     $content,
                     contentHtml,
-                    contentId = $target.attr('aria-describedBy'),
-                    qtipPositionTarget = 'event';
+                    contentId = $target.attr('aria-describedBy');
 
                 if (contentId) {
                     $content = $container.find('#' + contentId);
                     if ($content.length) {
-                        var targetHeight = parseInt($target.css('height'), 10),
-                            targetFontSize = parseInt($target.css('fontSize'), 10);
-
-                        /**
-                         * Tooltip may be attached to a phrase which is spread into 2 or more lines. For this case we apply
-                         * position target as a `mouse`. It gives the behavior of following tooltip by the cursor pointer.
-                         * It prevents appearing the tooltip somewhere in the middle of the text between 2 parts of a phrase to
-                         * which it was attached.
-                         */
-                        if ((targetHeight / targetFontSize) >= 2) {
-                            qtipPositionTarget = 'mouse';
-                        }
-
                         contentHtml = $content.html();
 
                         $target.qtip({
@@ -58,7 +44,7 @@ define([
                                 text: contentHtml
                             },
                             position: {
-                                target: qtipPositionTarget,
+                                target: 'mouse',
                                 my: 'bottom center',
                                 at: 'top center'
                             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/INV-43

Applied position mouse behaviour to all tooltip cases: multiline or one-line phrases.

PR: https://github.com/oat-sa/extension-tao-itemqti/pull/1376