### PR TITLE
[WIP] Fix/nsa 97/prevent pci libs set jquery globally

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '23.12.1',
+    'version'     => '23.12.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '24.0.2',
+    'version'     => '24.1.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -471,6 +471,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('23.12.0');
         }
 
-        $this->skip('23.12.0', '23.12.1');
+        $this->skip('23.12.0', '23.12.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -471,6 +471,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('23.12.0');
         }
 
-        $this->skip('23.12.0', '24.0.2');
+        $this->skip('23.12.0', '24.1.0');
     }
 }

--- a/views/js/legacyPortableSharedLib/jquery_2_1_1.js
+++ b/views/js/legacyPortableSharedLib/jquery_2_1_1.js
@@ -48,7 +48,7 @@ define(function() {
 				return factory( w );
 			};
 	} else {
-		factory( global );
+		factory( global, true );
 	}
 
 // Pass this if window is not defined yet

--- a/views/js/legacyPortableSharedLib/jquery_2_1_1.js
+++ b/views/js/legacyPortableSharedLib/jquery_2_1_1.js
@@ -48,7 +48,7 @@ define(function() {
 				return factory( w );
 			};
 	} else {
-		factory( global, true );
+		factory(global);
 	}
 
 // Pass this if window is not defined yet
@@ -9206,6 +9206,8 @@ return jQuery;
 
 }));
 
-// END JQUERY SOURCE
-return jQuery.noConflict(true);
+    // END JQUERY SOURCE
+    var dom = {};
+    dom.query = jQuery.noConflict(true);
+    return dom.query;
 });

--- a/views/js/legacyPortableSharedLib/jquery_2_1_1.js
+++ b/views/js/legacyPortableSharedLib/jquery_2_1_1.js
@@ -48,7 +48,7 @@ define(function() {
 				return factory( w );
 			};
 	} else {
-		factory(global);
+		factory( global, true );
 	}
 
 // Pass this if window is not defined yet
@@ -9207,7 +9207,5 @@ return jQuery;
 }));
 
     // END JQUERY SOURCE
-    var dom = {};
-    dom.query = jQuery.noConflict(true);
-    return dom.query;
+    return jQuery.noConflict(true);
 });

--- a/views/js/portableLib/jquery_2_1_1.js
+++ b/views/js/portableLib/jquery_2_1_1.js
@@ -48,7 +48,7 @@ define(function() {
 				return factory( w );
 			};
 	} else {
-		factory( global );
+		factory( global, true );
 	}
 
 // Pass this if window is not defined yet

--- a/views/js/portableLib/jquery_2_1_1.js
+++ b/views/js/portableLib/jquery_2_1_1.js
@@ -48,7 +48,7 @@ define(function() {
 				return factory( w );
 			};
 	} else {
-		factory( global );
+		factory( global, true );
 	}
 
 // Pass this if window is not defined yet
@@ -9207,7 +9207,5 @@ return jQuery;
 }));
 
 // END JQUERY SOURCE
-var dom = {};
-dom.query = jQuery.noConflict(true);
-return dom.query;
+return jQuery.noConflict(true);
 });

--- a/views/js/portableLib/jquery_2_1_1.js
+++ b/views/js/portableLib/jquery_2_1_1.js
@@ -48,7 +48,7 @@ define(function() {
 				return factory( w );
 			};
 	} else {
-		factory( global, true );
+		factory( global );
 	}
 
 // Pass this if window is not defined yet
@@ -9207,5 +9207,7 @@ return jQuery;
 }));
 
 // END JQUERY SOURCE
-return jQuery.noConflict(true);
+var dom = {};
+dom.query = jQuery.noConflict(true);
+return dom.query;
 });


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NSA-97
**Description:** The global jQuery is overridden by jQuery from PCI.
PCI shouldn't expose anything to the global scope.
 
**How to test:** Create test with PCI and check in browser dev console `jQuery.fn.jquery` version
The version must to be `1.9.1`