### PR TITLE
Fix/tao 9817/eliminated check box cannot be unchecked

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.3.0',
+    'version'     => '23.3.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,6 +434,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.3.0');
+        $this->skip('21.0.0', '23.3.1');
     }
 }

--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -91,7 +91,9 @@ define([
             interaction.toggleClass('eliminable', this.checked);
             // current visual
             widget.$original.toggleClass('eliminable', this.checked);
-
+            if (!this.checked) {
+                widget.$original.find('.eliminated').removeClass('eliminated');
+            }
             // indicate whether this has been unchecked on purpose
             interaction.toggleClass('eliminability-deselected', !this.checked);
         });


### PR DESCRIPTION
**Related to:**
https://oat-sa.atlassian.net/browse/TAO-9817

**Description**
If the “Allow elimination” was enabled and the user has chosen a choice response as eliminated and after that he disabled the “Allow elimination” option and has ticked the check-box that was eliminated before, this check-box cannot be unchecked anymore.

**What to check**: 
1. Create a new Item with choice Interaction 
2. In the Interaction Properties, tick the "Allow elimination" option
3. In the Response tab, eliminate response
4. In the Interaction Properties, uncheck the "Allow elimination" option
5. In the Response tab, tick/uncheck the response

**To run unit tests**
```
cd tao/views/build
npx grunt connect:dev taoqtiitemtest
```

