### PR TITLE
Upgraded qti-sdk for support of more than 255 variable declarations in a test.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "5.5.0",
+        "oat-sa/lib-tao-qti": "7.0.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7"
     },

--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.25.0',
+    'version'     => '26.0.0',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.19.0',


### PR DESCRIPTION
Count of variable declarations is stored in the test session using a short integer (0-255). This PR replaces this storage format with an integer (0-2147483647) and creates a new binary storage version, allowing the handling of test sessions with more than 255 variable declarations.

BEWARE:
All previously existing binary sessions are read correctly and subsequently written in this new format upon persistence.
BUT THERE'S NO TURNING BACK: A session stored in the new version won't be read correctly by a previous version, making the test unusable.