### PR TITLE
[Fix: CON 609] - Illegal character braking qti item

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.24.1',
+    'version'     => '25.24.2',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',

--- a/model/qti/ParserFactory.php
+++ b/model/qti/ParserFactory.php
@@ -855,7 +855,6 @@ class ParserFactory
         foreach ($correctResponseNodes as $correctResponseNode) {
             foreach ($correctResponseNode->value as $value) {
                 $correct = (string) $value;
-                //$correct = str_replace('<', '&lt', $correct);
                 $response = new Value();
                 foreach ($value->attributes() as $attrName => $attrValue) {
                     $response->setAttribute($attrName, strval($attrValue));

--- a/model/qti/ParserFactory.php
+++ b/model/qti/ParserFactory.php
@@ -855,6 +855,7 @@ class ParserFactory
         foreach ($correctResponseNodes as $correctResponseNode) {
             foreach ($correctResponseNode->value as $value) {
                 $correct = (string) $value;
+                //$correct = str_replace('<', '&lt', $correct);
                 $response = new Value();
                 foreach ($value->attributes() as $attrName => $attrValue) {
                     $response->setAttribute($attrName, strval($attrValue));
@@ -899,7 +900,7 @@ class ParserFactory
 
             $mapping = [];
             foreach ($mappingNode->mapEntry as $mapEntry) {
-                $mapping[(string) $mapEntry['mapKey']] = (string) $mapEntry['mappedValue'];
+                $mapping[(string) htmlspecialchars($mapEntry['mapKey'])] = (string) $mapEntry['mappedValue'];
             }
             $myResponse->setMapping($mapping);
 

--- a/views/js/qtiCreator/helper/itemLoader.js
+++ b/views/js/qtiCreator/helper/itemLoader.js
@@ -31,16 +31,17 @@ define([
         return uri.substr(pos + 1);
     };
 
-    var decodeHtml = function (str) {
-        var map =
-            {
-                '&amp;': '&',
-                '&lt;': '<',
-                '&gt;': '>',
-                '&quot;': '"',
-                '&#039;': "'"
-            };
-        return str.replace(/&amp;|&lt;|&gt;|&quot;|&#039;/g, function(m) {return map[m];});
+    const decodeHtml = function (str) {
+        const map = {
+            '&amp;': '&',
+            '&lt;': '<',
+            '&gt;': '>',
+            '&quot;': '"',
+            '&#039;': "'"
+        };
+        return str.replace(/&amp;|&lt;|&gt;|&quot;|&#039;/g, function(m) {
+            return map[m];
+        });
     };
 
     var qtiNamespace = 'http://www.imsglobal.org/xsd/imsqti_v2p2';
@@ -63,8 +64,8 @@ define([
                     var loader, itemData, newItem;
 
                     let newObject = {};
-                    for (var response in data.itemData.responses) {
-                        for (var mapKey in data.itemData.responses[response].mapping) {
+                    for (const response in data.itemData.responses) {
+                        for (const mapKey in data.itemData.responses[response].mapping) {
                             newObject[decodeHtml(mapKey)] = data.itemData.responses[response].mapping[mapKey];
                         }
                         data.itemData.responses[response].mapping = newObject;

--- a/views/js/qtiCreator/helper/itemLoader.js
+++ b/views/js/qtiCreator/helper/itemLoader.js
@@ -31,6 +31,18 @@ define([
         return uri.substr(pos + 1);
     };
 
+    var decodeHtml = function (str) {
+        var map =
+            {
+                '&amp;': '&',
+                '&lt;': '<',
+                '&gt;': '>',
+                '&quot;': '"',
+                '&#039;': "'"
+            };
+        return str.replace(/&amp;|&lt;|&gt;|&quot;|&#039;/g, function(m) {return map[m];});
+    };
+
     var qtiNamespace = 'http://www.imsglobal.org/xsd/imsqti_v2p2';
 
     var qtiSchemaLocation = {
@@ -49,6 +61,14 @@ define([
 
                 Promise.all([langList, itemRdf]).then(([languagesList, data]) => {
                     var loader, itemData, newItem;
+
+                    let newObject = {};
+                    for (var response in data.itemData.responses) {
+                        for (var mapKey in data.itemData.responses[response].mapping) {
+                            newObject[decodeHtml(mapKey)] = data.itemData.responses[response].mapping[mapKey];
+                        }
+                        data.itemData.responses[response].mapping = newObject;
+                    }
 
                     if (data.itemData && data.itemData.qtiClass === 'assessmentItem') {
 

--- a/views/js/qtiCreator/helper/itemLoader.js
+++ b/views/js/qtiCreator/helper/itemLoader.js
@@ -63,12 +63,14 @@ define([
                 Promise.all([langList, itemRdf]).then(([languagesList, data]) => {
                     var loader, itemData, newItem;
 
-                    let newObject = {};
-                    for (const response in data.itemData.responses) {
-                        for (const mapKey in data.itemData.responses[response].mapping) {
-                            newObject[decodeHtml(mapKey)] = data.itemData.responses[response].mapping[mapKey];
+                    if (data.itemData) {
+                        let newObject = {};
+                        for (const response in data.itemData.responses) {
+                            for (const mapKey in data.itemData.responses[response].mapping) {
+                                newObject[decodeHtml(mapKey)] = data.itemData.responses[response].mapping[mapKey];
+                            }
+                            data.itemData.responses[response].mapping = newObject;
                         }
-                        data.itemData.responses[response].mapping = newObject;
                     }
 
                     if (data.itemData && data.itemData.qtiClass === 'assessmentItem') {


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/CON-606
https://oat-sa.atlassian.net/browse/AUT-1 (old CON-609)

**Description**

It is not possible to create an inline text entry with a correct response containing the character "<" when using map response response processing: TAO refuses to save or import such an item

**Steps to reproduce**

- Create an item
- Add a text block
- Add an inline text entry
- Set the response mode to Map response
- In one of the possible response, enter a value with the character < (inferior)
- Save the item

**Actual result**

Error message: The item has not been saved! An error occurred at the level of the QTI model.

**Expected result**

TAO saves the item.

If you manually edit the item XML to enter &lt; instead of < then it seems to work BUT TAO cannot import back the item

**Deployed**

http://test-juan.playground.kitchen.it.taocloud.org:49241/tao/Main/login