### PR TITLE
fix: plugins array without indexes in the config

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.24.0',
+    'version'     => '25.24.1',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/migrations/Version202102051019351101_taoQtiItem.php
+++ b/migrations/Version202102051019351101_taoQtiItem.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\ClientLibConfigRegistry;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiItem\model\QtiCreatorClientConfigRegistry;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202102051019351101_taoQtiItem extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Actualize the plugins is client_lib_config_registry.conf';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $registry = ClientLibConfigRegistry::getRegistry();
+
+        if ($registry->isRegistered(QtiCreatorClientConfigRegistry::CREATOR)) {
+            /** @var array $config */
+            $config = $registry->get(QtiCreatorClientConfigRegistry::CREATOR);
+            $plugins = [];
+            if (!empty($config['plugins'])) {
+                foreach ($config['plugins'] as $plugin) {
+                    $plugins[] = $plugin;
+                }
+            }
+            $config['plugins'] = $plugins;
+            $registry->set(QtiCreatorClientConfigRegistry::CREATOR, $config);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/migrations/Version202102051019351101_taoQtiItem.php
+++ b/migrations/Version202102051019351101_taoQtiItem.php
@@ -27,20 +27,15 @@ final class Version202102051019351101_taoQtiItem extends AbstractMigration
         if ($registry->isRegistered(QtiCreatorClientConfigRegistry::CREATOR)) {
             /** @var array $config */
             $config = $registry->get(QtiCreatorClientConfigRegistry::CREATOR);
-            $plugins = [];
             if (!empty($config['plugins'])) {
-                foreach ($config['plugins'] as $plugin) {
-                    $plugins[] = $plugin;
-                }
+                $config['plugins'] = array_values($config['plugins']);
             }
-            $config['plugins'] = $plugins;
             $registry->set(QtiCreatorClientConfigRegistry::CREATOR, $config);
         }
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
-
+        $this->throwIrreversibleMigrationException();
     }
 }

--- a/model/QtiCreatorClientConfigRegistry.php
+++ b/model/QtiCreatorClientConfigRegistry.php
@@ -76,7 +76,7 @@ class QtiCreatorClientConfigRegistry extends ClientLibConfigRegistry
             'position' => $position,
         ];
 
-        $config['plugins'] = $plugins;
+        $config['plugins'] = array_values($plugins);
         $registry->set(self::CREATOR, $config);
     }
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-439

Sometimes (in old production environments) we have the incorrect structure for config/tao/client_lib_config_registry.conf.php.
`'taoQtiItem/controller/creator/index' => array(
            'plugins' => array(
                0 => array(
                    'name' => 'back',
                    'module' => 'taoQtiItem/qtiCreator/plugins/navigation/back',
                    'category' => 'navigation',
                    'position' => null
                ),
                2 => array(
                    'name' => 'itemTemplates',
                    'module' => 'taoNfer/qtiCreator/plugins/panel/itemTemplates',
                    'category' => 'panel',
                    'position' => null
                )
            )
        ),`
The easiest way to fix its revert it to the:
`'taoQtiItem/controller/creator/index' => array(
            'plugins' => array(
                array(
                    'name' => 'back',
                    'module' => 'taoQtiItem/qtiCreator/plugins/navigation/back',
                    'category' => 'navigation',
                    'position' => null
                ),
                array(
                    'name' => 'itemTemplates',
                    'module' => 'taoNfer/qtiCreator/plugins/panel/itemTemplates',
                    'category' => 'panel',
                    'position' => null
                )
            )
        ),`