### PR TITLE
[Refactoring] - CON 485 - Align language list requests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.23.0',
+    'version'     => '25.23.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/views/js/test/qtiCreator/component/itemAuthoring/test.js
+++ b/views/js/test/qtiCreator/component/itemAuthoring/test.js
@@ -40,10 +40,10 @@ define([
     $.mockjaxSettings.responseTime = 1;
 
     // Mock the item data query
-    $.mockjax({
-        url: '/*',
+    $.mockjax([{
+        url: /mockItemEndpoint/,
+        status: 200,
         responseText: {
-            success: true,
             itemIdentifier: 'item-1',
             itemData: {
                 content: {
@@ -54,7 +54,17 @@ define([
                 state: {}
             }
         }
-    });
+    }, {
+        url: 'undefined/tao/Languages/index',
+        responseText: {
+            "success": true,
+            "data": {
+                "en-GB":"British English",
+                "en-US":"English"
+            }
+        },
+        status: 200
+    }]);
 
     QUnit.module('API');
 
@@ -145,6 +155,15 @@ define([
                 label: 'Item'
             }
         }
+    }, {
+        title: 'Missing itemData url',
+        config: {
+            properties: {
+                uri: 'http://item#rdf-123',
+                label: 'Item',
+                baseUrl: 'http://foo/bar/'
+            }
+        }
     }]).test('error ', (data, assert) => {
         const ready = assert.async();
         const $container = $('#fixture-error');
@@ -171,7 +190,8 @@ define([
             properties: {
                 uri: 'http://item#rdf-123',
                 label: 'Item',
-                baseUrl: 'http://foo/bar/'
+                baseUrl: 'http://foo/bar/',
+                itemDataUrl: '//mockItemEndpoint',
             }
         };
         const instance = itemAuthoringFactory($container, config);
@@ -192,7 +212,7 @@ define([
                 assert.ok(false, 'The operation should not fail!');
                 assert.pushResult({
                     result: false,
-                    message: err
+                    message: JSON.stringify(err)
                 });
                 ready();
             });
@@ -205,7 +225,8 @@ define([
             properties: {
                 uri: 'http://item#rdf-123',
                 label: 'Item',
-                baseUrl: 'http://foo/bar/'
+                baseUrl: 'http://foo/bar/',
+                itemDataUrl: '//mockItemEndpoint',
             }
         };
 
@@ -233,7 +254,7 @@ define([
                 assert.ok(false, 'The operation should not fail!');
                 assert.pushResult({
                     result: false,
-                    message: err
+                    message: JSON.stringify(err)
                 });
                 ready();
             });
@@ -246,7 +267,8 @@ define([
             properties: {
                 uri: 'http://item#rdf-123',
                 label: 'Item',
-                baseUrl: 'http://foo/bar/'
+                baseUrl: 'http://foo/bar/',
+                itemDataUrl: '//mockItemEndpoint'
             }
         };
 
@@ -271,7 +293,7 @@ define([
                 assert.ok(false, 'The operation should not fail!');
                 assert.pushResult({
                     result: false,
-                    message: err
+                    message: JSON.stringify(err)
                 });
                 ready();
             });

--- a/views/js/test/qtiCreator/model/interactions/gapMatchInteraction/test.js
+++ b/views/js/test/qtiCreator/model/interactions/gapMatchInteraction/test.js
@@ -39,16 +39,24 @@ define([
     $.mockjaxSettings.responseTime = 1;
 
     // Mock the item data query
-    $.mockjax({
+    $.mockjax([{
         url: /mockItemEndpoint/,
-        response: function() {
-            this.responseText = {
-                success: true,
-                itemIdentifier: 'item-1',
-                itemData: gapMatchJson
-            };
+        status: 200,
+        responseText: {
+            itemIdentifier: 'item-1',
+            itemData: gapMatchJson
         }
-    });
+    }, {
+        url: 'undefined/tao/Languages/index',
+        responseText: {
+            "success": true,
+            "data": {
+                "en-GB":"British English",
+                "en-US":"English"
+            }
+        },
+        status: 200
+    }]);
 
     QUnit.module('API');
 

--- a/views/js/test/qtiCreator/model/interactions/mixin/editableInteraction/test.js
+++ b/views/js/test/qtiCreator/model/interactions/mixin/editableInteraction/test.js
@@ -35,16 +35,24 @@ define([
     $.mockjaxSettings.responseTime = 1;
 
     // Mock the item data query
-    $.mockjax({
+    $.mockjax([{
         url: /mockItemEndpoint/,
-        response: function () {
-            this.responseText = {
-                success: true,
-                itemIdentifier: 'item-1',
-                itemData: itemJson
-            };
+        status: 200,
+        responseText: {
+            itemIdentifier: 'item-1',
+            itemData: itemJson
         }
-    });
+    }, {
+        url: 'undefined/tao/Languages/index',
+        responseText: {
+            "success": true,
+            "data": {
+                "en-GB":"British English",
+                "en-US":"English"
+            }
+        },
+        status: 200
+    }]);
 
     QUnit.module('editableInteraction mixin');
 

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qti-item",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "license": "GPL-2.0",
     "description": "taoQtiItem frontend modules",
     "repository": {

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qti-item",
-    "version": "0.3.4",
+    "version": "0.3.3",
     "license": "GPL-2.0",
     "description": "taoQtiItem frontend modules",
     "repository": {


### PR DESCRIPTION
**Jira issue**
https://oat-sa.atlassian.net/browse/CON-485

**What has changed**
I refactored itemLoader to make separate request to fetch list of languages using `request` lib from tao-core-sdk
Also updated mocks in tests for `itemData` and `languages`

**Testing environment**
http://test-sveta.playground.kitchen.it.taocloud.org:40431/