### PR TITLE
Fix/TR-10/Accept a null response in the Extended Text interaction

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.16.4',
+    'version'     => '25.16.5',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-qti-item",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-+7l2uG0+6idJoxUZTojRLmZQvMgC0Z5BpIoWfbvgdM2Z/TiPHFk8PoLfn7VAOfkHl0CFTmgjHDI8N6Up5s0DGg=="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.14.0.tgz",
-      "integrity": "sha512-Xp3/Lym3KvUvAw8bSdncrHp8U68fOc2tMrKEli1RKMJcPJkHx+GdEvIBKd1AKYcIfojmKejTAl+bxLlZc667fg=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.14.1.tgz",
+      "integrity": "sha512-BkOS3iFssQ2o7t8FyFriVtKd8uJYzqAaRwZingvatZpbHPdfIQR6rTBcbUYRAZpG8KifmbzsoFI5je+HZwm5OQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.6.1",
-        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/TR-10/accept-null-response-in-extended-text-interaction"
+        "@oat-sa/tao-item-runner-qti": "^0.14.1"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qti-item",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "license": "GPL-2.0",
     "description": "taoQtiItem frontend modules",
     "repository": {
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.6.1",
-        "@oat-sa/tao-item-runner-qti": "0.14.0"
+        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/TR-10/accept-null-response-in-extended-text-interaction"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.6.1",
-        "@oat-sa/tao-item-runner-qti": "^0.14.1"
+        "@oat-sa/tao-item-runner-qti": "0.14.1"
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-10

Requires: 
 - [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/119
 - [x] once the companion has been merged, released and published, the version must be set in `package.json`, and the lock file updated as well.

When an Extended Text interaction is set with a null response, it triggers an error. This is particularly annoying in the Test Reviewer, as empty responses are restored as null responses.

How to test:
- unit tests:
```
cd taoQtiItem/views
npm i
cd ../../tao/views/build
npx grunt connect:dev taoqtiitemtest
```
- delivery / test review:
    1. pre-requisite:
        - a TAO instance with the extensions `ltiDeliveryProvider` and `ltiTestReview`
        - a LTI provider configured
    1. create a test containing at least one Extended Text interaction
    1. create the delivery
    1. copy the LTI link
    1. open http://ltiapps.net/test/tc.php
    1. paste the LTI link, set the correct key and secret, select the `Learner` role
    1. save the data and launch the TP
    1. complete the test wihout answering
    1. from the return page, copy the url parameter after `deliveryExecution=`
    1. return to the page http://ltiapps.net/test/tc.php
    1. set the URL as `http://<YOUR-HOST>/ltiTestReview/ReviewTool/launch?execution=<DELIVERY EXECUTION>`, replacing the placeholders by your local host and the url parameter copied previously
    1. tick the `Display optional parameters` option
    1. in `Custom parameters`, type: `show_correct=1 show_score=1`
    1. save the data and launch the TP
    1. without the fix an error should appear when the Extended Text item is reached, with the fix no error shoud show up
