### PR TITLE
[Fix] UNO 467 - Support correct version for default on render numerical input

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.9.2',
+    'version'     => '25.9.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.11.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -7,12 +7,12 @@
     "@oat-sa/tao-item-runner": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.4.0.tgz",
-      "integrity": "sha512-Z/fRV8TSxitZwO40zeL8T+pLbxoqp5L2dDqWf+0kPOV3Guf2juP1eXZygiXhwmHHOTgwpSeKSC0sOJJATsL5xQ=="
+      "integrity": "sha1-LPZJM8C73gRKZYXi/8OMvoMx+Xg="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.11.2.tgz",
-      "integrity": "sha512-CXkoTVf3bXkz6wpH2t3IsdbunIKcUCIVsdgTN6QbYsNBQ0tlsdziS+pwv1+3gaMU9T5/QqMmH1gK8/gUw78jFA=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.11.3.tgz",
+      "integrity": "sha512-K3LRz1ZN7KoySI3gdihmt7F+5bJp8hys8hga/kplYOnjYgq6O4CYSOcpcwQeuvxVDV8imZTam9/ty5Vm1Q0w0A=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.4.0",
-    "@oat-sa/tao-item-runner-qti": "0.11.2"
+    "@oat-sa/tao-item-runner-qti": "0.11.3"
   }
 }


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/UNO-467

**Description**

Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode change `inputmode` to support default `text` attribute