### PR TITLE
Fix/NEC-84/pci instance creation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.9.2',
+    'version'     => '23.9.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,6 +434,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.9.2');
+        $this->skip('21.0.0', '23.9.3');
     }
 }

--- a/views/js/runtime/qtiCustomInteractionContext.js
+++ b/views/js/runtime/qtiCustomInteractionContext.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2020 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
-define(function(){
+define(function() {
     'use strict';
 
     //need a global reference to have pciHooks shared in two different requirejs context ("default" and "portableCustomInteraction")
@@ -31,51 +31,52 @@ define(function(){
         /**
          * register a custom interaction (its runtime model) in global registery
          * register a renderer
-         * 
+         *
          * @param {Object} pciHook
          * @returns {undefined}
          */
-        register : function(pciHook){
-            var typeIdentifier = typeof pciHook.getTypeIdentifier === 'function' ? pciHook.getTypeIdentifier() : pciHook.typeIdentifier;
-            if(typeIdentifier){
+        register(pciHook) {
+            const typeIdentifier =
+                typeof pciHook.getTypeIdentifier === 'function' ? pciHook.getTypeIdentifier() : pciHook.typeIdentifier;
+            if (typeIdentifier) {
                 window._pciHooks[typeIdentifier] = pciHook;
-            }else{
+            } else {
                 throw new Error('invalid PCI hook');
             }
         },
         /**
          * notify when a custom interaction is ready for test taker interaction
-         * 
+         *
          * @param {string} pciInstance
          * @fires custominteractionready
          */
-        notifyReady : function(pciInstance){
+        notifyReady(pciInstance) {
             //@todo add pciIntance as event data and notify event to delivery engine
         },
         /**
          * notify when a custom interaction is completed by test taker
-         * 
+         *
          * @param {string} pciInstance
          * @fires custominteractiondone
          */
-        notifyDone : function(pciInstance){
+        notifyDone(pciInstance) {
             //@todo add pciIntance as event data and notify event to delivery engine
         },
 
-        onready : function onready(customInteraction, state){
+        onready(customInteraction, state) {
             //to be implemented in future story
         },
-        ondone : function ondone(customInteraction, response, state, status){
+        ondone(customInteraction, response, state, status) {
             //to be implemented in future story
         },
 
         /**
          * Get a cloned object representing the PCI model
-         * 
+         *
          * @param {string} pciTypeIdentifier
          * @returns {Object} clonedPciModel
          */
-        createPciInstance: function(pciTypeIdentifier) {
+        createPciInstance(pciTypeIdentifier) {
             const registeredPCI = window._pciHooks[pciTypeIdentifier];
 
             if (!registeredPCI) {

--- a/views/js/runtime/qtiCustomInteractionContext.js
+++ b/views/js/runtime/qtiCustomInteractionContext.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2020 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
-define(function() {
+define(['lodash'], function(_) {
     'use strict';
 
     //need a global reference to have pciHooks shared in two different requirejs context ("default" and "portableCustomInteraction")
@@ -83,7 +83,7 @@ define(function() {
                 throw new Error('no portable custom interaction hook found with the id ' + pciTypeIdentifier);
             }
 
-            return Object.assign({}, registeredPCI);
+            return _.cloneDeep(registeredPCI);
         }
     };
 });

--- a/views/js/runtime/qtiCustomInteractionContext.js
+++ b/views/js/runtime/qtiCustomInteractionContext.js
@@ -76,7 +76,7 @@ define(function(){
          * @returns {Object} clonedPciModel
          */
         createPciInstance: function(pciTypeIdentifier) {
-            var registeredPCI = window._pciHooks[pciTypeIdentifier];
+            const registeredPCI = window._pciHooks[pciTypeIdentifier];
 
             if (!registeredPCI) {
                 throw new Error('no portable custom interaction hook found with the id ' + pciTypeIdentifier);

--- a/views/js/runtime/qtiCustomInteractionContext.js
+++ b/views/js/runtime/qtiCustomInteractionContext.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2020 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
 define(function(){
@@ -75,31 +75,14 @@ define(function(){
          * @param {string} pciTypeIdentifier
          * @returns {Object} clonedPciModel
          */
-        createPciInstance : function(pciTypeIdentifier){
+        createPciInstance: function(pciTypeIdentifier) {
+            var registeredPCI = window._pciHooks[pciTypeIdentifier];
 
-            if(window._pciHooks[pciTypeIdentifier]){
-
-                var instance = {},
-                    proto = window._pciHooks[pciTypeIdentifier];
-
-                for(var name in proto){
-                    if(typeof proto[name] === 'function'){
-                        //@todo : delegate function call for better performance ?
-                        instance[name] = proto[name];
-                    }else if(proto[name] !== null && typeof proto[name] === 'object'){
-                        //a plain object:
-                        instance[name] = proto[name].constructor();
-                    }else{
-                        //not an object (nor a function) : e.g. 0, 123, '123', null, undefined
-                        instance[name] = proto[name];
-                    }
-                }
-
-                return instance;
-
-            }else{
+            if (!registeredPCI) {
                 throw new Error('no portable custom interaction hook found with the id ' + pciTypeIdentifier);
             }
+
+            return Object.assign({}, registeredPCI);
         }
     };
 });


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NEC-84
**Description:** The problem is all PCI properties with Object type are overrides by empty Object.
**Requires:** https://github.com/oat-sa/extension-tao-itemqti-pci/pull/193
**How to test:** 
- Install `extension-tao-itemqti-pci` version [fix/TAO-10102/liquid-interaction-preview](https://github.com/oat-sa/extension-tao-itemqti-pci/pull/193)
- Create item with liquids interaction
- Open item in preview 
- Click "Submit" button without item interaction
- Expected behavior: There are no errors in console

**Unit tests cli:** `npx grunt connect:test taoqtiitemtest`