### PR TITLE
Fix/tao 9844/user moves areas outside the canvas

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.3.1',
+    'version'     => '23.3.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,6 +434,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.3.1');
+        $this->skip('21.0.0', '23.3.2');
     }
 }


### PR DESCRIPTION
**Related to:**
https://oat-sa.atlassian.net/browse/TAO-9844

**Description**
User is not been able select the right order, when user moves areas from Graphic Order Interaction outside the canvas

**Expected result**: User is not been able to move areas from Graphic Order Interaction outside the canvas 

**How to check:**

1. Create new item, for instance with  Graphic Order Interaction.
2. Create area using the Tool Box on the left.
3. Move this area outside the canvas.

**To run unit tests**
```
cd tao/views/build
npx grunt connect:dev taoqtiitemtest
```