### PR TITLE
Fix/UDI-43/change default value for MatchInteraction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.3.5',
+    'version'     => '23.3.6',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,6 +434,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.3.5');
+        $this->skip('21.0.0', '23.3.6');
     }
 }

--- a/views/js/qtiCreator/model/interactions/MatchInteraction.js
+++ b/views/js/qtiCreator/model/interactions/MatchInteraction.js
@@ -16,7 +16,7 @@ define([
         getDefaultAttributes : function(){
             return {
                 'shuffle' : false,
-                'maxAssociations' : 0,
+                'maxAssociations' : 1,
                 'minAssociations' : 0
             };
         },

--- a/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
@@ -42,12 +42,12 @@ define([
         minMaxComponentFactory($form.find('.min-max-panel'), {
             min : {
                 fieldName: 'minAssociations',
-                value:     _.parseInt(interaction.attr('minAssociations')) || 1,
+                value:     _.parseInt(interaction.attr('minAssociations')) || 0,
                 toggler:   false
             },
             max : {
                 fieldName: 'maxAssociations',
-                value:     _.parseInt(interaction.attr('maxAssociations')) || 1,
+                value:     _.parseInt(interaction.attr('maxAssociations')) || 0,
                 toggler:   false
             },
             lowerThreshold : 0,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/UDI-43

How to test:
- Creating match interaction with lots of columns and rows
- Defining match correct response for several choices
-Max =1 and min = 0 numbers of associations are 1 default 
- Change this to 0
- Save
- Go to respond
- Go back to question
- Back to having the value 0