### PR TITLE
[Fix - ADF 194]: Match interaction causes 'Uncaught TypeError: Cannot set property 'checked' of null' after it's addition to the canvas.

### DIFF
--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -350,7 +350,8 @@ define([
                         }
                     } else if (minValue === 0 && maxValue > 0) {
                         this.enableField(fields.min, 1);
-                        this.$component[0].querySelector('input[name=minChoices-toggler]').checked = true;
+                        const input = this.$component[0].querySelector('input[name=minChoices-toggler]') || this.$component[0].querySelector('input[name=minAssociations]');
+                        input.checked = true;
                     }
                 }
                 return this;


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/ADF-194

**Description**

When user adds the Match Interaction to the canvas, there are several errors 'Uncaught TypeError: Cannot set property 'checked' of null' appear in browser console. Also, 'Max' is now set to 1 by default instead of 0 and every time user tries to set 'Max' option to 1 or higher, the errors appear again.

**Steps to reproduce**

- Go to Items tab.
- Create a new item and go to Authoring.
- Call DevTools console (F12).
- Drag and drop Match interaction to the canvas and try to set Max to any value more than 0 (1 or higher).

**Actual result**

'Uncaught TypeError: Cannot set property 'checked' of null' error appear in console after dragging interaction to the canvas; 'Max' is set to 1 by default and every changing of 'Max' causes same errors to appear.

**Expected result**

No errors upon adding the interaction nor upon changing 'Max' option. 'Max' is set to 0 by default.

**Environment to check**

http://playground.kitchen.it.taocloud.org/?p=newmeridian-integration_delivery.git;a=summary