### PR TITLE
Fix TAO 10464 - Uncaught type error upon dragging the Media Interaction on canvas

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.7.2',
+    'version'     => '25.7.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.8.2',

--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
@@ -178,6 +178,8 @@ define([
 
         $heightContainer = $('.height-container', $form);
 
+        const defaultSize = 100;
+
         // Initialize MediaSizer
         $form.find('.media-sizer-panel').on('sizechange.mediasizer', function() {
             $(this).find('input').trigger('change');
@@ -187,8 +189,8 @@ define([
             showReset: false,
             responsive: false,
             applyToMedium: false,
-            width: interaction.object.attr('width'),
-            height: interaction.object.attr('height'),
+            width: interaction.object.attr('width') || defaultSize,
+            height: interaction.object.attr('height') || defaultSize,
             minWidth: 50,
             maxWidth: $container.innerWidth()
         });


### PR DESCRIPTION
**Related to this PR**

https://github.com/oat-sa/tao-core-ui-fe/pull/163

**Related to this issue**

https://oat-sa.atlassian.net/browse/TAO-10464

**Description**

When the user drags the Media Interaction on the canvas, there's no file selection window opens. Instead 'Uncaught type error' appears on the browser console and the widow opens only after clicking empty space outside the interaction and clicking it again.

**Steps to reproduce**

- Go to the Items tab.
- Create a new item and go to Authoring.
- Drag and drop Media Interaction on the canvas.

**Actual result**

Error in console, the file selection window is not opened.

**Expected result**

The file selection window shows up without any errors.