### PR TITLE
[Fix: ADF-364] Proposal for fix error on removing assets

### DIFF
--- a/views/js/qtiCreator/model/mixin/editable.js
+++ b/views/js/qtiCreator/model/mixin/editable.js
@@ -35,10 +35,12 @@ define([
 
             if (found) {
                 const parent = found.parent;
-                const response = element.getResponseDeclaration();
-                if (response) {
-                    invalidator.completelyValid(response);
-                    Element.unsetElement(response);
+                if (element.getResponseDeclaration) {
+                    const response = element.getResponseDeclaration();
+                    if (response) {
+                        invalidator.completelyValid(response);
+                        Element.unsetElement(response);
+                    }
                 }
                 if (Element.isA(parent, 'interaction')) {
                     if (element.qtiClass === 'gapImg') {


### PR DESCRIPTION
**Ticket**

https://oat-sa.atlassian.net/browse/ADF-364

**Description**

When delete an image in a text block, the message can not be removed clicking in cross and error `element.getResponseDeclaration` is not a function.

You need to reload the page to escape from that trap

**Environment**

http://test-gabriel.playground.kitchen.it.taocloud.org:42221

**How to reproduce**

- Go to item authoring and authoring an item
- Put a block and add an image (just to open the modal)
- Close the modal
- Click in bin icon of the image

**Alternative**

`related.getResponseDeclaration();` but not sure if its desired