### PR TITLE
Fix/invsup 42/text reader interaction images

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.9.0',
+    'version'     => '25.9.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.11.0',

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -69,7 +69,7 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
 
         $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];
         foreach ($attributeNodes as $node) {
-            if (!$node->nodeValue) {
+            if ($node->nodeValue) {
                 $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);
             }
         }

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -60,16 +60,16 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
      */
     private function replaceEncodedNodes($xpath, array $packedAssets)
     {
-        $replacementList = [];
-        foreach ($packedAssets as $key => $asset) {
-            if ($asset instanceof PackedAsset) {
-                $replacementList[$key] = $asset->getReplacedBy();
-            }
+        $replacementList = array_filter($packedAssets, function ($asset) {
+            return $asset instanceof PackedAsset;
+        });
+        foreach ($replacementList as $key => $asset) {
+            $replacementList[$key] = $asset->getReplacedBy();
         }
 
         $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];
         foreach ($attributeNodes as $node) {
-            if ($node->nodeValue) {
+            if (!$node->nodeValue) {
                 $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);
             }
         }

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -47,6 +47,20 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
             }
         }
 
+        //replace assets in html encoded properties (such as content of text reader interaction)
+        $replacementList = [];
+        foreach ($packedAssets as $key => $asset) {
+            $replacementList[$key] = $asset->getReplacedBy();
+        }
+
+        $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];
+        unset($xpath);
+        foreach ($attributeNodes as $node) {
+            if ($node->nodeValue) {
+                $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);
+            }
+        }
+
         return $packedAssets;
     }
 }

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -32,6 +32,7 @@ use oat\taoQtiItem\model\pack\QtiAssetPacker\PackedAsset;
 class QtiItemAssetXmlReplacer extends ConfigurationService
 {
     /**
+     * @param DOMDocument $packedAssets
      * @param PackedAsset[] $packedAssets
      * @return PackedAsset[]
      */
@@ -47,7 +48,18 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
             }
         }
 
-        //replace assets in html encoded properties (such as content of text reader interaction)
+        $this->replaceEncodedNodes($xpath, $packedAssets);
+
+        return $packedAssets;
+    }
+
+    /**
+     * Replace assets in html encoded properties (such as content of text reader interaction)
+     * @param $xpath
+     * @param array $packedAssets
+     */
+    private function replaceEncodedNodes($xpath, array $packedAssets)
+    {
         $replacementList = [];
         foreach ($packedAssets as $key => $asset) {
             if ($asset instanceof PackedAsset) {
@@ -56,13 +68,10 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
         }
 
         $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];
-        unset($xpath);
         foreach ($attributeNodes as $node) {
             if ($node->nodeValue) {
                 $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);
             }
         }
-
-        return $packedAssets;
     }
 }

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -70,6 +70,7 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
         }
 
         $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];
+
         foreach ($attributeNodes as $node) {
             if ($node->nodeValue) {
                 $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -50,7 +50,9 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
         //replace assets in html encoded properties (such as content of text reader interaction)
         $replacementList = [];
         foreach ($packedAssets as $key => $asset) {
-            $replacementList[$key] = $asset->getReplacedBy();
+            if ($asset instanceof PackedAsset) {
+                $replacementList[$key] = $asset->getReplacedBy();
+            }
         }
 
         $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -58,7 +58,7 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
      * @param $xpath
      * @param array $packedAssets
      */
-    private function replaceEncodedNodes($xpath, array $packedAssets)
+    private function replaceEncodedNodes(DOMXPath $xpath, array $packedAssets): void
     {
         $replacementList = array_filter($packedAssets, function ($asset) {
             return $asset instanceof PackedAsset;

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -32,6 +32,11 @@ use oat\taoQtiItem\model\pack\QtiAssetPacker\PackedAsset;
 class QtiItemAssetXmlReplacer extends ConfigurationService
 {
     /**
+     * xpath query to find nodes which may contain html encoded content
+     */
+    private const HTML_CONTENT_NODES_QUERY = "//*[local-name()='entry']|//*[local-name()='property']";
+
+    /**
      * @param DOMDocument $packedAssets
      * @param PackedAsset[] $packedAssets
      * @return PackedAsset[]
@@ -67,7 +72,7 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
             $replacementList[$key] = $asset->getReplacedBy();
         }
 
-        $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];
+        $attributeNodes = $xpath->query(self::HTML_CONTENT_NODES_QUERY) ?: [];
         foreach ($attributeNodes as $node) {
             if ($node->nodeValue) {
                 $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -74,7 +74,7 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
             $replacementList[$key] = $asset->getReplacedBy();
         }
 
-        $attributeNodes = $xpath->query("//*[local-name()='entry']|//*[local-name()='property']") ?: [];
+        $attributeNodes = $xpath->query(self::HTML_CONTENT_NODES_QUERY) ?: [];
         foreach ($attributeNodes as $node) {
             if ($node->nodeValue) {
                 $node->nodeValue = strtr(htmlentities($node->nodeValue, ENT_XML1), $replacementList);

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -63,6 +63,7 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
         $replacementList = array_filter($packedAssets, function ($asset) {
             return $asset instanceof PackedAsset;
         });
+        
         foreach ($replacementList as $key => $asset) {
             $replacementList[$key] = $asset->getReplacedBy();
         }

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -64,6 +64,7 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
             return $asset instanceof PackedAsset;
         });
         
+        /** @var PackedAsset $asset */
         foreach ($replacementList as $key => $asset) {
             $replacementList[$key] = $asset->getReplacedBy();
         }

--- a/test/unit/model/compile/QtiItemAssetXmlReplacerTest.php
+++ b/test/unit/model/compile/QtiItemAssetXmlReplacerTest.php
@@ -41,13 +41,16 @@ class QtiItemAssetXmlReplacerTest extends TestCase
     public function testReplaceAssetNodeValue()
     {
         $packedAsset = $this->createMock(PackedAsset::class);
-        $packedAsset->expects($this->once())
-            ->method('getReplacedBy')
-            ->willReturn('new-link-fixture')
-        ;
+        $packedAsset->method('getReplacedBy')
+            ->willReturn('new-link-fixture_1');
+
+        $packedAsset2 = $this->createMock(PackedAsset::class);
+        $packedAsset2->method('getReplacedBy')
+            ->willReturn('new-link-fixture_2');
 
         $packedAssets = [
             'fixture' => $packedAsset,
+            'decoded_fixture' => $packedAsset2,
             'another-fixture' => '',
         ];
 
@@ -56,23 +59,32 @@ class QtiItemAssetXmlReplacerTest extends TestCase
         $element->setAttribute('src', 'fixture');
         $domDocument->appendChild($element);
 
+        $element = $domDocument->createElement('property');
+        $element->appendChild($domDocument->createTextNode(htmlentities(
+            '<img src="decoded_fixture" alt="type="image/png"/>'
+        )));
+        $domDocument->appendChild($element);
+
         $this->subject->replaceAssetNodeValue($domDocument, $packedAssets);
 
         $attributes = $domDocument->getElementsByTagName('video')->item(0)->attributes;
-        $this->assertEquals('new-link-fixture', $attributes['src']->nodeValue);
+        $this->assertEquals('new-link-fixture_1', $attributes['src']->nodeValue);
+
+        $propertyValue = $domDocument->getElementsByTagName('property')->item(0)->nodeValue;
+        $this->assertEquals(htmlentities(
+            '<img src="new-link-fixture_2" alt="type="image/png"/>'
+        ), $propertyValue);
     }
 
     public function testReplaceAssetNodeValues()
     {
         $packedAsset1 = $this->createMock(PackedAsset::class);
-        $packedAsset1->expects($this->once())
-            ->method('getReplacedBy')
+        $packedAsset1->method('getReplacedBy')
             ->willReturn('new-link-fixture-1')
         ;
 
         $packedAsset2 = $this->createMock(PackedAsset::class);
-        $packedAsset2->expects($this->once())
-            ->method('getReplacedBy')
+        $packedAsset2->method('getReplacedBy')
             ->willReturn('new-link-fixture-2')
         ;
 


### PR DESCRIPTION
Steps to reproduce:
1. Create an item with text reader interaction
2. Insert an image from mediamanager into text reader 
3. Create a test and compile it into delivery
4. Run the test.

Actual result: image missed
Expected result: image shown


Text reader interaction stores page content as html encoded value of one of it's properties. Example of `qti.xml`:
```
 <property key="0">&lt;img src="1fe328075f563f125050a.jpg" alt="118773941_10158798813033713_3113751345144007801_n.jpg" type="image/jpeg" width="84%" /&gt; page 1 column 1</property>
```
After refactoring of asset replacing this case was missed.

PR where this bug was introduced: https://github.com/oat-sa/extension-tao-itemqti/pull/1481 