### PR TITLE
fix/AUT-138/use e.target to get clicked link

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/Widget.js
@@ -106,8 +106,8 @@ define([
         //if the answer state has been registered
         if (this.registeredStates.answer) {
             //initialize the state switcher
-            $toolbar.on('click', '.link', () => {
-                const $link = $(this),
+            $toolbar.on('click', '.link', (e) => {
+                const $link = $(e.target),
                     state = $link.data('state');
 
                 $link.siblings('.selected').removeClass('selected').addClass('link');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-138

Issue after refactoring ES5 code and using arrow function.

How to test:

1. Add any interaction to the canvas
2. Select "Response" tab.
3. No errors

 