### PR TITLE
Fix/tao 10258/label text added right after putting custom interactions canvas cleared

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.13.0',
+    'version'     => '25.13.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/js/portableLib/OAT/util/html.js
+++ b/views/js/portableLib/OAT/util/html.js
@@ -24,12 +24,6 @@ define([
 
     return {
         render : function render($container){
-            var markup = $container.html();
-
-            //remove xml ns (would break jquery selector otherwise)
-            markup = xml.removeNamespace(markup);
-            $container.html(markup);
-
             //render math
             math.render($container);
 


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/TAO-10258
**Description:** Label text added right after putting the Custom Interactions to canvas is cleared
**How to test:** 
1. Create new test item, click Authoring.
2. Expand Custom Interactions section at left, drag and drop Math entry/Audio/Likert Scale interaction to canvas
3. Click "some text..." label and enter description text
4. Click out of the interaction on canvas/Click "Save" and "Preview" buttons/Click "Done" button
5. Observe the label
**Expected Result:**
The entered text is displayed in field with "some text..." label


**Reason:**
an event is added to the element that is inside the container
this string breaks this event `$container.html(markup);`
this removes all elements inside the container and creates new ones

this functionality is useless, so we can remove it