### PR TITLE
Fix/TR-157/Do not disable media interactions in review

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.18.1',
+    'version'     => '25.18.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.13.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-qti-item",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qti-item",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "license": "GPL-2.0",
     "description": "taoQtiItem frontend modules",
     "repository": {
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.6.1",
-        "@oat-sa/tao-item-runner-qti": "0.15.1"
+        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/TR-157/do-not-disable-mediainteraction-in-review"
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-157

Requires: 
 - [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/128
 - [x] once the companion has been merged, update `package-lock.json` with the published version

Update `@oat-sa/tao-item-runner-qti` with the fix to prevent the media interaction to be disabled in review mode.
(Fix a regression introduced by the fix made for [TR-213](https://oat-sa.atlassian.net/browse/TR-213), in the PR #1592)

Requirements:
- a TAO instance with the LTI Test Review extension installed
- a test containing a media interaction with some limitation (ex: max play 1)
- LTI configured
- run `npm i` in the views folder of the extension

How to test:
- have a test containing a media interaction with some limitation (ex: max play 1)
- publish the test, and grab an LTI link for the delivery 
- open the LTI emulator (http://ltiapps.net/test/tc.php), put the link to the delivery into the launch URL, the key, and the secret, then set the role as `Learner`.
- save and launch the activity into another window
- take the test, reach the limits in the media interactions
- once the test is finished, copy the deliveryExecution parameter (it will be needed to launch the ltiTestReview)
    <img width="1125" alt="image" src="https://user-images.githubusercontent.com/1500098/100768839-a13efe00-33fb-11eb-93bf-a9d2bdc1ce92.png">
- go back to the LTI emulator
- set the URL as `<HOST>/ltiTestReview/ReviewTool/launch?execution=<DELIVERY_EXECUTION>`, replacing the placeholders by your TAO host and the deliveryExecution parameter copied in a previous step
- tick the checkbox `Display optional parameters`
- write the custom parameters: `show_score=1 show_correct=1`
    <img width="1160" alt="image" src="https://user-images.githubusercontent.com/1500098/100769673-ae102180-33fc-11eb-9e9e-e1f41480ee16.png">
- keep the role as `Learner`.
- save and launch the activity into another window
- the ltiTestReview should start with the delivery and the answer previously given
- make sure the media interaction are not limited, the interactions should be reachable, but not modifiable.
