### PR TITLE
feat: add svg file type in resource manager

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/helpers/resourceManager.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/resourceManager.js
@@ -49,7 +49,7 @@ define([
             params : {
                 uri : options.uri,
                 lang : options.lang,
-                filters : 'image/jpeg,image/png,image/gif'
+                filters : 'image/jpeg,image/png,image/gif,image/svg+xml'
             },
             pathParam : 'path',
             select : function(e, files){


### PR DESCRIPTION
**Ticket**: [AUT-75](https://oat-sa.atlassian.net/browse/AUT-75)

**Description**
As an item author
I would like to be able to use SVG files when uploading files through the asset manager 
and also when choosing an image to be used on the NMC Graphic Gap Match PCI,  the Hotspot Interactions or the Gap Match Interactions
so that I could have the benefits of using a vector type of image

**How to check**
1. Install newmeridian pci [extension](https://github.com/oat-sa/extension-tao-newmeridian-pci)
2. Create item
3. Add any of graphic interactions (Graphic Gap Match, Hotspot, NMC Graphic Gap Match PCI)
4. Choose SVG, SVGZ file in resource manager
5. Check that it was correctly added to the interaction

**Deployed on**: http://test-anastasia-2.playground.kitchen.it.taocloud.org:45401