### PR TITLE
Fix/tca 389/fix issue in item content backup during import

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '24.0.1',
+    'version'     => '24.1.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.6.0',

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'version'     => '24.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
-        'taoItems' => '>=10.5.0',
+        'taoItems' => '>=10.6.0',
         'tao'      => '>=41.6.0',
         'generis'  => '>=12.17.0',
     ],

--- a/model/qti/Service.php
+++ b/model/qti/Service.php
@@ -288,7 +288,7 @@ class Service extends ConfigurableService
 
             return $oldItemContentPropertyValues;
         } catch (Exception $e) {
-            common_Logger::e('Item content backup failed: ' . $e->getMessage());
+            $this->logError('Item content backup failed: ' . $e->getMessage());
             throw new common_Exception("QTI Item backup failed. Item uri - " . $item->getUri());
         }
     }
@@ -306,7 +306,7 @@ class Service extends ConfigurableService
                 $item->editPropertyValueByLg($itemContentProperty, $itemContentPropertyValue, $language);
             }
         } catch (Exception $e) {
-            common_Logger::e('Rollback item error: ' . $e->getMessage());
+            $this->logError('Rollback item error: ' . $e->getMessage());
             throw new common_Exception(sprintf('Cannot rollback item. Item uri - %s :: Backup folders - %s ', $item->getUri(), json_encode($backUpNames)));
         }
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -471,6 +471,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('23.12.0');
         }
 
-        $this->skip('23.12.0', '24.0.1');
+        $this->skip('23.12.0', '24.1.0');
     }
 }

--- a/test/unit/model/qti/QtiItemServiceTest.php
+++ b/test/unit/model/qti/QtiItemServiceTest.php
@@ -17,6 +17,8 @@
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  */
 
+declare(strict_types=1);
+
 namespace oat\taoQtiItem\test\unit\model;
 
 use Exception;
@@ -33,7 +35,7 @@ use taoItems_models_classes_ItemsService;
 use oat\generis\test\TestCase;
 use oat\taoQtiItem\model\qti\Service;
 
-class ServiceTest extends TestCase
+class QtiItemServiceTest extends TestCase
 {
     /**
      * @var Service

--- a/test/unit/model/qti/ServiceTest.php
+++ b/test/unit/model/qti/ServiceTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoQtiItem\test\unit\model;
+
+use Exception;
+use common_Exception;
+use core_kernel_classes_ContainerCollection;
+use core_kernel_classes_Literal;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use oat\generis\model\fileReference\FileReferenceSerializer;
+use oat\generis\test\MockObject;
+use oat\oatbox\filesystem\Directory;
+use Psr\Log\LoggerInterface;
+use taoItems_models_classes_ItemsService;
+use oat\generis\test\TestCase;
+use oat\taoQtiItem\model\qti\Service;
+
+class ServiceTest extends TestCase
+{
+    /**
+     * @var Service
+     */
+    private $qtiService;
+
+    /**
+     * @var taoItems_models_classes_ItemsService|MockObject
+     */
+    private $itemServiceMock;
+
+    /**
+     * @var FileReferenceSerializer|MockObject
+     */
+    private $fileSerializerMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->itemServiceMock = $this->createMock(taoItems_models_classes_ItemsService::class);
+        $this->fileSerializerMock = $this->createMock(FileReferenceSerializer::class);
+
+        $slMock = $this->getServiceLocatorMock([
+            taoItems_models_classes_ItemsService::class => $this->itemServiceMock,
+            FileReferenceSerializer::SERVICE_ID => $this->fileSerializerMock
+        ]);
+
+        $this->qtiService = new Service();
+        $this->qtiService->setServiceLocator($slMock);
+        $this->qtiService->setLogger($this->getLoggerMock());
+    }
+
+    public function testBackupContentByRdfItemThrowsExceptionWhenBackupFailed(): void
+    {
+        self::expectException(common_Exception::class);
+
+        $this->itemServiceMock->method('getItemContentProperty')
+            ->willThrowException(new Exception('TEST_EXCEPTION'));
+
+        $item = $this->getItemMock();
+        $this->qtiService->backupContentByRdfItem($item);
+    }
+
+    public function testBackupContentByRdfItemReturnsOldDirectories(): void
+    {
+        // Mock item content directory for each language.
+        $itemContentPropertyMock = $this->getItemContentPropertyMock();
+        $this->itemServiceMock->method('getItemContentProperty')
+            ->willReturn($itemContentPropertyMock);
+        $propertyValue1 = new core_kernel_classes_Literal('DIRECTORY_1');
+        $propertyValue2 = new core_kernel_classes_Literal('DIRECTORY_2');
+        $propertiesCollection1 = $this->createMock(core_kernel_classes_ContainerCollection::class);
+        $propertiesCollection1->method('get')
+            ->willReturn($propertyValue1);
+        $propertiesCollection2 = $this->createMock(core_kernel_classes_ContainerCollection::class);
+        $propertiesCollection2->method('get')
+            ->willReturn($propertyValue2);
+
+
+        $this->configureItemServiceMockToReturnItemContentDirectory();
+        $this->fileSerializerMock->expects(self::exactly(2))
+            ->method('serialize')
+            ->willReturnOnConsecutiveCalls(
+                "SERIALIZED_DIRECTORY_1",
+                "SERIALIZED_DIRECTORY_2"
+            );
+
+        // Mock item methods to return property languages and values.
+        $propertyLanguages = ['LANGUAGE_1', 'LANGUAGE_2'];
+        $item = $this->getItemMock();
+        $item->method('getUsedLanguages')
+            ->willReturn($propertyLanguages);
+        $item->expects(self::exactly(2))
+            ->method('getPropertyValuesByLg')
+            ->willReturnOnConsecutiveCalls(
+                $propertiesCollection1,
+                $propertiesCollection2
+            );
+        $item->expects(self::exactly(2))
+            ->method('editPropertyValueByLg')
+            ->withConsecutive(
+                [$itemContentPropertyMock, 'SERIALIZED_DIRECTORY_1', 'LANGUAGE_1'],
+                [$itemContentPropertyMock, 'SERIALIZED_DIRECTORY_2', 'LANGUAGE_2']
+            );
+
+        $itemContentBackup = $this->qtiService->backupContentByRdfItem($item);
+
+        self::assertIsArray($itemContentBackup, 'Method must return an array.');
+        self::assertArrayHasKey('LANGUAGE_1', $itemContentBackup, 'Result must contain old directory name for each language.');
+        self::assertArrayHasKey('LANGUAGE_2', $itemContentBackup, 'Result must contain old directory name for each language.');
+        self::isTrue(in_array('DIRECTORY_1', $itemContentBackup), 'Returned backup must contain all previous item content nt directories');
+        self::isTrue(in_array('DIRECTORY_2', $itemContentBackup), 'Returned backup must contain all previous item content nt directories');
+    }
+
+    public function testRestoreContentByRdfItemThrowsException(): void
+    {
+        self::expectException(common_Exception::class);
+
+        $this->itemServiceMock->method('getItemContentProperty')
+            ->willThrowException(new Exception('TEST_EXCEPTION'));
+
+        $item = $this->getItemMock();
+        $backupNames = [];
+
+        $this->qtiService->restoreContentByRdfItem($item, $backupNames);
+    }
+
+    public function testRestoreContentByRdfItemUpdatesContentPropertyValues(): void
+    {
+        $backupNames = [
+            'LANGUAGE_1' => 'BACKUP_DIRECTORY_1',
+            'LANGUAGE_2' => 'BACKUP_DIRECTORY_2',
+        ];
+
+        $itemContentPropertyMock = $this->getItemContentPropertyMock();
+        $this->itemServiceMock->method('getItemContentProperty')
+            ->willReturn($itemContentPropertyMock);
+
+        $item = $this->getItemMock();
+        $item->expects(self::exactly(2))
+            ->method('editPropertyValueByLg')
+            ->withConsecutive(
+                [$itemContentPropertyMock, 'BACKUP_DIRECTORY_1', 'LANGUAGE_1'],
+                [$itemContentPropertyMock, 'BACKUP_DIRECTORY_2', 'LANGUAGE_2']
+            );
+
+        $this->qtiService->restoreContentByRdfItem($item, $backupNames);
+    }
+
+    private function getLoggerMock(): LoggerInterface
+    {
+        return $this->createMock(LoggerInterface::class);
+    }
+
+    /**
+     * @return core_kernel_classes_Property|MockObject
+     */
+    private function getItemContentPropertyMock(): core_kernel_classes_Property
+    {
+        return $this->createMock(core_kernel_classes_Property::class);
+    }
+
+    /**
+     * @return core_kernel_classes_Resource|MockObject
+     */
+    private function getItemMock(): core_kernel_classes_Resource
+    {
+        return $this->createMock(core_kernel_classes_Resource::class);
+    }
+
+    private function configureItemServiceMockToReturnItemContentDirectory(): void
+    {
+        $this->itemServiceMock->method('composeItemDirectoryPath')
+            ->willReturn('NEW PATH');
+        $defaulItemDirectoryMock = $this->createMock(Directory::class);
+        $defaulItemDirectoryMock->method('getDirectory')
+            ->willReturn($this->createMock(Directory::class));
+        $this->itemServiceMock->method('getDefaultItemDirectory')
+            ->willReturn($defaulItemDirectoryMock);
+    }
+}
+


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TCA-389

Problem:
QTI APIP item import fails when there is item with the same identifier and we have to overwrite it. During import we try to backup all item's files and with S3 flysystem adapter it fails randomly when we move files to new directory. 

Solution:
Instead of moving files update item's http://www.tao.lu/Ontologies/TAOItem.rdf#ItemContent property to point to the new directory.

How to test:
- Import QTI item.
- Import the same item again using API `/taoQtiItem/RestQtiItem/importDeferred` with IBN guardian configured and following API request parameters:
`enableMetadataGuardians:true`
`enableMetadataValidators:true`
`itemMustExist:false`
`itemMustBeOverwritten:true`   


Requires: https://github.com/oat-sa/extension-tao-item/pull/399