### PR TITLE
[WIP] Fix/NSA-102/ Prevent overridden jQuery from PIC/PCI

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '24.1.1',
+    'version'     => '24.2.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -471,6 +471,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('23.12.0');
         }
 
-        $this->skip('23.12.0', '24.1.1');
+        $this->skip('23.12.0', '24.2.0');
     }
 }

--- a/views/js/legacyPortableSharedLib/jquery_2_1_1.js
+++ b/views/js/legacyPortableSharedLib/jquery_2_1_1.js
@@ -11,7 +11,7 @@
  * of jQuery.
  */
 
-define(function() {
+define(function(require, exports, module) {
 
 // BEGIN JQUERY SOURCE
 

--- a/views/js/legacyPortableSharedLib/jquery_2_1_1.js
+++ b/views/js/legacyPortableSharedLib/jquery_2_1_1.js
@@ -1,9 +1,4 @@
 /**
- * JEROME's note:
- * 
- * The only change in jQuery source is the comment added from
- * l. 9190 to l. 9192.
- *
  * Wrapped into a define call with no dependency to scope
  * the whole source code and get rid of the window.$ and window.jQuery.
  *
@@ -12,9 +7,6 @@
  */
 
 define(function(require, exports, module) {
-
-// BEGIN JQUERY SOURCE
-
 /*!
  * jQuery JavaScript Library v2.1.1
  * http://jquery.com/
@@ -9199,13 +9191,7 @@ if ( typeof noGlobal === strundefined ) {
 	window.jQuery = window.$ = jQuery;
 }
 
-
-
-
 return jQuery;
 
 }));
-
-// END JQUERY SOURCE
-return jQuery.noConflict(true);
 });

--- a/views/js/portableLib/jquery_2_1_1.js
+++ b/views/js/portableLib/jquery_2_1_1.js
@@ -11,7 +11,7 @@
  * of jQuery.
  */
 
-define(function() {
+define(function(require, exports, module) {
 
 // BEGIN JQUERY SOURCE
 

--- a/views/js/portableLib/jquery_2_1_1.js
+++ b/views/js/portableLib/jquery_2_1_1.js
@@ -1,9 +1,4 @@
 /**
- * JEROME's note:
- * 
- * The only change in jQuery source is the comment added from
- * l. 9190 to l. 9192.
- *
  * Wrapped into a define call with no dependency to scope
  * the whole source code and get rid of the window.$ and window.jQuery.
  *
@@ -12,9 +7,6 @@
  */
 
 define(function(require, exports, module) {
-
-// BEGIN JQUERY SOURCE
-
 /*!
  * jQuery JavaScript Library v2.1.1
  * http://jquery.com/
@@ -9199,13 +9191,7 @@ if ( typeof noGlobal === strundefined ) {
 	window.jQuery = window.$ = jQuery;
 }
 
-
-
-
 return jQuery;
 
 }));
-
-// END JQUERY SOURCE
-return jQuery.noConflict(true);
 });


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NSA-102 
**Description:** PCI/PCI are overridden global jQuery.
**Steps to reproduce:**
The test must have a few sections: the first section should contain PCI (Text Reader), it's going to overload the global jQuery version from 1.9.1 to 2.1.1
Items in the next section must use interaction with one of the jQuery plugins (e.g. select2, datePicker, ...) (Inline Choice)
The test with described conditions is available for guests on [sprint 128](http://test-sprint128.playground.kitchen.it.taocloud.org:43231/tao/Main/login).
**Unit tests cli:** `npx grunt testall`