### PR TITLE
Fix/broken unit test with container

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.3.1',
+    'version'     => '25.3.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.8.2',

--- a/model/qti/container/Container.php
+++ b/model/qti/container/Container.php
@@ -377,11 +377,16 @@ abstract class Container extends Element implements IdentifiedElementContainer
             'elements' => $this->getArraySerializedElementCollection($this->getElements(), $filterVariableContent, $filtered),
         ];
         
-        if (DEBUG_MODE) {
+        if ($this->isDebugMode()) {
             //in debug mode, add debug data, such as the related item
             $data['debug'] = ['relatedItem' => is_null($this->getRelatedItem()) ? '' : $this->getRelatedItem()->getSerial()];
         }
         
         return $data;
+    }
+
+    private function isDebugMode(): bool
+    {
+        return defined('DEBUG_MODE') ? DEBUG_MODE : false;
     }
 }


### PR DESCRIPTION
Fix unit test du to `DEBUG_MODE` constant:

```
 $ vendor/bin/phpunit taoMediaManager/test/unit/model/sharedStimulus/parser/JsonQtiAttributeParserTest.php 
PHPUnit 8.5.8-52-ga3588fce9 by Sebastian Bergmann and contributors.

EE                                                                  2 / 2 (100%)

Time: 60 ms, Memory: 6.00 MB

There were 2 errors:

1) oat\taoMediaManager\test\unit\model\sharedStimulus\parser\JsonQtiAttributeParserTest::testParseWithLanguage
Use of undefined constant DEBUG_MODE - assumed 'DEBUG_MODE' (this will throw an Error in a future version of PHP)

/Users/siwane/workspace/tao/package-tao/taoQtiItem/model/qti/container/Container.php:380
/Users/siwane/workspace/tao/package-tao/taoQtiItem/model/qti/Element.php:468
/Users/siwane/workspace/tao/package-tao/taoMediaManager/model/sharedStimulus/parser/JsonQtiAttributeParser.php:45
/Users/siwane/workspace/tao/package-tao/taoMediaManager/test/unit/model/sharedStimulus/parser/JsonQtiAttributeParserTest.php:43

2) oat\taoMediaManager\test\unit\model\sharedStimulus\parser\JsonQtiAttributeParserTest::testParseWithoutLanguage
Use of undefined constant DEBUG_MODE - assumed 'DEBUG_MODE' (this will throw an Error in a future version of PHP)

/Users/siwane/workspace/tao/package-tao/taoQtiItem/model/qti/container/Container.php:380
/Users/siwane/workspace/tao/package-tao/taoQtiItem/model/qti/Element.php:468
/Users/siwane/workspace/tao/package-tao/taoMediaManager/model/sharedStimulus/parser/JsonQtiAttributeParser.php:45
/Users/siwane/workspace/tao/package-tao/taoMediaManager/test/unit/model/sharedStimulus/parser/JsonQtiAttributeParserTest.php:52

ERRORS!
Tests: 2, Assertions: 0, Errors: 2.
```