### PR TITLE
BOSA 36 - Hidden tooltip when pattern mask matches with 0 value 

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.9.3',
+    'version'     => '23.9.4',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -434,6 +434,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('21.0.0');
         }
 
-        $this->skip('21.0.0', '23.9.3');
+        $this->skip('21.0.0', '23.9.4');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-Z/fRV8TSxitZwO40zeL8T+pLbxoqp5L2dDqWf+0kPOV3Guf2juP1eXZygiXhwmHHOTgwpSeKSC0sOJJATsL5xQ=="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.4.18.tgz",
-      "integrity": "sha512-gLiMNqsGSs82UhtCuYIdsCf1IA94sHIyEsBrKKyb90sJF++W5pw8+2xb95+RGmB+k+R1cnjDj5IgsIejAswyOw=="
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.4.19.tgz",
+      "integrity": "sha512-scjmtp1LEZyyhzwz5LKjZ/0BO47cC3KjWrzoZGfaAKZW3bn8zJpbTCI5aDQDOD8A3FPBfHY0IFs87jsHyG4CWA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.4.0",
-    "@oat-sa/tao-item-runner-qti": "0.4.19"
+    "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/BOSA-36/text-entry-pattermask"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.4.0",
-    "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/BOSA-36/text-entry-pattermask"
+    "@oat-sa/tao-item-runner-qti": "0.4.19"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.4.0",
-    "@oat-sa/tao-item-runner-qti": "0.4.18"
+    "@oat-sa/tao-item-runner-qti": "0.4.19"
   }
 }


### PR DESCRIPTION
**Blocked by**

https://github.com/oat-sa/tao-item-runner-qti-fe/pull/60

**Related to**

https://oat-sa.atlassian.net/browse/BOSA-36

**Description**

Inline text entry, when you click on the hole in the text, it appears directly "This is not a valid answer": even though you haven't written anything yet. This appears when you select a pattern mask that matches 0 value.

![imagen](https://user-images.githubusercontent.com/34692207/78665139-a207aa80-78d5-11ea-886a-607de31e13bf.png)
