### PR TITLE
Fix/import shared stimulus outside item directory

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.9.1',
+    'version'     => '23.9.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -577,7 +577,7 @@ class ImportService extends ConfigurableService
 
                 $itemAssetManager->finalize();
 
-                if (isset($sharedStimulusHandler)) {
+                if (isset($sharedStimulusHandler) && $sharedStimulusHandler instanceof SharedStimulusAssetHandler) {
                     $sharedFiles = $sharedStimulusHandler->getSharedFiles();
                 }
                 

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -547,11 +547,7 @@ class ImportService extends ConfigurableService
                 $peHandler = new PortableAssetHandler($qtiModel, $folder, dirname($qtiFile));
                 $itemAssetManager->loadAssetHandler($peHandler);
 
-                if (
-                $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->isInstalled(
-                    'taoMediaManager'
-                )
-                ) {
+                if ($this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->isInstalled('taoMediaManager')) {
                     /** Shared stimulus handler */
                     $sharedStimulusHandler = new SharedStimulusAssetHandler();
                     $sharedStimulusHandler
@@ -581,8 +577,10 @@ class ImportService extends ConfigurableService
 
                 $itemAssetManager->finalize();
 
-                $sharedFiles = $sharedStimulusHandler->getSharedFiles();
-
+                if (isset($sharedStimulusHandler)) {
+                    $sharedFiles = $sharedStimulusHandler->getSharedFiles();
+                }
+                
                 $qtiModel = $this->createQtiItemModel($itemAssetManager->getItemContent(), false);
                 $qtiService->saveDataItemToRdfItem($qtiModel, $rdfItem);
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,6 +434,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.9.1');
+        $this->skip('21.0.0', '23.9.2');
     }
 }


### PR DESCRIPTION
SharedStimulusHandler exists only if taoMediaManager extension is installed.
This fixes the error.