### PR TITLE
Feat/aut 113/add itemidentifier validator

### DIFF
--- a/controller/QtiCreator.php
+++ b/controller/QtiCreator.php
@@ -22,31 +22,33 @@
 
 namespace oat\taoQtiItem\controller;
 
+use common_exception_BadRequest;
 use common_exception_Error;
 use core_kernel_classes_Resource;
 use oat\generis\model\data\event\ResourceUpdated;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\event\EventManager;
 use oat\tao\model\http\HttpJsonResponseTrait;
+use oat\tao\model\media\MediaService;
 use oat\tao\model\TaoOntology;
 use oat\taoItems\model\event\ItemCreatedEvent;
+use oat\taoItems\model\media\ItemMediaResolver;
 use oat\taoQtiItem\helpers\Authoring;
 use oat\taoQtiItem\model\CreatorConfig;
 use oat\taoQtiItem\model\event\ItemCreatorLoad;
 use oat\taoQtiItem\model\HookRegistry;
+use oat\taoQtiItem\model\ItemModel;
 use oat\taoQtiItem\model\qti\event\UpdatedItemEventDispatcher;
+use oat\taoQtiItem\model\qti\exception\QtiModelException;
+use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\parser\XmlToItemParser;
 use oat\taoQtiItem\model\qti\Service;
+use oat\taoQtiItem\model\qti\validator\ItemIdentifierValidator;
 use tao_actions_CommonModule;
 use tao_helpers_File;
 use tao_helpers_Http;
 use tao_helpers_Uri;
 use taoItems_models_classes_ItemsService;
-use oat\taoQtiItem\model\ItemModel;
-use oat\taoItems\model\media\ItemMediaResolver;
-use oat\tao\model\media\MediaService;
-use oat\taoQtiItem\model\qti\exception\QtiModelException;
-use common_exception_BadRequest;
 
 /**
  * QtiCreator Controller provide actions to edit a QTI item
@@ -196,6 +198,7 @@ class QtiCreator extends tao_actions_CommonModule
                     Authoring::checkEmptyMedia($xml);
 
                     $item = $this->getXmlToItemParser()->parseAndSanitize($xml);
+                    $this->getItemIdentifierValidator()->validate($item);
 
                     $returnValue['success'] = $itemService->saveDataItemToRdfItem($item, $rdfItem);
 
@@ -325,6 +328,11 @@ class QtiCreator extends tao_actions_CommonModule
     private function getXmlToItemParser(): XmlToItemParser
     {
         return $this->getServiceLocator()->get(XmlToItemParser::class);
+    }
+
+    private function getItemIdentifierValidator(): ItemIdentifierValidator
+    {
+        return $this->getServiceLocator()->get(ItemIdentifierValidator::class);
     }
 
     /**

--- a/model/qti/validator/ItemIdentifierValidator.php
+++ b/model/qti/validator/ItemIdentifierValidator.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\validator;
+
+
+use common_exception_Error;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoQtiItem\model\qti\Item;
+
+class ItemIdentifierValidator extends ConfigurableService
+{
+    /**
+     * @throws common_exception_Error
+     */
+    public function validate(Item $item): void
+    {
+        //validate assessmentItem identifier
+        if (preg_match("/^[a-zA-Z_][a-zA-Z0-9_-]*$/u", $item->getAttributeValue('identifier')) !== 1) {
+            throw new common_exception_Error("The item identifier is not valid");
+        }
+    }
+}

--- a/test/unit/model/qti/validator/ItemIdentifierValidatorTest.php
+++ b/test/unit/model/qti/validator/ItemIdentifierValidatorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti\validator;
+
+use common_exception_Error;
+use oat\generis\test\TestCase;
+use oat\taoQtiItem\model\qti\Item;
+use oat\taoQtiItem\model\qti\validator\ItemIdentifierValidator;
+
+class ItemIdentifierValidatorTest extends TestCase
+{
+    /** @var ItemIdentifierValidator */
+    private $subject;
+
+    /** @var Item $item */
+    private $item;
+
+    protected function setUp(): void
+    {
+
+        $this->item = $this->createMock(Item::class);
+
+        $this->subject = new ItemIdentifierValidator();
+    }
+
+    public function testValidate(): void
+    {
+        $this->item->expects($this->once())
+            ->method('getAttributeValue')
+            ->willReturn('some-fake-id-64228-217055');
+
+        $this->subject->validate($this->item);
+    }
+
+    public function testValidateWithError(): void
+    {
+        $this->item->expects($this->once())
+            ->method('getAttributeValue')
+            ->willReturn('some.fake.id.64228.217055');
+
+        $this->expectException(common_exception_Error::class);
+        $this->subject->validate($this->item);
+    }
+}

--- a/views/js/qtiCreator/widgets/helpers/validators.js
+++ b/views/js/qtiCreator/widgets/helpers/validators.js
@@ -24,7 +24,7 @@ define([
 ], function(validators, _, __, Element) {
     'use strict';
 
-    var _qtiIdPattern = /^[_a-zA-Z]{1}[a-zA-Z0-9\-._]{0,31}$/i;
+    var _qtiIdPattern = /^[_a-zA-Z]{1}[a-zA-Z0-9\-_]{0,31}$/i;
 
     var qtiValidators = [
         {

--- a/views/js/qtiCreator/widgets/helpers/validators.js
+++ b/views/js/qtiCreator/widgets/helpers/validators.js
@@ -24,18 +24,18 @@ define([
 ], function(validators, _, __, Element) {
     'use strict';
 
-    var _qtiIdPattern = /^[_a-zA-Z]{1}[a-zA-Z0-9\-_]{0,31}$/i;
+    // var _qtiIdPattern = /^[_a-zA-Z]{1}[a-zA-Z0-9\-._]{0,31}$/i;
 
     var qtiValidators = [
-        {
-            name: 'qtiIdentifier',
-            message: __('invalid identifier'),
-            validate: function validate(value, callback) {
-                if (typeof callback === 'function') {
-                    callback(_qtiIdPattern.test(value));
-                }
-            }
-        },
+        // {
+        //     name: 'qtiIdentifier',
+        //     message: __('invalid identifier'),
+        //     validate: function validate(value, callback) {
+        //         if (typeof callback === 'function') {
+        //             callback(_qtiIdPattern.test(value));
+        //         }
+        //     }
+        // },
         //warning: simplistic implementation, allow only one unique identifier in the item no matter the element class/type
         {
             name: 'availableIdentifier',

--- a/views/js/qtiCreator/widgets/helpers/validators.js
+++ b/views/js/qtiCreator/widgets/helpers/validators.js
@@ -24,19 +24,9 @@ define([
 ], function(validators, _, __, Element) {
     'use strict';
 
-    // var _qtiIdPattern = /^[_a-zA-Z]{1}[a-zA-Z0-9\-._]{0,31}$/i;
+    /* TODO: _qtiIdPattern and validator object/  callback was remove and will be properly implemented */
 
     var qtiValidators = [
-        // {
-        //     name: 'qtiIdentifier',
-        //     message: __('invalid identifier'),
-        //     validate: function validate(value, callback) {
-        //         if (typeof callback === 'function') {
-        //             callback(_qtiIdPattern.test(value));
-        //         }
-        //     }
-        // },
-        //warning: simplistic implementation, allow only one unique identifier in the item no matter the element class/type
         {
             name: 'availableIdentifier',
             message: __('this identifier is already in use'),


### PR DESCRIPTION
DIR raised an incident ( ) regarding the inability to extract results from some of their deliveries. The identified root cause was that the items in the tests included in those deliveries had some malformed identifiers, for instance: B3-LagT.mt-GGM-03-bis. This is not compliant with the QTI standard (there should not be any . in the identifier) and it breaks the result extraction flow.

To fix the root cause of the issue, we would need to make sure that in authoring there is no way a user can define an invalid identifier for an item. This applies both for plain item authoring, but also for item import.