### PR TITLE
Fix/REF-83/removing expected length and expected lines

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '24.1.1',
+    'version'     => '24.1.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -471,6 +471,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('23.12.0');
         }
 
-        $this->skip('23.12.0', '24.1.1');
+        $this->skip('23.12.0', '24.1.2');
     }
 }

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -188,17 +188,17 @@ define([
             var newValue = parseInt(attrValue,10);
             if(! isNaN(newValue)){
                 interaction.attr('expectedLength', attrValue);
-            }else{
-                interaction.attr('expectedLength', -1);//invalid qti, 0
+            } else {
+                interaction.removeAttr('expectedLength');
             }
         };
 
-        callbacks.expectedLines = function(interactions, attrValue){
+        callbacks.expectedLines = function(interaction, attrValue){
             var newValue = parseInt(attrValue,10);
             if(! isNaN(newValue)){
                 interaction.attr('expectedLines', attrValue);
-            }else{
-                interaction.attr('expectedLines',-1);//invalid qti, 0
+            } else {
+                interaction.removeAttr('expectedLines');
             }
         };
 

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -184,23 +184,18 @@ define([
             interaction.attr('patternMask', attrValue);
         };
 
-        callbacks.expectedLength = function(interaction, attrValue){
+        function setAttributes (attribute, interaction, attrValue) {
             var newValue = parseInt(attrValue,10);
             if(! isNaN(newValue)){
-                interaction.attr('expectedLength', attrValue);
+                interaction.attr(attribute, attrValue);
             } else {
-                interaction.removeAttr('expectedLength');
+                interaction.removeAttr(attribute);
             }
         };
 
-        callbacks.expectedLines = function(interaction, attrValue){
-            var newValue = parseInt(attrValue,10);
-            if(! isNaN(newValue)){
-                interaction.attr('expectedLines', attrValue);
-            } else {
-                interaction.removeAttr('expectedLines');
-            }
-        };
+        callbacks.expectedLength = setAttributes.bind(null, 'expectedLength');
+
+        callbacks.expectedLines = setAttributes.bind(null, 'expectedLines');
 
         formElement.setChangeCallbacks($form, interaction, callbacks);
     };

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,9 @@
       "integrity": "sha512-Z/fRV8TSxitZwO40zeL8T+pLbxoqp5L2dDqWf+0kPOV3Guf2juP1eXZygiXhwmHHOTgwpSeKSC0sOJJATsL5xQ=="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.7.0"
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.7.0.tgz",
+      "integrity": "sha512-rrFAwDNSE4vGPzZjQ8okj1z7q7nLuAo9WSRSgkQfS7dsc/Ex5ca5FVqRyB6lKsThx9rLmbknBl55gwSZ/yHUuQ=="
     }
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/REF-83

In case of empty value in input `Length` or `Lines` remove related attributes from the interaction.

How to test:

- Add Extended Text interaction to the canvas
- Set value for Length or Lines in Interaction Properties then 
- Delete the value (set in step 2)
- Click Save