### PR TITLE
fix: get item content from php input

### DIFF
--- a/controller/QtiCreator.php
+++ b/controller/QtiCreator.php
@@ -185,7 +185,7 @@ class QtiCreator extends tao_actions_CommonModule
         $request = $this->getPsrRequest();
         $queryParams = $request->getQueryParams();
         if (isset($queryParams['uri'])) {
-            $xml = $request->getBody()->getContents();
+            $xml = file_get_contents('php://input');
             $rdfItem = $this->getResource(urldecode($queryParams['uri']));
             /** @var Service $itemService */
             $itemService = $this->getServiceLocator()->get(Service::class);


### PR DESCRIPTION
The bug was introduced in the latest version of guzzle/psr7

`$request->getBody()->getContents();` always returns empty body

PR with fix: https://github.com/guzzle/psr7/pull/382

steps to reproduce:
1. update tao to the latest version
2. open any item and press save button
Actual results: error message
Expected result: item successfully saved