### PR TITLE
Fix/nex 1190/check media container

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.2.0',
+    'version'     => '25.2.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.6.0',

--- a/views/js/qtiCreator/widgets/static/img/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/img/states/Active.js
@@ -14,7 +14,20 @@ define([
     'ui/resourcemgr',
     'nouislider',
     'ui/tooltip'
-], function($, __, stateFactory, Active, formTpl, formElement, inlineHelper, itemUtil, _, imageUtil, mediaEditorComponent, mimeType){
+], function (
+    $,
+    __,
+    stateFactory,
+    Active,
+    formTpl,
+    formElement,
+    inlineHelper,
+    itemUtil,
+    _,
+    imageUtil,
+    mediaEditorComponent,
+    mimeType
+) {
     'use strict';
 
     /**
@@ -23,87 +36,35 @@ define([
      */
     var mediaEditor = null;
 
-    var ImgStateActive = stateFactory.extend(Active, function(){
-        this.initForm();
-    }, function(){
-        this.widget.$form.empty();
-    });
+    var ImgStateActive = stateFactory.extend(
+        Active,
+        function () {
+            this.initForm();
+        },
+        function () {
+            this.widget.$form.empty();
+        }
+    );
 
     /**
      * Extract a default label from a file/path name
      * @param {String} fileName - the file/path
      * @returns {String} a label
      */
-    var _extractLabel = function extractLabel(fileName){
+    var _extractLabel = function extractLabel(fileName) {
         return fileName
             .replace(/\.[^.]+$/, '')
             .replace(/^(.*)\//, '')
             .replace(/\W/, ' ')
             .substr(0, 255);
     };
-
-    ImgStateActive.prototype.initForm = function(){
-
-        var _widget = this.widget,
-            $img = _widget.$original,
-            $form = _widget.$form,
-            img = _widget.element,
-            baseUrl = _widget.options.baseUrl;
-
-        $form.html(formTpl({
-            baseUrl : baseUrl || '',
-            src : img.attr('src'),
-            alt : img.attr('alt')
-        }));
-
-        //init slider and set align value before ...
-        _initAdvanced(_widget);
-        _initMediaSizer(_widget);
-        _initAlign(_widget);
-        _initUpload(_widget);
-
-        //... init standard ui widget
-        formElement.initWidget($form);
-
-        //init data change callbacks
-        formElement.setChangeCallbacks($form, img, {
-            src : _.throttle(function(img, value){
-
-                img.attr('src', value);
-                if (!$img.hasClass('hidden')) {
-                    $img.addClass('hidden');
-                }
-                $img.attr('src', _widget.getAssetManager().resolve(value));
-                $img.trigger('contentChange.qti-widget').change();
-
-                inlineHelper.togglePlaceholder(_widget);
-
-                _initAdvanced(_widget);
-                if (img.attr('off-media-editor') === 1) {
-                    img.removeAttr('off-media-editor');
-                } else {
-                    _initMediaSizer(_widget);
-                }
-            }, 1000),
-            alt : function(img, value){
-                img.attr('alt', value);
-            },
-            longdesc : formElement.getAttributeChangeCallback(),
-            align : function(img, value){
-                inlineHelper.positionFloat(_widget, value);
-            }
-        });
-
-    };
-
-    var _initAlign = function(widget){
-
+    var _initAlign = function (widget) {
         var align = 'default';
 
         //init float positioning:
-        if(widget.element.hasClass('rgt')){
+        if (widget.element.hasClass('rgt')) {
             align = 'right';
-        }else if(widget.element.hasClass('lft')){
+        } else if (widget.element.hasClass('lft')) {
             align = 'left';
         }
 
@@ -111,29 +72,29 @@ define([
         widget.$form.find('select[name=align]').val(align);
     };
 
-    var _getMedia = function(imgQtiElement, $imgNode, cb) {
+    var _getMedia = function (imgQtiElement, $imgNode, cb) {
         //init data-responsive:
         if (typeof imgQtiElement.data('responsive') === 'undefined') {
-            if(imgQtiElement.attr('width') && !/[0-9]+%/.test(imgQtiElement.attr('width'))){
+            if (imgQtiElement.attr('width') && !/[0-9]+%/.test(imgQtiElement.attr('width'))) {
                 imgQtiElement.data('responsive', false);
-            }else{
+            } else {
                 imgQtiElement.data('responsive', true);
             }
         }
 
         if (
-            typeof imgQtiElement.attr('original-width') !== 'undefined'
-            && typeof imgQtiElement.attr('original-height') !== 'undefined'
-            && typeof imgQtiElement.attr('type') !== 'undefined'
-            && typeof imgQtiElement.attr('src') !== 'undefined'
-            && typeof imgQtiElement.attr('width') !== 'undefined'
-            && typeof imgQtiElement.attr('height') !== 'undefined'
+            typeof imgQtiElement.attr('original-width') !== 'undefined' &&
+            typeof imgQtiElement.attr('original-height') !== 'undefined' &&
+            typeof imgQtiElement.attr('type') !== 'undefined' &&
+            typeof imgQtiElement.attr('src') !== 'undefined' &&
+            typeof imgQtiElement.attr('width') !== 'undefined' &&
+            typeof imgQtiElement.attr('height') !== 'undefined'
         ) {
             cb({
                 $node: $imgNode,
                 type: imgQtiElement.attr('type'),
-                src:  imgQtiElement.attr('src'),
-                width:  imgQtiElement.attr('width'),
+                src: imgQtiElement.attr('src'),
+                width: imgQtiElement.attr('width'),
                 height: imgQtiElement.attr('height'),
                 responsive: imgQtiElement.data('responsive')
             });
@@ -143,8 +104,8 @@ define([
                 cb({
                     $node: $imgNode,
                     type: imgQtiElement.attr('type'),
-                    src:  imgQtiElement.attr('src'),
-                    width:  imgQtiElement.attr('width'),
+                    src: imgQtiElement.attr('src'),
+                    width: imgQtiElement.attr('width'),
                     height: imgQtiElement.attr('height'),
                     responsive: imgQtiElement.data('responsive')
                 });
@@ -152,8 +113,7 @@ define([
         }
     };
 
-    var _initMediaSizer = function(widget){
-
+    var _initMediaSizer = function (widget) {
         var img = widget.element,
             $src = widget.$form.find('input[name=src]'),
             $mediaResizer = widget.$form.find('.img-resizer'),
@@ -173,53 +133,53 @@ define([
                 };
                 media.$container = $mediaSpan.parents('.widget-box');
                 if (media.$container.length) {
-                    mediaEditor = mediaEditorComponent($mediaResizer, media, options)
-                        .on('change', function (nMedia) {
-                            media = nMedia;
-                            $img.prop('style', null); // not allowed by qti
-                            $img.removeAttr('style');
-                            img.data('responsive', media.responsive);
-                            _(['width', 'height']).each(function(sizeAttr){
-                                var val;
-                                if (media[sizeAttr] === '' || typeof media[sizeAttr] === 'undefined' || media[sizeAttr] === null){
-                                    img.removeAttr(sizeAttr);
-                                    $mediaSpan.css(sizeAttr, '');
+                    mediaEditor = mediaEditorComponent($mediaResizer, media, options).on('change', function (nMedia) {
+                        media = nMedia;
+                        $img.prop('style', null); // not allowed by qti
+                        $img.removeAttr('style');
+                        img.data('responsive', media.responsive);
+                        _(['width', 'height']).each(function (sizeAttr) {
+                            var val;
+                            if (
+                                media[sizeAttr] === '' ||
+                                typeof media[sizeAttr] === 'undefined' ||
+                                media[sizeAttr] === null
+                            ) {
+                                img.removeAttr(sizeAttr);
+                                $mediaSpan.css(sizeAttr, '');
+                            } else {
+                                val = Math.round(media[sizeAttr]);
+                                if (media.responsive) {
+                                    val += '%';
+                                    img.attr(sizeAttr, val);
+                                    $img.attr(sizeAttr, '100%');
                                 } else {
-                                    val = Math.round(media[sizeAttr]);
-                                    if (media.responsive) {
-                                        val += '%';
-                                        img.attr(sizeAttr, val);
-                                        $img.attr(sizeAttr, '100%');
-                                    } else {
-                                        img.attr(sizeAttr, val);
-                                    }
-                                    $mediaSpan.css(sizeAttr, val);
+                                    img.attr(sizeAttr, val);
                                 }
-                                //trigger choice container size adaptation
-                                widget.$container.trigger('contentChange.qti-widget');
-                            });
-                            $img.removeClass('hidden');
+                                $mediaSpan.css(sizeAttr, val);
+                            }
+                            //trigger choice container size adaptation
+                            widget.$container.trigger('contentChange.qti-widget');
                         });
+                        $img.removeClass('hidden');
+                    });
                 }
             });
         }
     };
 
-    var _initAdvanced = function(widget){
-
+    var _initAdvanced = function (widget) {
         var $form = widget.$form,
             src = widget.element.attr('src');
 
-        if(src){
+        if (src) {
             $form.find('[data-role=advanced]').show();
-        }else{
+        } else {
             $form.find('[data-role=advanced]').hide();
         }
     };
 
-
-    var _initUpload = function(widget){
-
+    var _initUpload = function (widget) {
         var $form = widget.$form,
             options = widget.options,
             img = widget.element,
@@ -227,37 +187,39 @@ define([
             $src = $form.find('input[name=src]'),
             $alt = $form.find('input[name=alt]');
 
-        var _openResourceMgr = function(){
+        var _openResourceMgr = function () {
             $uploadTrigger.resourcemgr({
-                title : __('Please select an image file from the resource manager. You can add files from your computer with the button "Add file(s)".'),
-                appendContainer : options.mediaManager.appendContainer,
-                mediaSourcesUrl : options.mediaManager.mediaSourcesUrl,
-                browseUrl : options.mediaManager.browseUrl,
-                uploadUrl : options.mediaManager.uploadUrl,
-                deleteUrl : options.mediaManager.deleteUrl,
-                downloadUrl : options.mediaManager.downloadUrl,
-                fileExistsUrl : options.mediaManager.fileExistsUrl,
-                params : {
-                    uri : options.uri,
-                    lang : options.lang,
-                    filters : [
-                        {'mime':'image/jpeg'},
-                        {'mime':'image/png'},
-                        {'mime':'image/gif'},
-                        {'mime':'image/svg+xml'},
-                        {'mime':'application/x-gzip', 'extension':'svgz'}
+                title: __(
+                    'Please select an image file from the resource manager. You can add files from your computer with the button "Add file(s)".'
+                ),
+                appendContainer: options.mediaManager.appendContainer,
+                mediaSourcesUrl: options.mediaManager.mediaSourcesUrl,
+                browseUrl: options.mediaManager.browseUrl,
+                uploadUrl: options.mediaManager.uploadUrl,
+                deleteUrl: options.mediaManager.deleteUrl,
+                downloadUrl: options.mediaManager.downloadUrl,
+                fileExistsUrl: options.mediaManager.fileExistsUrl,
+                params: {
+                    uri: options.uri,
+                    lang: options.lang,
+                    filters: [
+                        { mime: 'image/jpeg' },
+                        { mime: 'image/png' },
+                        { mime: 'image/gif' },
+                        { mime: 'image/svg+xml' },
+                        { mime: 'application/x-gzip', extension: 'svgz' }
                     ]
                 },
-                pathParam : 'path',
-                select : function(e, files){
+                pathParam: 'path',
+                select: function (e, files) {
                     var file, alt;
                     var confirmBox, cancel, save;
-                    if(files && files.length){
+                    if (files && files.length) {
                         file = files[0].file;
                         alt = files[0].alt;
                         $src.val(file);
-                        if($.trim($alt.val()) === ''){
-                            if(alt === ''){
+                        if ($.trim($alt.val()) === '') {
+                            if (alt === '') {
                                 alt = _extractLabel(file);
                             }
                             img.attr('alt', alt);
@@ -267,36 +229,34 @@ define([
                             cancel = confirmBox.find('.cancel');
                             save = confirmBox.find('.save');
 
-                            $('.alt-text',confirmBox).html('"' + $alt.val() + '"<br>with<br>"' + alt+'" ?');
+                            $('.alt-text', confirmBox).html(`"${$alt.val()}"<br>with<br>"${alt}" ?`);
 
                             confirmBox.modal({ width: 500 });
 
-                            save.off('click')
-                                .on('click', function () {
-                                    img.attr('alt', alt);
-                                    $alt.val(alt).trigger('change');
-                                    confirmBox.modal('close');
-                                });
+                            save.off('click').on('click', function () {
+                                img.attr('alt', alt);
+                                $alt.val(alt).trigger('change');
+                                confirmBox.modal('close');
+                            });
 
-                            cancel.off('click')
-                                .on('click', function () {
-                                    confirmBox.modal('close');
-                                });
+                            cancel.off('click').on('click', function () {
+                                confirmBox.modal('close');
+                            });
                         }
 
-                        _.defer(function(){
+                        _.defer(function () {
                             img.attr('off-media-editor', 1);
                             $src.trigger('change');
                         });
                     }
                 },
-                open : function(){
+                open: function () {
                     // hide tooltip if displayed
-                    if($src.data('$tooltip')){
+                    if ($src.data('$tooltip')) {
                         $src.blur().data('$tooltip').hide();
                     }
                 },
-                close : function(){
+                close: function () {
                     // triggers validation:
                     $src.blur();
                 }
@@ -306,10 +266,62 @@ define([
         $uploadTrigger.on('click', _openResourceMgr);
 
         //if empty, open file manager immediately
-        if(!$src.val()){
+        if (!$src.val()) {
             _openResourceMgr();
         }
+    };
 
+    ImgStateActive.prototype.initForm = function () {
+        var _widget = this.widget,
+            $img = _widget.$original,
+            $form = _widget.$form,
+            imgElem = _widget.element,
+            baseUrl = _widget.options.baseUrl;
+
+        $form.html(
+            formTpl({
+                baseUrl: baseUrl || '',
+                src: imgElem.attr('src'),
+                alt: imgElem.attr('alt')
+            })
+        );
+
+        //init slider and set align value before ...
+        _initAdvanced(_widget);
+        _initMediaSizer(_widget);
+        _initAlign(_widget);
+        _initUpload(_widget);
+
+        //... init standard ui widget
+        formElement.initWidget($form);
+
+        //init data change callbacks
+        formElement.setChangeCallbacks($form, imgElem, {
+            src: _.throttle(function (img, value) {
+                img.attr('src', value);
+                if (!$img.hasClass('hidden')) {
+                    $img.addClass('hidden');
+                }
+                $img.attr('src', _widget.getAssetManager().resolve(value));
+                $img.trigger('contentChange.qti-widget').change();
+
+                inlineHelper.togglePlaceholder(_widget);
+
+                _initAdvanced(_widget);
+                if (img.attr('off-media-editor') === 1) {
+                    img.removeAttr('off-media-editor');
+                } else {
+                    _initMediaSizer(_widget);
+                }
+            }, 1000),
+            alt: function (img, value) {
+                img.attr('alt', value);
+            },
+            longdesc: formElement.getAttributeChangeCallback(),
+            align: function (img, value) {
+                inlineHelper.positionFloat(_widget, value);
+            }
+        });
     };
 
     return ImgStateActive;

--- a/views/js/qtiCreator/widgets/static/img/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/img/states/Active.js
@@ -172,33 +172,35 @@ define([
                     }
                 };
                 media.$container = $mediaSpan.parents('.widget-box');
-                mediaEditor = mediaEditorComponent($mediaResizer, media, options)
-                    .on('change', function (nMedia) {
-                        media = nMedia;
-                        $img.prop('style', null); // not allowed by qti
-                        $img.removeAttr('style');
-                        img.data('responsive', media.responsive);
-                        _(['width', 'height']).each(function(sizeAttr){
-                            var val;
-                            if (media[sizeAttr] === '' || typeof media[sizeAttr] === 'undefined' || media[sizeAttr] === null){
-                                img.removeAttr(sizeAttr);
-                                $mediaSpan.css(sizeAttr, '');
-                            } else {
-                                val = Math.round(media[sizeAttr]);
-                                if (media.responsive) {
-                                    val += '%';
-                                    img.attr(sizeAttr, val);
-                                    $img.attr(sizeAttr, '100%');
+                if (media.$container.length) {
+                    mediaEditor = mediaEditorComponent($mediaResizer, media, options)
+                        .on('change', function (nMedia) {
+                            media = nMedia;
+                            $img.prop('style', null); // not allowed by qti
+                            $img.removeAttr('style');
+                            img.data('responsive', media.responsive);
+                            _(['width', 'height']).each(function(sizeAttr){
+                                var val;
+                                if (media[sizeAttr] === '' || typeof media[sizeAttr] === 'undefined' || media[sizeAttr] === null){
+                                    img.removeAttr(sizeAttr);
+                                    $mediaSpan.css(sizeAttr, '');
                                 } else {
-                                    img.attr(sizeAttr, val);
+                                    val = Math.round(media[sizeAttr]);
+                                    if (media.responsive) {
+                                        val += '%';
+                                        img.attr(sizeAttr, val);
+                                        $img.attr(sizeAttr, '100%');
+                                    } else {
+                                        img.attr(sizeAttr, val);
+                                    }
+                                    $mediaSpan.css(sizeAttr, val);
                                 }
-                                $mediaSpan.css(sizeAttr, val);
-                            }
-                            //trigger choice container size adaptation
-                            widget.$container.trigger('contentChange.qti-widget');
+                                //trigger choice container size adaptation
+                                widget.$container.trigger('contentChange.qti-widget');
+                            });
+                            $img.removeClass('hidden');
                         });
-                        $img.removeClass('hidden');
-                    });
+                }
             });
         }
     };


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-1190

The root of the issue: after inserting an image Active Widget sends `HEAD` request and then create mediaEditorComponent. In case a user fast click on the image (active widget invoke) and then outside (active widget removed) request is pending and finished when widget element `'.widget-box'` already removed from DOM.

**Fix in comment https://github.com/oat-sa/extension-tao-itemqti/commit/84b6a122b63988cc649c22fef05ecf5e80018811**
Also, the file was formatted to fix eslint errors

Steps to reproduce:

1. Go to 'Assets' tab.
2. Create a new passage bу clicking 'New asset'.
3. Click 'Authoring' button.
4. In Authoring mode choose the shared stimulus block and click 'Insert image' button.
5. Click on empty space inside the block and then again on image many times 
6. Should be no errors in browser console.

