### PR TITLE
Fix/tao 9824/shuffling interface doesnt disappear after shuffle option is ticked off

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.11.2',
+    'version'     => '25.11.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -26,7 +26,7 @@ define(['jquery'], function($) {
                 $shuffleToggle = $container.find('[data-role="shuffle-pin"]');
 
             var toggleVisibility = function(show) {
-                if (show) {
+                if (show === 'true') {
                     $shuffleToggle.show();
                 } else {
                     $shuffleToggle.hide();


### PR DESCRIPTION
**Related to task:** https://oat-sa.atlassian.net/browse/TAO-9824
**Description:** Shuffling interface doesn't disappear after "Shuffle" option is ticked off
**How to test:** 
1. Select The item and go to its Authoring
2. Drag and Drop a Choice Interaction
3. In the right side, tick the Shuffle option
4. Pin one of the choices
5. Tick off the Shuffle option

**Expected Result:**
As soon as the Shuffle option is ticked off, the Shuffle interface disappears