### PR TITLE
feat: AUT-13 add `Rich text + math` format to extended text interactions

### DIFF
--- a/install/scripts/SetupExtendedTextInteractionConfigurationRegistry.php
+++ b/install/scripts/SetupExtendedTextInteractionConfigurationRegistry.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\install\scripts;
+
+use oat\oatbox\extension\script\ScriptAction;
+use oat\oatbox\reporting\Report;
+use oat\taoQtiItem\model\QtiCreator\ExtendedTextInteractionConfigurationRegistry;
+
+/**
+ * Run the following to enable Math Entry format option
+ * php index.php 'oat\taoQtiItem\install\scripts\SetupExtendedTextInteractionConfigurationRegistry' -m 1
+ *
+ * Run the following to disable Math Entry format option
+ * php index.php 'oat\taoQtiItem\install\scripts\SetupExtendedTextInteractionConfigurationRegistry' -m 0
+ */
+class SetupExtendedTextInteractionConfigurationRegistry extends ScriptAction
+{
+    public const HAS_MATH = 'math';
+
+    protected function provideOptions(): array
+    {
+        return [
+            self::HAS_MATH => [
+                'prefix'      => 'm',
+                'longPrefix'  => self::HAS_MATH,
+                'description' => 'Enables / disables Math entry on extended text interactions',
+            ],
+        ];
+    }
+
+    protected function provideDescription(): string
+    {
+        return sprintf('Sets `%s` values.', ExtendedTextInteractionConfigurationRegistry::class);
+    }
+
+    protected function run(): Report
+    {
+        $setValues = [];
+
+        /** @var ExtendedTextInteractionConfigurationRegistry $registry */
+        $registry = $this->propagate(new ExtendedTextInteractionConfigurationRegistry());
+
+        $this->setHasMath($registry, $setValues);
+
+        return $this->createReport($setValues);
+    }
+
+    private function createReport(array $setValues): Report
+    {
+        return $setValues
+            ? Report::createSuccess(
+                sprintf(
+                    "Applied the following configuration to `%s`\n%s",
+                    ExtendedTextInteractionConfigurationRegistry::class,
+                    json_encode($setValues)
+                )
+            )
+            : Report::createError(
+                sprintf('No values set to `%s`', ExtendedTextInteractionConfigurationRegistry::class)
+            );
+    }
+
+    private function setHasMath(ExtendedTextInteractionConfigurationRegistry $registry, array &$setValues): void
+    {
+        if (!$this->hasOption(self::HAS_MATH)) {
+            return;
+        }
+
+        $hasMath = (bool)$this->getOption(self::HAS_MATH);
+
+        $setValues[self::HAS_MATH] = $hasMath;
+
+        $registry->setHasMath($hasMath);
+    }
+}

--- a/install/scripts/SetupExtendedTextInteractionConfigurationRegistry.php
+++ b/install/scripts/SetupExtendedTextInteractionConfigurationRegistry.php
@@ -39,6 +39,9 @@ class SetupExtendedTextInteractionConfigurationRegistry extends ScriptAction
 {
     public const HAS_MATH = 'math';
 
+    /** @var ExtendedTextInteractionConfigurationRegistry */
+    private $registry;
+
     protected function provideOptions(): array
     {
         return [
@@ -57,18 +60,21 @@ class SetupExtendedTextInteractionConfigurationRegistry extends ScriptAction
 
     protected function run(): Report
     {
-        $setValues = [];
+        $this->registry = $this->propagate(new ExtendedTextInteractionConfigurationRegistry());
 
-        /** @var ExtendedTextInteractionConfigurationRegistry $registry */
-        $registry = $this->propagate(new ExtendedTextInteractionConfigurationRegistry());
+        if ($this->hasOption(self::HAS_MATH)) {
+            $this->registry->setHasMath(
+                (bool)$this->getOption(self::HAS_MATH)
+            );
+        }
 
-        $this->setHasMath($registry, $setValues);
-
-        return $this->createReport($setValues);
+        return $this->createReport();
     }
 
-    private function createReport(array $setValues): Report
+    private function createReport(): Report
     {
+        $setValues = $this->registry->get(ExtendedTextInteractionConfigurationRegistry::ID);
+
         return $setValues
             ? Report::createSuccess(
                 sprintf(
@@ -80,18 +86,5 @@ class SetupExtendedTextInteractionConfigurationRegistry extends ScriptAction
             : Report::createError(
                 sprintf('No values set to `%s`', ExtendedTextInteractionConfigurationRegistry::class)
             );
-    }
-
-    private function setHasMath(ExtendedTextInteractionConfigurationRegistry $registry, array &$setValues): void
-    {
-        if (!$this->hasOption(self::HAS_MATH)) {
-            return;
-        }
-
-        $hasMath = (bool)$this->getOption(self::HAS_MATH);
-
-        $setValues[self::HAS_MATH] = $hasMath;
-
-        $registry->setHasMath($hasMath);
     }
 }

--- a/model/QtiCreator/ExtendedTextInteractionConfigurationRegistry.php
+++ b/model/QtiCreator/ExtendedTextInteractionConfigurationRegistry.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\QtiCreator;
+
+use oat\tao\model\ClientLibConfigRegistry;
+
+class ExtendedTextInteractionConfigurationRegistry extends ClientLibConfigRegistry
+{
+    public const ID = 'taoQtiItem/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question';
+
+    public function setHasMath(bool $hasMath): void
+    {
+        $this->register(
+            self::ID,
+            [
+                'hasMath' => $hasMath,
+            ]
+        );
+    }
+}

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -67,7 +67,7 @@ define([
         };
 
         if (config.hasMath) {
-            formats.math = {label : __('Rich text') + ' + ' + __('math'), selected : false};
+            formats.math = {label : __('Rich text + math'), selected : false};
         }
 
         var constraints = {

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -47,6 +47,7 @@ define([
             $original = _widget.$original,
             $inputs,
             interaction = _widget.element,
+            isMathEntry = interaction.attr('data-math-entry') === 'true',
             format = interaction.attr('format'),
             patternMask = interaction.attr('patternMask'),
             expectedLength = parseInt(interaction.attr('expectedLength'), 10),
@@ -57,9 +58,10 @@ define([
             $counterMaxLength = $('.text-counter-chars > .count-max-length', $original);
 
         var formats = {
-            plain : {label : __("Plain text"), selected : false},
-            preformatted : {label : __("Pre-formatted text"), selected : false},
-            xhtml : {label : __("XHTML"), selected : false}
+            plain : {label : __('Plain text'), selected : false},
+            preformatted : {label : __('Pre-formatted text'), selected : false},
+            xhtml : {label : __('Rich text'), selected : false},
+            math : {label : __('Rich text') + ' + ' + __('math'), selected : false}
         };
 
         var constraints = {
@@ -82,6 +84,11 @@ define([
             constraints.none.selected = false;
             constraints.pattern.selected = true;
         }
+
+        if (format === 'xhtml' && isMathEntry) {
+            format = 'math';
+        }
+
         /**
          * Set the selected on the right items before sending it to the view for formats
          */
@@ -119,16 +126,19 @@ define([
             var response = interaction.getResponseDeclaration();
             var correctResponse = _.values(response.getCorrect());
             var previousFormat = interaction.attr('format');
+            var isMath = attrValue === 'math';
+            var format = isMath ? 'xhtml' : attrValue;
 
             //remove the interaction
             renderer.destroy(interaction);
 
             //change the format and rerender
-            interaction.attr('format', attrValue);
+            interaction.attr('format', format);
+            interaction.attr('data-math-entry', isMath ? 'true' : 'false');
             renderer.render(interaction);
 
-            if(previousFormat === 'xhtml'){
-                if(typeof correctResponse[0] !== 'undefined'){
+            if (format !=='xhtml' && previousFormat === 'xhtml') {
+                if (typeof correctResponse[0] !== 'undefined') {
                     // Get a correct response with all possible html tags removed.
                     // (Why not let jquery do that :-) ?)
                     response.setCorrect($('<p>' + correctResponse[0] + '</p>').text());
@@ -191,7 +201,7 @@ define([
             } else {
                 interaction.removeAttr(attribute);
             }
-        };
+        }
 
         callbacks.expectedLength = setAttributes.bind(null, 'expectedLength');
 

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -19,14 +19,17 @@ define([
     'jquery',
     'lodash',
     'i18n',
+    'module',
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/interactions/blockInteraction/states/Question',
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'taoQtiItem/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction',
     'taoQtiItem/qtiCommonRenderer/helpers/patternMask',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/extendedText'
-], function($, _, __, stateFactory, Question, formElement, renderer, patternMaskHelper, formTpl){
+], function($, _, __, module, stateFactory, Question, formElement, renderer, patternMaskHelper, formTpl){
     'use strict';
+
+    var config = module.config();
 
     var initState = function initState(){
         // Disable inputs until response edition.
@@ -60,9 +63,12 @@ define([
         var formats = {
             plain : {label : __('Plain text'), selected : false},
             preformatted : {label : __('Pre-formatted text'), selected : false},
-            xhtml : {label : __('Rich text'), selected : false},
-            math : {label : __('Rich text') + ' + ' + __('math'), selected : false}
+            xhtml : {label : __('Rich text'), selected : false}
         };
+
+        if (config.hasMath) {
+            formats.math = {label : __('Rich text') + ' + ' + __('math'), selected : false};
+        }
 
         var constraints = {
             none : {label : __("None"), selected : true},

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -143,7 +143,7 @@ define([
             interaction.attr('data-math-entry', isMath ? 'true' : 'false');
             renderer.render(interaction);
 
-            if (format !=='xhtml' && previousFormat === 'xhtml') {
+            if (format !== 'xhtml' && previousFormat === 'xhtml') {
                 if (typeof correctResponse[0] !== 'undefined') {
                     // Get a correct response with all possible html tags removed.
                     // (Why not let jquery do that :-) ?)


### PR DESCRIPTION
feat: [AUT-13](https://oat-sa.atlassian.net/browse/AUT-13) add `Rich text + math` format to extended text interactions

⚠️ Related to https://github.com/oat-sa/extension-tao-udir/pull/116

**How to test**:

1. Enable the new optional format by running `php index.php 'oat\taoQtiItem\install\scripts\SetupExtendedTextInteractionConfigurationRegistry' -m 1`
2. Create an Item with an extended text interaction and a new format
3. Save the Item
4. Create a new Test
5. Add the Item to the Test
6. Export the Test
7. Import the Test to https://demo.udir.taocloud.org
8. Preview it

![image](https://user-images.githubusercontent.com/2943256/112831371-21b4f900-9094-11eb-9a2a-2d539857e8d7.png)