### PR TITLE
[Feat - ADF 153]: Order interaction improvement

### DIFF
--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -350,7 +350,7 @@ define([
                         }
                     } else if (minValue === 0 && maxValue > 0) {
                         this.enableField(fields.min, 1);
-                        this.setMinValue(maxValue);
+                        this.$component[0].querySelector('input[name=minChoices-toggler]').checked = true;
                     }
                 }
                 return this;

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -348,6 +348,9 @@ define([
                         if(fromField === fields.min && minValue > maxValue){
                             this.setMaxValue(minValue);
                         }
+                    } else if (minValue === 0 && maxValue > 0) {
+                        this.enableField(fields.min, 1);
+                        this.setMinValue(maxValue);
                     }
                 }
                 return this;


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/ADF-153

**Description**

QTI Order and Graphical Order interactions allow setting `minChoices` and maxChoices attributes to them.
According to the QTI specification on the interactions (Order, Graphical Order) maxChoices are only applied as a restriction when a `minChoices` value is defined as well.

    The minimum number of choices that the candidate must select and order to form a valid response to the interaction. If specified, `minChoices` must be 1 or greater but must not exceed the number of choices available. If unspecified, all of the choices must be ordered and maxChoices is ignored.

In other words, `minChoices` can be applied on their own, maxChoices require `minChoices` to be specified.

**Business requirements**

As an Item Author

I want `minChoices` restriction on Order and Graphical Order interactions to be automatically enabled whenever I enable maxChoices restriction
so that I'm not confused by the need to have both defined if I only want to apply a maxChoices restriction.

**Acceptance criteria**

Having an Order or Graphical Order interactions with maxChoices and `minChoices` restrictions disabled
when I enable the maxChoices restriction
then automatically enable the `minChoices` restriction and set its value to 1.