### PR TITLE
Fix nex 1860/extract pdf assets on export

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.10.2',
+    'version'     => '25.10.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.11.0',

--- a/manifest.php
+++ b/manifest.php
@@ -43,10 +43,10 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.11.1',
+    'version'     => '25.11.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
-        'taoItems' => '>=10.11.0',
+        'taoItems' => '>=10.13.0',
         'tao'      => '>=45.2.0',
         'generis'  => '>=12.17.0',
     ],

--- a/model/qti/AssetParser.php
+++ b/model/qti/AssetParser.php
@@ -253,6 +253,8 @@ class AssetParser
             $this->addAsset('audio', $object->attr('data'));
         } elseif (strpos($type, "text/html") !== false) {
             $this->addAsset('html', $object->attr('data'));
+        } elseif (strpos($type, "application/pdf") !== false) {
+            $this->addAsset('pdf', $object->attr('data'));
         }
     }
 

--- a/model/qti/AssetParser.php
+++ b/model/qti/AssetParser.php
@@ -253,7 +253,7 @@ class AssetParser
             $this->addAsset('audio', $object->attr('data'));
         } elseif (strpos($type, "text/html") !== false) {
             $this->addAsset('html', $object->attr('data'));
-        } elseif (strpos($type, "application/pdf") !== false) {
+        } elseif ($type === 'application/pdf') {
             $this->addAsset('pdf', $object->attr('data'));
         }
     }


### PR DESCRIPTION
Related to [NEX-1860](https://oat-sa.atlassian.net/browse/NEX-1860)

Inserting media file from ckeditor `Insert Media` is interpreted as `<object>` element on qit.xml. 
During export of test/item we try to traverse the qti file and extract all asset.  Extracting assets from <object> elements currently doesn't include the `application/pdf` mime-type and the resulted export qti.xml to include the URL of the `taomedia://`  for the pdf asset.

This fix adds the pdf mime-type on the available exportable asset types from qti object element

