### PR TITLE
fix: lib-tao-qti update 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "7.0.1",
+        "oat-sa/lib-tao-qti": "7.0.2",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.0.0",


### PR DESCRIPTION
In order to fix error related to task: 
https://oat-sa.atlassian.net/browse/AUT-281
we need to update qui sdk repository with fixed regex pattern.