### PR TITLE
Upgraded lib-beeme to 0.2.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "5.4.1",
+        "oat-sa/lib-tao-qti": "5.5.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/composer-npm-bridge": "^0.3.0",
         "naneau/semver": "~0.0.7"

--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.15.3',
+    'version'     => '25.16.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',


### PR DESCRIPTION
This PR upgrades lib-beeme to version 0.2.0.
This is necessary for deployment in a customer environment in this sprint, please.