### PR TITLE
Code styles fixes in feedback implementation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.4.1',
+    'version'     => '25.4.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.8.2',

--- a/model/qti/feedback/Feedback.php
+++ b/model/qti/feedback/Feedback.php
@@ -96,10 +96,7 @@ abstract class Feedback extends IdentifiedElement implements FlowContainer, Cont
         $collection = $relatedItem->getIdentifiedElements();
 
         try {
-            $feedback = $collection->getUnique($newIdentifier, self::class);
-            if (is_null($feedback)) {
-                return true;
-            }
+            return null === $collection->getUnique($newIdentifier, self::class);
         } catch (QtiModelException $e) {
         }
 

--- a/model/qti/feedback/Feedback.php
+++ b/model/qti/feedback/Feedback.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,19 +15,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
  */
 
 namespace oat\taoQtiItem\model\qti\feedback;
 
-use oat\taoQtiItem\model\qti\feedback\Feedback;
+use InvalidArgumentException;
 use oat\taoQtiItem\model\qti\IdentifiedElement;
 use oat\taoQtiItem\model\qti\container\FlowContainer;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\container\ContainerStatic;
 use oat\taoQtiItem\model\qti\exception\QtiModelException;
 use oat\taoQtiItem\model\qti\ContentVariable;
+use oat\taoQtiItem\model\qti\attribute\OutcomeIdentifier;
+use oat\taoQtiItem\model\qti\attribute\ShowHideTemplateElement;
 
 /**
  * The QTI_Feedback object represent one of the three available feedbackElements
@@ -38,13 +37,20 @@ use oat\taoQtiItem\model\qti\ContentVariable;
  * @author Sam Sipasseuth, <sam.sipasseuth@taotesting.com>
  * @package taoQTI
  * @see http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10243
-
  */
 abstract class Feedback extends IdentifiedElement implements FlowContainer, ContentVariable
 {
+    protected $body;
 
-    protected $body = null;
-
+    /**
+     * Feedback constructor.
+     *
+     * @param array     $attributes
+     * @param Item|null $relatedItem
+     * @param string    $serial
+     *
+     * @throws QtiModelException
+     */
     public function __construct($attributes = [], Item $relatedItem = null, $serial = '')
     {
         parent::__construct($attributes, $relatedItem, $serial);
@@ -59,8 +65,8 @@ abstract class Feedback extends IdentifiedElement implements FlowContainer, Cont
     protected function getUsedAttributes()
     {
         return [
-            'oat\\taoQtiItem\\model\\qti\\attribute\\OutcomeIdentifier',
-            'oat\\taoQtiItem\\model\\qti\\attribute\\ShowHideTemplateElement'
+            OutcomeIdentifier::class,
+            ShowHideTemplateElement::class
         ];
     }
 
@@ -68,19 +74,18 @@ abstract class Feedback extends IdentifiedElement implements FlowContainer, Cont
      * Check if the given new identifier is valid in the current state of the qti element
      *
      * @param string $newIdentifier
-     * @return booean
+     * @return bool
      * @throws InvalidArgumentException
      */
     public function isIdentifierAvailable($newIdentifier)
     {
-
         $returnValue = false;
 
         if (empty($newIdentifier) || is_null($newIdentifier)) {
             throw new InvalidArgumentException("newIdentifier must be set");
         }
 
-        if (!empty($this->identifier) && $newIdentifier == $this->identifier) {
+        if (!empty($this->identifier) && $newIdentifier === $this->identifier) {
             $returnValue = true;
         } else {
             $relatedItem = $this->getRelatedItem();
@@ -90,7 +95,7 @@ abstract class Feedback extends IdentifiedElement implements FlowContainer, Cont
                 $collection = $relatedItem->getIdentifiedElements();
 
                 try {
-                    $feedback = $collection->getUnique($newIdentifier, 'oat\\taoQtiItem\\model\\qti\\feedback\\Feedback');
+                    $feedback = $collection->getUnique($newIdentifier, static::class);
                     if (is_null($feedback)) {
                         $returnValue = true;
                     }
@@ -105,7 +110,6 @@ abstract class Feedback extends IdentifiedElement implements FlowContainer, Cont
 
     public function toArray($filterVariableContent = false, &$filtered = [])
     {
-
         $data = parent::toArray($filterVariableContent, $filtered);
 
         if ($filterVariableContent) {

--- a/model/qti/feedback/Feedback.php
+++ b/model/qti/feedback/Feedback.php
@@ -79,33 +79,31 @@ abstract class Feedback extends IdentifiedElement implements FlowContainer, Cont
      */
     public function isIdentifierAvailable($newIdentifier)
     {
-        $returnValue = false;
-
         if (empty($newIdentifier) || is_null($newIdentifier)) {
             throw new InvalidArgumentException("newIdentifier must be set");
         }
 
         if (!empty($this->identifier) && $newIdentifier === $this->identifier) {
-            $returnValue = true;
-        } else {
-            $relatedItem = $this->getRelatedItem();
-            if (is_null($relatedItem)) {
-                $returnValue = true; //no restriction on identifier since not attached to any qti item
-            } else {
-                $collection = $relatedItem->getIdentifiedElements();
-
-                try {
-                    $feedback = $collection->getUnique($newIdentifier, self::class);
-                    if (is_null($feedback)) {
-                        $returnValue = true;
-                    }
-                } catch (QtiModelException $e) {
-                    //return false
-                }
-            }
+            return true;
         }
 
-        return $returnValue;
+        $relatedItem = $this->getRelatedItem();
+
+        if (is_null($relatedItem)) {
+            return true; // no restriction on identifier since not attached to any qti item
+        }
+
+        $collection = $relatedItem->getIdentifiedElements();
+
+        try {
+            $feedback = $collection->getUnique($newIdentifier, self::class);
+            if (is_null($feedback)) {
+                return true;
+            }
+        } catch (QtiModelException $e) {
+        }
+
+        return false;
     }
 
     public function toArray($filterVariableContent = false, &$filtered = [])

--- a/model/qti/feedback/Feedback.php
+++ b/model/qti/feedback/Feedback.php
@@ -95,7 +95,7 @@ abstract class Feedback extends IdentifiedElement implements FlowContainer, Cont
                 $collection = $relatedItem->getIdentifiedElements();
 
                 try {
-                    $feedback = $collection->getUnique($newIdentifier, static::class);
+                    $feedback = $collection->getUnique($newIdentifier, self::class);
                     if (is_null($feedback)) {
                         $returnValue = true;
                     }

--- a/model/qti/feedback/FeedbackBlock.php
+++ b/model/qti/feedback/FeedbackBlock.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,14 +15,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
  */
 
 namespace oat\taoQtiItem\model\qti\feedback;
-
-use oat\taoQtiItem\model\qti\feedback\FeedbackBlock;
-use oat\taoQtiItem\model\qti\feedback\Feedback;
 
 /**
  * The QTI_FeedbackBlock
@@ -32,11 +26,9 @@ use oat\taoQtiItem\model\qti\feedback\Feedback;
  * @author Sam Sipasseuth, <sam.sipasseuth@taotesting.com>
  * @package taoQTI
  * @see http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10250
-
  */
 class FeedbackBlock extends Feedback
 {
-
     /**
      * the QTI tag name as defined in QTI standard
      *

--- a/model/qti/feedback/FeedbackInline.php
+++ b/model/qti/feedback/FeedbackInline.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,14 +15,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
  */
 
 namespace oat\taoQtiItem\model\qti\feedback;
-
-use oat\taoQtiItem\model\qti\feedback\FeedbackInline;
-use oat\taoQtiItem\model\qti\feedback\Feedback;
 
 /**
  * The QTI_FeedbackInline
@@ -36,7 +30,6 @@ use oat\taoQtiItem\model\qti\feedback\Feedback;
  */
 class FeedbackInline extends Feedback
 {
-
     /**
      * the QTI tag name as defined in QTI standard
      *

--- a/model/qti/feedback/ModalFeedback.php
+++ b/model/qti/feedback/ModalFeedback.php
@@ -46,9 +46,4 @@ class ModalFeedback extends Feedback
             [TitleOptional::class]
         );
     }
-    
-    public function toForm()
-    {
-        return (new self($this))->getForm();
-    }
 }

--- a/model/qti/feedback/ModalFeedback.php
+++ b/model/qti/feedback/ModalFeedback.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,14 +15,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
  */
 
 namespace oat\taoQtiItem\model\qti\feedback;
 
-use oat\taoQtiItem\model\qti\feedback\ModalFeedback;
-use oat\taoQtiItem\model\qti\feedback\Feedback;
+use oat\taoQtiItem\model\qti\attribute\TitleOptional;
 
 /**
  * The QTI_FeedbackBlock
@@ -32,11 +28,9 @@ use oat\taoQtiItem\model\qti\feedback\Feedback;
  * @author Sam Sipasseuth, <sam.sipasseuth@taotesting.com>
  * @package taoQTI
  * @see http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10428
-
  */
 class ModalFeedback extends Feedback
 {
-
     /**
      * the QTI tag name as defined in QTI standard
      *
@@ -47,18 +41,14 @@ class ModalFeedback extends Feedback
 
     protected function getUsedAttributes()
     {
-
         return array_merge(
             parent::getUsedAttributes(),
-            [
-            'oat\\taoQtiItem\\model\\qti\\attribute\\TitleOptional'
-                ]
+            [TitleOptional::class]
         );
     }
     
     public function toForm()
     {
-        $formContainer = new ModalFeedback($this);
-        return $formContainer->getForm();
+        return (new self($this))->getForm();
     }
 }


### PR DESCRIPTION
I found out it when I worked on [BSA-104](https://oat-sa.atlassian.net/browse/BSA-104).

"Use" statements in these files includes classes that already defined in that namespace, it may trigger unexpected errors in the future. Also, I fixed some other issues, mostly related to code style and common sense.