### PR TITLE
Feature/con 288/added item enhanced meta data

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.21.0',
+    'version'     => '25.22.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/model/QtiJsonItemCompiler.php
+++ b/model/QtiJsonItemCompiler.php
@@ -29,6 +29,7 @@ use core_kernel_classes_Resource;
 use DOMDocument;
 use Exception;
 use oat\oatbox\filesystem\Directory;
+use oat\oatbox\log\LoggerAwareTrait;
 use oat\taoItems\model\media\ItemMediaResolver;
 use oat\taoQtiItem\model\compile\QtiAssetCompiler\QtiItemAssetCompiler;
 use oat\taoQtiItem\model\compile\QtiAssetCompiler\QtiItemAssetXmlReplacer;
@@ -54,6 +55,7 @@ use Throwable;
  */
 class QtiJsonItemCompiler extends QtiItemCompiler
 {
+    use LoggerAwareTrait;
 
     public const ITEM_FILE_NAME = 'item.json';
     public const VAR_ELT_FILE_NAME = 'variableElements.json';
@@ -305,7 +307,7 @@ class QtiJsonItemCompiler extends QtiItemCompiler
         try {
             return new core_kernel_classes_Resource($uri);
         } catch (common_exception_Error $e) {
-            error_log('ERROR::' . $e->getMessage());
+            $this->logError('MetaData resource retrieving failed: ' . $e->getMessage());
         }
 
         return null;


### PR DESCRIPTION
ticket :https://oat-sa.atlassian.net/browse/CON-288

[DataStore][BE] Gather metadata information and parse to storage format

We need to gather metadata information and parse it to the storage format (I propose the JSON format).

testing :
create a new delivery and serach inside the private folder
![image](https://user-images.githubusercontent.com/50211080/104565691-edad6880-564c-11eb-8f30-b3a1e5c08f76.png)
 