### PR TITLE
Feature/CON-25/support Item Preview providers from module config

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.16.9',
+    'version'     => '25.17.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/js/qtiCreator/plugins/menu/preview.js
+++ b/views/js/qtiCreator/plugins/menu/preview.js
@@ -25,13 +25,14 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
+    'module',
     'jquery',
     'i18n',
     'core/plugin',
     'ui/hider',
     'taoItems/previewer/factory',
     'tpl!taoQtiItem/qtiCreator/plugins/button',
-], function($, __, pluginFactory, hider, previewerFactory, buttonTpl){
+], function(module, $, __, pluginFactory, hider, previewerFactory, buttonTpl){
     'use strict';
 
     /**
@@ -91,7 +92,8 @@ define([
              * @param {String} uri - the uri of this item to preview
              */
             itemCreator.on('preview', function(uri) {
-                var type = 'qtiItem';
+                const config = module.config();
+                var type = config.provider || 'qtiItem';
 
                 if (!this.isEmpty()) {
                     previewerFactory(type, uri, {}, {

--- a/views/js/qtiCreator/plugins/menu/preview.js
+++ b/views/js/qtiCreator/plugins/menu/preview.js
@@ -84,7 +84,7 @@ define([
          * @fires {itemCreator#preview}
          */
         init : function init(){
-            var itemCreator = this.getHost();
+            const itemCreator = this.getHost();
 
             /**
              * Preview an item
@@ -93,7 +93,7 @@ define([
              */
             itemCreator.on('preview', function(uri) {
                 const config = module.config();
-                var type = config.provider || 'qtiItem';
+                const type = config.provider || 'qtiItem';
 
                 if (!this.isEmpty()) {
                     previewerFactory(type, uri, {}, {
@@ -124,7 +124,7 @@ define([
         render : function render(){
 
             //attach the element to the menu area
-            var $container = this.getAreaBroker().getMenuArea();
+            const $container = this.getAreaBroker().getMenuArea();
             if (this.getHost().isEmpty()) {
                 this.disable();
             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-25
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/110
https://github.com/oat-sa/extension-tao-test-preview-ui-loader/pull/12
https://github.com/oat-sa/extension-tao-itemqti/pull/1585

Added support for Item Preview providers from `module.config `

How to test:
- go to page Items
- click Preview
- check that preview uses new UI
- go to Item Authoring page
- click Preview
- check that preview uses new UI
![image](https://user-images.githubusercontent.com/25976342/99570701-6395aa80-29e3-11eb-8832-13a1491e32c4.png)