### PR TITLE
Pattern mask message field for inline text interaction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.10.1',
+    'version'     => '23.11.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -445,6 +445,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('23.10.0');
         }
 
-        $this->skip('23.10.0', '23.10.1');
+        $this->skip('23.10.0', '23.11.0');
     }
 }

--- a/views/js/qtiCreator/tpl/forms/interactions/textEntry.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/textEntry.tpl
@@ -28,24 +28,36 @@
 </div>
 
 <div class="panel extendedText">
+
     {{!-- Let the user enter his own pattern --}}
-    <div class="constraint constraint-pattern" {{#unless constraints.pattern.selected}}style="display:none"{{/unless}}>
-        <label>
-            {{__ "Pattern"}}
-        </label>
+    <div class="panel constraint constraint-pattern" {{#unless constraints.pattern.selected}}style="display:none"{{/unless}}>
+
+        <label>{{__ "Pattern"}}</label>
+
         <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
         <span class="tooltip-content">{{__ "If given, the pattern mask specifies a regular expression that the candidate's response must match in order to be considered valid"}}</span>
         <input type="text" name="patternMask" value="{{#if patternMask}}{{patternMask}}{{/if}}"/>
     </div>
+
+    <div class="panel constraint constraint-pattern" {{#unless constraints.pattern.selected}}style="display:none"{{/unless}}>
+
+        <label>{{__ "Pattern instrustion"}}</label>
+
+        <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+        <span class="tooltip-content">{{__ "User-frendly message to inform the test takers about the required format (pattern)"}}</span>
+        <input type="text" name="patternMaskMessage" value="{{#if patternMaskMessage}}{{patternMaskMessage}}{{/if}}"/>
+    </div>
+
     {{!-- Use the patternMask w/ a regex controlled by thoses UI components --}}
-    <div class="constraint constraint-maxLength" {{#unless constraints.maxLength.selected}}style="display:none"{{/unless}}>
-        <label class="spinner">
-            {{__ "Max length"}}
-        </label>
+    <div class="panel constraint constraint-maxLength" {{#unless constraints.maxLength.selected}}style="display:none"{{/unless}}>
+
+        <label class="spinner">{{__ "Max length"}}</label>
+
         <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
         <span class="tooltip-content">{{__ "We will use the patternMask to do this, to be compliant with the IMS standard"}}</span>
-        <input type="text" data-min="0" data-increment="1" class="incrementer" name="maxLength" {{#if maxLength}}value="{{maxLength}}"{{/if}} />
+        <input type="text" name="maxLength" data-min="0" data-increment="1" class="incrementer" {{#if maxLength}}value="{{maxLength}}"{{/if}} />
     </div>
+
 </div>
 
 <hr>

--- a/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Question.js
@@ -29,12 +29,13 @@ define([
     var TextEntryInteractionStateQuestion = stateFactory.extend(Question);
 
     TextEntryInteractionStateQuestion.prototype.initForm = function(){
-        
+
         var _widget = this.widget,
             $form = _widget.$form,
             $inputs,
             interaction = _widget.element,
             patternMask = interaction.attr('patternMask'),
+            patternMaskMessage = interaction.attr('data-pattermask-message'),
             maxChars = parseInt(patternMaskHelper.parsePattern(patternMask,'chars'), 10);
 
         var constraints = {
@@ -57,6 +58,7 @@ define([
             expectedLength : parseInt(interaction.attr('expectedLength')),
             constraints : constraints,
             patternMask : patternMask,
+            patternMaskMessage : patternMaskMessage,
             maxLength : maxChars,
         }));
 
@@ -64,7 +66,8 @@ define([
 
         $inputs = {
             maxLength : $form.find('[name="maxLength"]'),
-            patternMask : $form.find('[name="patternMask"]')
+            patternMask : $form.find('[name="patternMask"]'),
+            patternMaskMessage : $form.find('[name="patternMaskMessage"]')
         };
 
         formElement.setChangeCallbacks($form, interaction, {
@@ -86,6 +89,9 @@ define([
                 interaction.attr('patternMask', attrValue);
                 //If anything is entered inside the patternMask, reset maxLength
                 $inputs.maxLength.val('');
+            },
+            patternMaskMessage : function patternMaskMessage(interaction, attrValue) {
+                interaction.attr('data-pattermask-message', attrValue);
             },
             maxLength : function maxLength(interaction, attrValue){
                 var newValue = parseInt(attrValue,10);


### PR DESCRIPTION
The task is here https://oat-sa.atlassian.net/browse/BSA-101

This change introduces a new text field that allows to enter and store the custom message for pattern mask validation rule. Validation is not implemented here, but message can be edited and also stored in the Item file.