### PR TITLE
fix/UDI-135/Clicking scrollbar "closes" the interaction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.7.1',
+    'version'     => '23.7.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,6 +434,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.7.1');
+        $this->skip('21.0.0', '23.7.2');
     }
 }

--- a/views/js/qtiCreator/widgets/states/Active.js
+++ b/views/js/qtiCreator/widgets/states/Active.js
@@ -32,17 +32,19 @@ define([
             $modalFeedbacksArea = $('#modalFeedbacks'),
             outerContainer = document.querySelector("#item-editor-scroll-outer");
 
-        //move to sleep state by clicking anywhere outside the interaction
-        areaBroker.getContentCreatorPanelArea().on('mousedown.active.' + _widget.serial, function(e){
-            if (
-                container !== e.target
+        function checkIfWidgetShouldSleep(e) {
+            return container !== e.target
                 && !$.contains(container, e.target)
                 && $.contains(outerContainer, e.target) // in case click on scrollbar
                 && (!areaBroker || !areaBroker.getEditorBarArea || !$.contains(areaBroker.getEditorBarArea().get(0), e.target))
                 && (!$modalFeedbacksArea.length || !$.contains($modalFeedbacksArea[0], e.target)) //if click triggered inside the #modalFeedback then state must not be changed.
                 && ($(e.target).data('role') !== 'restore')
-                && !($(e.target).closest('.widget-popup').length)
-            ){
+                && !($(e.target).closest('.widget-popup').length);
+        }
+
+        //move to sleep state by clicking anywhere outside the interaction
+        areaBroker.getContentCreatorPanelArea().on('mousedown.active.' + _widget.serial, function(e){
+            if (checkIfWidgetShouldSleep(e)){
                 _widget.changeState('sleep');
             }
         }).on('beforesave.qti-creator.active', function(){

--- a/views/js/qtiCreator/widgets/states/Active.js
+++ b/views/js/qtiCreator/widgets/states/Active.js
@@ -29,13 +29,15 @@ define([
             container   = _widget.$container[0],
             item        = _widget.element.getRootElement(),
             areaBroker  = _widget.getAreaBroker(),
-            $modalFeedbacksArea = $('#modalFeedbacks');
+            $modalFeedbacksArea = $('#modalFeedbacks'),
+            outerContainer = document.querySelector("#item-editor-scroll-outer");
 
         //move to sleep state by clicking anywhere outside the interaction
         areaBroker.getContentCreatorPanelArea().on('mousedown.active.' + _widget.serial, function(e){
             if (
                 container !== e.target
                 && !$.contains(container, e.target)
+                && $.contains(outerContainer, e.target) // in case click on scrollbar
                 && (!areaBroker || !areaBroker.getEditorBarArea || !$.contains(areaBroker.getEditorBarArea().get(0), e.target))
                 && (!$modalFeedbacksArea.length || !$.contains($modalFeedbacksArea[0], e.target)) //if click triggered inside the #modalFeedback then state must not be changed.
                 && ($(e.target).data('role') !== 'restore')


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/UDI-135

On `mousedown`  event was added a condition: check if click inside the outer container. In case clicking on `scrollbar` it will be outside the outer container.

How to test

1. Create Graphic gap interaction
2. Select response
3. Clicking the scrollbar
4. The Response widget shouldn't close