### PR TITLE
[UNO-152] The system does not reject decimal entering into the mix/max fields

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.14.0',
+    'version'     => '25.14.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -180,7 +180,7 @@ define([
                 if ( isFieldSupported(field) && _.isNumber(intValue) &&
                      intValue >= config.lowerThreshold && intValue <= config.upperThreshold ) {
 
-                    if ( this.is('rendered') && controls[field].input.val() !== intValue ) {
+                    if ( this.is('rendered') && _.parseInt(controls[field].input.val()) !== intValue ) {
                         return controls[field].input.val(intValue).trigger('change');
                     }
 

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -180,7 +180,7 @@ define([
                 if ( isFieldSupported(field) && _.isNumber(intValue) &&
                      intValue >= config.lowerThreshold && intValue <= config.upperThreshold ) {
 
-                    if ( this.is('rendered') && parseInt(controls[field].input.val()) !== intValue ) {
+                    if ( this.is('rendered') && parseFloat(controls[field].input.val()) !== intValue ) {
                         return controls[field].input.val(intValue).trigger('change');
                     }
 

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -175,12 +175,13 @@ define([
              */
             setValue : function setValue(field, value){
                 var config = this.getConfig();
-                var intValue = _.parseInt(value);
+                const inputParser = config.allowDecimal ? parseFloat : parseInt
+                var intValue = inputParser(value);
 
                 if ( isFieldSupported(field) && _.isNumber(intValue) &&
                      intValue >= config.lowerThreshold && intValue <= config.upperThreshold ) {
 
-                    if ( this.is('rendered') && parseFloat(controls[field].input.val()) !== intValue ) {
+                    if ( this.is('rendered') && inputParser(controls[field].input.val()) !== intValue ) {
                         return controls[field].input.val(intValue).trigger('change');
                     }
 

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -69,7 +69,10 @@ define([
         upperThreshold:     4,
 
         //does the 2 fields sync themselves
-        syncValues:       true
+        syncValues:       true,
+
+        //does the input can have decimal value
+        allowDecimal: false,
     };
 
     /**
@@ -350,6 +353,27 @@ define([
                 return this;
             },
 
+            /**
+             * convert value to number
+             *
+             * @param {String} [fromField = min] - min or max, where the change comes from to update accordingly
+             * @returns {minMax} chains
+             * @throws {TypeError} if the field is unknown
+             */
+            convertToNumber: function syncValues(fromField){
+                fromField = fromField || fields.min;
+
+                if (isFieldSupported(fromField) && this.is('rendered')) {
+                    if(fromField === fields.max){
+                        this.setMaxValue(_.parseInt(this.getMaxValue()));
+                    } else {
+                        this.setMinValue(_.parseInt(this.getMinValue()));
+                    }
+                }
+
+                return this;
+            },
+
         }, defaultConfig)
             .setTemplate(minMaxTpl)
             .on('init', function(){
@@ -400,6 +424,10 @@ define([
 
                         fieldControl.input.on('change', function(){
                             self.syncValues(field);
+
+                            if (!config.allowDecimal) {
+                                self.convertToNumber(field);
+                            }
 
                             self.trigger('change');
                         });

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -180,7 +180,7 @@ define([
                 if ( isFieldSupported(field) && _.isNumber(intValue) &&
                      intValue >= config.lowerThreshold && intValue <= config.upperThreshold ) {
 
-                    if ( this.is('rendered') && _.parseInt(controls[field].input.val()) !== intValue ) {
+                    if ( this.is('rendered') && parseInt(controls[field].input.val()) !== intValue ) {
                         return controls[field].input.val(intValue).trigger('change');
                     }
 
@@ -360,14 +360,12 @@ define([
              * @returns {minMax} chains
              * @throws {TypeError} if the field is unknown
              */
-            convertToNumber: function syncValues(fromField){
-                fromField = fromField || fields.min;
-
+            convertToNumber: function convertToNumber(fromField){
                 if (isFieldSupported(fromField) && this.is('rendered')) {
                     if(fromField === fields.max){
-                        this.setMaxValue(_.parseInt(this.getMaxValue()));
+                        this.setMaxValue(parseInt(this.getMaxValue()));
                     } else {
-                        this.setMinValue(_.parseInt(this.getMinValue()));
+                        this.setMinValue(parseInt(this.getMinValue()));
                     }
                 }
 

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -175,13 +175,12 @@ define([
              */
             setValue : function setValue(field, value){
                 var config = this.getConfig();
-                const inputParser = config.allowDecimal ? parseFloat : parseInt
-                var intValue = inputParser(value);
+                var intValue = _.parseInt(value);
 
                 if ( isFieldSupported(field) && _.isNumber(intValue) &&
                      intValue >= config.lowerThreshold && intValue <= config.upperThreshold ) {
 
-                    if ( this.is('rendered') && inputParser(controls[field].input.val()) !== intValue ) {
+                    if ( this.is('rendered') && controls[field].input.val() !== `${intValue}` ) {
                         return controls[field].input.val(intValue).trigger('change');
                     }
 


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/UNO-152
 
Add possibility to disable decimal numbers for minMax component. enable it by default
  
#### How to test
 
- open authoring for any test item
- add choice interaction
- try to change min or max choices
- try to provide decimal value
- check that it converted to number after input delay