### PR TITLE
Fix/TR-213/Limit the number of times a media can be played

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.17.0',
+    'version'     => '25.17.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-+7l2uG0+6idJoxUZTojRLmZQvMgC0Z5BpIoWfbvgdM2Z/TiPHFk8PoLfn7VAOfkHl0CFTmgjHDI8N6Up5s0DGg=="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.14.1.tgz",
-      "integrity": "sha512-BkOS3iFssQ2o7t8FyFriVtKd8uJYzqAaRwZingvatZpbHPdfIQR6rTBcbUYRAZpG8KifmbzsoFI5je+HZwm5OQ=="
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.15.1.tgz",
+      "integrity": "sha512-F9UO65s6UQ2nzc4ljEsWRGSFs0onD0pQ2Q1VxjEGiSHzqspvypavx7/CrkKCtlomoK+mClSaJS0tvZ/8rubKRQ=="
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-qti-item",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.6.1",
-        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/TR-213/limit-the-number-of-times-a-media-can-be-played"
+        "@oat-sa/tao-item-runner-qti": "0.15.1"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qti-item",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "license": "GPL-2.0",
     "description": "taoQtiItem frontend modules",
     "repository": {
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.6.1",
-        "@oat-sa/tao-item-runner-qti": "0.14.1"
+        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/TR-213/limit-the-number-of-times-a-media-can-be-played"
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-213

Requires: 
 - [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/124
 - [x] once the companion PR has been merged, update the `package.json` and `package-lock.json` with the published version

Update `@oat-sa/tao-item-runner-qti` with the fix making sure the media player prevents playing more times when the state is restored and the limit is reached.