### PR TITLE
Feature UNO 467 - Extend Response Properties on text Entry interaction with possibility to set baseType property 

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.7.3',
+    'version'     => '25.8.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.8.2',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-LPZJM8C73gRKZYXi/8OMvoMx+Xg="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.10.3.tgz",
-      "integrity": "sha512-4UrrD8963SO25atxKSqXkhlVSeN3uQ5YyhshDJqmgw9/vMSzvKAfb28mq2kedoFoVwBeCyi0ksdo9/BWIV3n3A=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.11.0.tgz",
+      "integrity": "sha512-VVng1+uhsvab5DOYXkO73CusCvQkWlWegLgYuQTXsNidtRsw5fIFBv8j+rjdFj1C7x+tEo//VBgHSVkQ2r6D7g=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.4.0",
-    "@oat-sa/tao-item-runner-qti": "0.10.3"
+    "@oat-sa/tao-item-runner-qti": "0.11.0"
   }
 }


### PR DESCRIPTION
**Needs to be merged and publish before this PR**

https://github.com/oat-sa/tao-item-runner-qti-fe/pull/96

**Related to**

https://oat-sa.atlassian.net/browse/UNO-467

**Description**

**As** content creator
**I would** like during the assessment on textEntry interaction and in case of touch-based devices, to open the numeric keyboard for input
**so that**  we increase user experience and eliminate possibilities for wrong input

**Acceptance Criteria**

**AC1**

**GIVEN** an inline `textEntry` interaction flagged as expecting a numeric input
**WHEN** the test taker tap on the input field with a touch-based device like a tablet
**THEN** the device opens the numeric keyboard instead of the alphanumeric keyboard

**Considerations**

The main goal is to implement this story on the NextGen test runner.

- NextGen test runner

Implementation of NextGen test runner already support such behavior.  We have to add inputmode=numeric if the `baseType` is integer and `inputmode=decimal` if the `baseType` is a `float`

- CurrentGen test runner

Implementation for CurrentGen test runner implement similar logic as on NextGen test runner relying on `inputmode`

**How to Test**

**Requires touch-based device, tablet or similar**

Create an item with `textEntry` interaction with Response `baseType` declaration set to integer or float.

Create a test including the item(s) created before and publish to NextGen to deliver an environment that is linked with New Test runner ex.

on demo.udir publish on using tenant: UDIR QA (new Test Runner)

Launch delivery execution from the touch-based device

Verify during input on textEntry interaction with numeric `baseType`,  numeric keyboard is rendered.