### PR TITLE
Upgraded qti-sdk for continued support of Match operator in PHP 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "7.0.0",
+        "oat-sa/lib-tao-qti": "7.0.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7"
     },


### PR DESCRIPTION
In PHP 8.*, `match` is a reserved word, the Match operator class has been renamed `MatchOperator` but former Tao compiled tests still contain generated PHP code with references to the `Match` class.

This PR makes sure these compiled tests still run in PHP 7.*.
However, when run on PHP 8.0, the older compiled tests containing usages of the `Match` class will have to be updated either by re-publishing or by running a script to update the generated PHP code.
