### PR TITLE
Fix/CON-238/reset settings in media after changing source

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.23.1',
+    'version'     => '25.23.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
@@ -291,6 +291,8 @@ define([
                 let value;
                 if (interaction.object.attr(attrName) !== attrValue) {
                     interaction.object.attr(attrName, attrValue);
+                    interaction.object.removeAttr('width');
+                    interaction.object.removeAttr('height');
 
                     value = $.trim(attrValue).toLowerCase();
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-238

Fixed reset of width in Media Interaction and object after changing source.

How to test:

- go to Item Authoring
- create Media Interaction and A-block with object contained video with width 50% for example
- save go to Items page
- return to item Authoring
- change source in Media Interaction(to audio) and object(to image)
- width should be reseted