### PR TITLE
feat: if preselected empty we are using default list

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
@@ -56,7 +56,6 @@ define([
         }
 
         for (var i in types) {
-
             if (_.indexOf(preselected, types[i].mime) >= 0) {
                 types[i].selected = true;
                 selectedMime = types[i].mime;

--- a/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
@@ -18,6 +18,7 @@
  */
 
 define([
+    'module',
     'lodash',
     'i18n',
     'taoQtiItem/qtiCreator/widgets/states/factory',
@@ -25,7 +26,7 @@ define([
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'taoQtiItem/qtiCommonRenderer/helpers/uploadMime',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/upload'
-], function(_, __, stateFactory, Question, formElement, uploadHelper, formTpl){
+], function(module, _, __, stateFactory, Question, formElement, uploadHelper, formTpl){
 
     'use strict';
     var UploadInteractionStateQuestion = stateFactory.extend(Question);
@@ -40,6 +41,13 @@ define([
             // Pre-select a value in the types combo box if needed.
             preselected = uploadHelper.getExpectedTypes(interaction);
 
+        const config = module.config();
+
+        if (preselected.length === 0 && config.defaultList.length > 0) {
+            preselected = preselected.concat(config.defaultList)
+            uploadHelper.setExpectedTypes(interaction, config.defaultList);
+        }
+
         types.unshift({ "mime" : "any/kind", "label" : __("-- Any kind of file --") });
 
         if (interaction.attr('type') === '') {
@@ -48,6 +56,7 @@ define([
         }
 
         for (var i in types) {
+
             if (_.indexOf(preselected, types[i].mime) >= 0) {
                 types[i].selected = true;
                 selectedMime = types[i].mime;

--- a/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
@@ -43,8 +43,8 @@ define([
 
         const config = module.config();
 
-        if (preselected.length === 0 && config.defaultList.length > 0) {
-            preselected = preselected.concat(config.defaultList)
+        if (preselected.length === 0 && config.defaultList && config.defaultList.length > 0) {
+            preselected = preselected.concat(config.defaultList);
             uploadHelper.setExpectedTypes(interaction, config.defaultList);
         }
 


### PR DESCRIPTION
Providing user with preselected default list mime types for upload interaction.

https://oat-sa.atlassian.net/browse/AUT-19