### PR TITLE
MS-988 chore: versiom bump

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,8 +1,29 @@
 {
     "name": "@oat-sa/tao-qti-item",
     "version": "0.4.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "@oat-sa/tao-qti-item",
+            "version": "0.4.0",
+            "license": "GPL-2.0",
+            "dependencies": {
+                "@oat-sa/tao-item-runner": "0.7.1",
+                "@oat-sa/tao-item-runner-qti": "0.21.0"
+            }
+        },
+        "node_modules/@oat-sa/tao-item-runner": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.7.1.tgz",
+            "integrity": "sha512-3+kd6sH5yckD9iH3+IDnmTHctT0dFUx55vFfhlo8LvzyaE77I6Eci0uyOQpoDUMqRTzyw7tABBkNue0WkfAAsw=="
+        },
+        "node_modules/@oat-sa/tao-item-runner-qti": {
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.21.0.tgz",
+            "integrity": "sha512-W7Bq659CoctZDeYvbFxfJxOEEd+M+HSUqXK6E7yLYHoZoqXjNcIx0Ft4NdwBr8aAQid9i3UwQSgu1/5f7scUfQ=="
+        }
+    },
     "dependencies": {
         "@oat-sa/tao-item-runner": {
             "version": "0.7.1",
@@ -10,9 +31,9 @@
             "integrity": "sha512-3+kd6sH5yckD9iH3+IDnmTHctT0dFUx55vFfhlo8LvzyaE77I6Eci0uyOQpoDUMqRTzyw7tABBkNue0WkfAAsw=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.20.0.tgz",
-            "integrity": "sha512-ar07RnGVTi0ASQhAmT/ZOfRrmc7j+K0H9R9SwyN7/cFvMGSVPYrczjy7LPS86xnRpYqRWuzpEOdiVWvYgxdPZg=="
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.21.0.tgz",
+            "integrity": "sha512-W7Bq659CoctZDeYvbFxfJxOEEd+M+HSUqXK6E7yLYHoZoqXjNcIx0Ft4NdwBr8aAQid9i3UwQSgu1/5f7scUfQ=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.7.1",
-        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/ms-988/audio-pci"
+        "@oat-sa/tao-item-runner-qti": "0.21.0"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.7.1",
-        "@oat-sa/tao-item-runner-qti": "0.20.0"
+        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/ms-988/audio-pci"
     }
 }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-988

**Contains**

- Version bump of `tao-item-runner-fe` library

**Requires**

- [x] Release https://github.com/oat-sa/tao-item-runner-qti-fe/compare/develop...fix/ms-988/audio-pci
- [x] Change version in this PR