### PR TITLE
Fix/tca 772/oatsd 947 replace assets in file href nodes

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.21.0',
+    'version'     => '25.21.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetXmlReplacer.php
@@ -53,6 +53,15 @@ class QtiItemAssetXmlReplacer extends ConfigurationService
             }
         }
 
+        $fileHrefNodes =  $xpath->query("//*[local-name()='fileHref']");
+
+        /** @var DOMElement $fileHrefNodes */
+        foreach ($fileHrefNodes as $node) {
+            if (isset($packedAssets[$node->nodeValue])) {
+                $node->nodeValue = $packedAssets[$node->nodeValue]->getReplacedBy();
+            }
+        }
+
         $this->replaceEncodedNodes($xpath, $packedAssets);
 
         return $packedAssets;

--- a/test/unit/model/compile/QtiItemAssetXmlReplacerTest.php
+++ b/test/unit/model/compile/QtiItemAssetXmlReplacerTest.php
@@ -48,10 +48,15 @@ class QtiItemAssetXmlReplacerTest extends TestCase
         $packedAsset2->method('getReplacedBy')
             ->willReturn('new-link-fixture_2');
 
+        $packedAsset3 = $this->createMock(PackedAsset::class);
+        $packedAsset3->method('getReplacedBy')
+            ->willReturn('new-link-fixture_3');
+
         $packedAssets = [
             'fixture' => $packedAsset,
             'decoded_fixture' => $packedAsset2,
             'another-fixture' => '',
+            'hrefFixture' => $packedAsset3,
         ];
 
         $domDocument = new DOMDocument('1.0', 'UTF-8');
@@ -65,6 +70,11 @@ class QtiItemAssetXmlReplacerTest extends TestCase
         )));
         $domDocument->appendChild($element);
 
+        $element = $domDocument->createElement('fileHref');
+        $element->appendChild($domDocument->createTextNode('hrefFixture'));
+        $domDocument->appendChild($element);
+
+
         $this->subject->replaceAssetNodeValue($domDocument, $packedAssets);
 
         $attributes = $domDocument->getElementsByTagName('video')->item(0)->attributes;
@@ -74,6 +84,9 @@ class QtiItemAssetXmlReplacerTest extends TestCase
         $this->assertEquals(htmlentities(
             '<img src="new-link-fixture_2" alt="type="image/png"/>'
         ), $propertyValue);
+
+        $hrefValue = $domDocument->getElementsByTagName('fileHref')->item(0)->nodeValue;
+        $this->assertEquals('new-link-fixture_3', $hrefValue);
     }
 
     public function testReplaceAssetNodeValues()


### PR DESCRIPTION
At time of item compilation path to assets should be replaced.
`QtiItemAssetXmlReplacer` replaces only assets links in element properties.

APIP elements may have links to assets in `<fileHref>` nodes:
```
<audioFileInfo contentLinkIdentifier="audioFileInfo374902_xml" mimeType="application/xml">
    <fileHref>assets/psg_ae001_374902.xml</fileHref>
    <voiceType>Synthetic</voiceType>
    <voiceSpeed>Standard</voiceSpeed>
</audioFileInfo>
```

Such links also have to be replaces.

Steps to test:

1. Import the package attached to https://oat-sa.atlassian.net/browse/TCA-772
2. compile delivery
3. run the test and press play button