### PR TITLE
Fix/CON-540/plugin blockAdder fix event click outside

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.23.1',
+    'version'     => '25.23.3',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.23.2',
+    'version'     => '25.23.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/views/js/qtiCreator/editor/blockAdder/blockAdder.js
+++ b/views/js/qtiCreator/editor/blockAdder/blockAdder.js
@@ -82,8 +82,8 @@ define([
                 });
 
             //when clicking outside of the selector popup, consider it done
-            $editorPanel.on('ready.qti-widget', function (e) {
-                $itemEditorPanel.off(`click${_ns} mousedown${_ns}`).on(`click${_ns} mousedown${_ns}`, function () {
+            $editorPanel.on('ready.qti-widget', function () {
+                $itemEditorPanel.off(`click${_ns} mousedown${_ns}`).on(`click${_ns} mousedown${_ns}`, function (e) {
                     const popup = selector.getPopup()[0];
                     if (widget && widget.element && popup !== e.target && !$.contains(popup, e.target)) {
                         _done($wrap);

--- a/views/js/qtiCreator/editor/blockAdder/blockAdder.js
+++ b/views/js/qtiCreator/editor/blockAdder/blockAdder.js
@@ -84,9 +84,11 @@ define([
             //when clicking outside of the selector popup, consider it done
             $editorPanel.on('ready.qti-widget', function () {
                 $itemEditorPanel.off(`click${_ns} mousedown${_ns}`).on(`click${_ns} mousedown${_ns}`, function (e) {
-                    const popup = selector.getPopup()[0];
-                    if (widget && widget.element && popup !== e.target && !$.contains(popup, e.target)) {
-                        _done($wrap);
+                    if (selector) {
+                        const popup = selector.getPopup()[0];
+                        if (widget && widget.element && popup !== e.target && !$.contains(popup, e.target)) {
+                            _done($wrap);
+                        }
                     }
                 });
             });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-540

Regression after https://github.com/oat-sa/extension-tao-itemqti/pull/1624
Fixed issue with click outside

How to test:
- enable blockAdded plugin config/taoQtiItem/qtiCreator.conf.php option 'multi-column' => true,
- go to Item Authoring
- add some interaction in item
- try to double click on plus button
- in opened widget check some Common interaction
- plugin should work correctly, no errors in console