### PR TITLE
fix/AUT-480/Mapping response processing is breaking scoring for other interaction in composite items

### DIFF
--- a/views/js/qtiCreator/helper/itemLoader.js
+++ b/views/js/qtiCreator/helper/itemLoader.js
@@ -64,8 +64,8 @@ define([
                     var loader, itemData, newItem;
 
                     if (data.itemData) {
-                        let newObject = {};
                         for (const response in data.itemData.responses) {
+                            const newObject = {};
                             for (const mapKey in data.itemData.responses[response].mapping) {
                                 newObject[decodeHtml(mapKey)] = data.itemData.responses[response].mapping[mapKey];
                             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-480

Fix: `newObject` was used for all responses, now `newObject` moved inside `for` cycle and for each response will be new object

**How to reproduce issue:**

1. Create composite item with choice interaction and inline text entry interaction
2. Set inline text entry to map response processing
3. save & exit
4. open the item again
5. do nothing but just save again and exit
6. as soon as you export the item, you will see the mapping values of the text_entry interaction appearing on response declaration of choice interaction

**Expected result:** mapping only applies to inline text entry interaction
**Actual result:** mapping gets applied to the choice interaction as well

Before:
![image](https://user-images.githubusercontent.com/25976342/117281332-33947380-ae6c-11eb-8e6e-ea2afa3a6419.png)

After:
![image](https://user-images.githubusercontent.com/25976342/117281486-5faff480-ae6c-11eb-851b-8e8e26beb1cf.png)
