### PR TITLE
Feature/tr 552 allow widget to render process before save

### DIFF
--- a/views/js/qtiCreator/itemCreator.js
+++ b/views/js/qtiCreator/itemCreator.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
  *
  */
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-552

- Make a new event listener for `registerBeforeSaveProcess`. These processes should be finished before save, so save process will wait for it.

Test:
- Test behavior with `textReaderInteraction` in this PR: https://github.com/oat-sa/extension-pcisample/pull/87