### PR TITLE
Fix/con 28/simple cache for pci

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '18.7.7',
+    'version'     => '18.7.7.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => array(
         'taoItems' => '>=6.6.0',

--- a/views/js/qtiCreator/editor/interactionsToolbar.js
+++ b/views/js/qtiCreator/editor/interactionsToolbar.js
@@ -48,6 +48,8 @@ define([
         interactiontoolbarready : 'interactiontoolbarready.qti-widget'
     };
 
+    var timeouts = null;
+
     function getGroupId(groupLabel){
         return groupLabel.replace(/\W+/g, '-').toLowerCase();
     }
@@ -72,8 +74,9 @@ define([
     
     function create($sidebar, interactions){
 
+        var index = 0;
         _.each(interactions, function(interactionAuthoringData){
-            add($sidebar, interactionAuthoringData);
+            add($sidebar, interactionAuthoringData, ++index);
         });
 
         buildSubGroups($sidebar);
@@ -121,7 +124,7 @@ define([
         return !!$sidebar.find('li[data-qti-class="' + interactionClass + '"]').length;
     }
     
-    function add($sidebar, interactionAuthoringData){
+    function add($sidebar, interactionAuthoringData, index){
 
         if(exists($sidebar, interactionAuthoringData.qtiClass)){
             throw 'the interaction is already in the sidebar';
@@ -157,8 +160,28 @@ define([
             //the group does not exist yet : create a <section> for the group
             $group = addGroup($sidebar, groupLabel);
         }
+
+        var $interaction;
+        if (index < 20) {
+            $interaction = $(insertInteractionTpl(tplData));
+        } else {
+            if (!timeouts) {
+                timeouts = [];
+            }
+            $interaction = $('<li>Loading...</li>');
+            timeouts.push(setTimeout(() => {
+                if ($.contains(document, $interaction[0])) {
+                    $interaction.replaceWith(insertInteractionTpl(tplData));
+                } else {
+                    _.each(timeouts, function(timeoutID){
+                        clearTimeout(timeoutID);
+                    });
+                    timeouts = null;
+                }
+            }, 10000 + Number(index / 10).toFixed() * 1000));
+        }
         
-        var $interaction = $(insertInteractionTpl(tplData));
+
         $group.find('.tool-list').append($interaction);
         
         return $interaction;

--- a/views/js/qtiCreator/editor/interactionsToolbar.js
+++ b/views/js/qtiCreator/editor/interactionsToolbar.js
@@ -17,6 +17,7 @@
  *
  */
 define([
+    'module',
     'jquery',
     'lodash',
     'i18n',
@@ -25,7 +26,7 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/toolbars/insertInteractionGroup',
     'tpl!taoQtiItem/qtiCreator/tpl/toolbars/tooltip',
     'ui/tooltip'
-], function($, _, __, hider, insertInteractionTpl, insertSectionTpl, tooltipTpl, tooltip){
+], function(module, $, _, __, hider, insertInteractionTpl, insertSectionTpl, tooltipTpl, tooltip){
     'use strict';
 
     /**
@@ -49,6 +50,15 @@ define([
     };
 
     var timeouts = null;
+    var configs = module.config();
+    var syncLoading = _.defaults(
+        configs && configs.sync || {}, 
+        {
+            first: 20,
+            part: 10,
+            delay: 10000,
+            pause: 1000
+        });
 
     function getGroupId(groupLabel){
         return groupLabel.replace(/\W+/g, '-').toLowerCase();
@@ -162,7 +172,7 @@ define([
         }
 
         var $interaction;
-        if (index < 20) {
+        if (index < syncLoading.first) {
             $interaction = $(insertInteractionTpl(tplData));
         } else {
             if (!timeouts) {
@@ -178,7 +188,7 @@ define([
                     });
                     timeouts = null;
                 }
-            }, 10000 + Number(index / 10).toFixed() * 1000));
+            }, syncLoading.delay + Number(index / syncLoading.part).toFixed() * syncLoading.pause));
         }
         
 

--- a/views/js/qtiCreator/itemCreator.js
+++ b/views/js/qtiCreator/itemCreator.js
@@ -194,7 +194,7 @@ define([
                 });
 
                 this.on('exit', function() {
-                    $('.item-editor-item', areaBroker.getItemPanelArea()).empty();
+                    areaBroker.getInteractionPanelArea().empty();
                 })
 
                 var usedCustomInteractionIds = [];
@@ -214,10 +214,14 @@ define([
                     return true;
                 }).then(function(){
                     //load custom elements
+                    console.log('PCI+Pic start loading');
                     return Promise.all([
                         loadCustomInteractions(usedCustomInteractionIds),
                         loadInfoControls()
-                    ]);
+                    ]).then(() => {
+                        console.log('PCI+Pic are loaded');
+                    })
+                    // return true;
                 }).then(function(){
                     //initialize all the plugins
                     return pluginRun('init').then(function(){

--- a/views/js/qtiCreator/itemCreator.js
+++ b/views/js/qtiCreator/itemCreator.js
@@ -218,7 +218,6 @@ define([
                         loadCustomInteractions(usedCustomInteractionIds),
                         loadInfoControls()
                     ]);
-                    // return true;
                 }).then(function(){
                     //initialize all the plugins
                     return pluginRun('init').then(function(){

--- a/views/js/qtiCreator/itemCreator.js
+++ b/views/js/qtiCreator/itemCreator.js
@@ -214,13 +214,10 @@ define([
                     return true;
                 }).then(function(){
                     //load custom elements
-                    console.log('PCI+Pic start loading');
                     return Promise.all([
                         loadCustomInteractions(usedCustomInteractionIds),
                         loadInfoControls()
-                    ]).then(() => {
-                        console.log('PCI+Pic are loaded');
-                    })
+                    ]);
                     // return true;
                 }).then(function(){
                     //initialize all the plugins


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/CON-28
- added caching for PCI definitions tree to minimize IOPS
- reduced performance impact from loading numerous  PCI icons  by chunking

Deployed at http://test-depp-con-27.playground.kitchen.it.taocloud.org:44361/ 
Env is preloaded with ~ 400 PCI interactions 


TODO

- [ ] compile js before releasing 