### PR TITLE
Fix/CGA-167/Don't determinate interaction wrapper as a text block

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.13.2',
+    'version'     => '25.13.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/js/qtiCreator/widgets/item/Widget.js
+++ b/views/js/qtiCreator/widgets/item/Widget.js
@@ -356,6 +356,7 @@ define([
                     });
 
                     var $widget = $col.children();
+
                     if($widget.length > 1 || !$widget.hasClass('widget-blockInteraction')){//not an immediate qti element
                         if($widget.hasClass('colrow')){
                             $widget.each(function(){
@@ -366,7 +367,7 @@ define([
                                     i++;
                                 }
                             });
-                        }else{
+                        } else if ($widget.find('.widget-blockInteraction').length === 0) {
                             isTextBlock = true;
                         }
                     }
@@ -390,7 +391,7 @@ define([
                 subContainerBody = $subContainer.html();//get serialized body
 
             $originalTextBlock.removeAttr('data-text-block-id').html('{{_container:new}}');
-
+            console.log('PUSH SUBCONTAINERS');
             subContainers.push({
                 body : subContainerBody,
                 elements : subContainerElements,
@@ -404,6 +405,7 @@ define([
         var serializedItemBody = $clonedContainer.find('.qti-itemBody').html(),
             itemBody = item.getBody();
 
+        console.log('subContainers', subContainers.length)
         if(subContainers.length){
 
             containerHelper.createElements(itemBody, serializedItemBody, function(newElts){
@@ -412,26 +414,28 @@ define([
 
                     throw 'number of sub-containers mismatch';
                 }else{
-
+                    console.log('Something wrong here!!!');
                     _.each(newElts, function(container){
 
                         var containerData = subContainers.shift();//get data in order
                         var containerElements = _detachElements(itemBody, containerData.elements);
 
+                        console.log('container.setElements')
                         container.setElements(containerElements, containerData.body);
-
+                        console.log('container.initTextWidget')
                         _this.initTextWidget(container, containerData.$original);
 
                     });
 
                     _.defer(function(){
+                        console.log('callback.call');
                         callback.call(_this);
                     });
                 }
             });
 
         }else{
-
+            console.log('callback.call');
             callback.call(_this);
         }
 

--- a/views/js/qtiCreator/widgets/item/Widget.js
+++ b/views/js/qtiCreator/widgets/item/Widget.js
@@ -391,7 +391,7 @@ define([
                 subContainerBody = $subContainer.html();//get serialized body
 
             $originalTextBlock.removeAttr('data-text-block-id').html('{{_container:new}}');
-            console.log('PUSH SUBCONTAINERS');
+
             subContainers.push({
                 body : subContainerBody,
                 elements : subContainerElements,
@@ -405,7 +405,6 @@ define([
         var serializedItemBody = $clonedContainer.find('.qti-itemBody').html(),
             itemBody = item.getBody();
 
-        console.log('subContainers', subContainers.length)
         if(subContainers.length){
 
             containerHelper.createElements(itemBody, serializedItemBody, function(newElts){
@@ -414,28 +413,23 @@ define([
 
                     throw 'number of sub-containers mismatch';
                 }else{
-                    console.log('Something wrong here!!!');
                     _.each(newElts, function(container){
 
                         var containerData = subContainers.shift();//get data in order
                         var containerElements = _detachElements(itemBody, containerData.elements);
 
-                        console.log('container.setElements')
                         container.setElements(containerElements, containerData.body);
-                        console.log('container.initTextWidget')
                         _this.initTextWidget(container, containerData.$original);
 
                     });
 
                     _.defer(function(){
-                        console.log('callback.call');
                         callback.call(_this);
                     });
                 }
             });
 
         }else{
-            console.log('callback.call');
             callback.call(_this);
         }
 

--- a/views/js/test/qtiCreator/model/interactions/gapMatchInteraction/test.js
+++ b/views/js/test/qtiCreator/model/interactions/gapMatchInteraction/test.js
@@ -157,6 +157,7 @@ define([
 
                 assert.equal($('.qti-choice', $choiceArea).length, 10, 'There are 10 choices in the item initially');
                 
+                // TODO: Implement and subscribe on ckEditor's ready event to get rid from timeout.
                 // wait till editor loads
                 setTimeout(() => {
                     deleteFirstChoice();
@@ -185,7 +186,7 @@ define([
                     assert.equal($('.qti-choice', $choiceArea).first().children('div').text(), 'select box', 'The final choice is now in 1st position');
                     
                     instance.destroy();
-                }, 0);
+                }, 50);
             })
             .after('destroy', function() {
                 done();

--- a/views/js/test/qtiCreator/model/interactions/gapMatchInteraction/test.js
+++ b/views/js/test/qtiCreator/model/interactions/gapMatchInteraction/test.js
@@ -186,7 +186,7 @@ define([
                     assert.equal($('.qti-choice', $choiceArea).first().children('div').text(), 'select box', 'The final choice is now in 1st position');
                     
                     instance.destroy();
-                }, 50);
+                }, 100);
             })
             .after('destroy', function() {
                 done();


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/CGA-167
**Description:** The COGNIA client has some items where interactions are wrap to the `div`'s element without the `grid` layout. In this case the element is determining as a text block and will not work properly in editing state.
**How to test:** 
- The taoMp extensions must be installed to support scaffolding PCI
- Download the item attached to the https://oat-sa.atlassian.net/browse/CGA-167
- In editing mode user should be able to make changes to the item by using editor