### PR TITLE
Fix/aut 48/invalid xml in table

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -319,7 +319,7 @@ define([
      * @param {String} serial
      */
     function _findWidgetContainer($container, serial){
-        return $.find($container.selector + ' .widget-box[data-serial=' + serial + ']')
+        return $.find($container.selector + ' .widget-box[data-serial=' + serial + ']');
     }
 
     /**

--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -320,7 +320,7 @@ define([
      */
     function _findWidgetContainer($container, serial){
         // re-query widget container to apply changes in case of deletion
-        return $.find($container.selector + ' .widget-box[data-serial=' + serial + ']');
+        return $($container.selector).find('.widget-box[data-serial=' + serial + ']');
     }
 
     /**

--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -319,6 +319,7 @@ define([
      * @param {String} serial
      */
     function _findWidgetContainer($container, serial){
+        // re-query widget container to apply changes in case of deletion
         return $.find($container.selector + ' .widget-box[data-serial=' + serial + ']');
     }
 

--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -319,7 +319,7 @@ define([
      * @param {String} serial
      */
     function _findWidgetContainer($container, serial){
-        return $container.find('.widget-box[data-serial=' + serial + ']');
+        return $.find($container.selector + ' .widget-box[data-serial=' + serial + ']')
     }
 
     /**

--- a/views/js/qtiCreator/model/mixin/editable.js
+++ b/views/js/qtiCreator/model/mixin/editable.js
@@ -35,10 +35,12 @@ define([
 
             if (found) {
                 const parent = found.parent;
-                const response = element.getResponseDeclaration();
-                if (response) {
-                    invalidator.completelyValid(response);
-                    Element.unsetElement(response);
+                if (element.getResponseDeclaration) {
+                    const response = element.getResponseDeclaration();
+                    if (response) {
+                        invalidator.completelyValid(response);
+                        Element.unsetElement(response);
+                    }
                 }
                 if (Element.isA(parent, 'interaction')) {
                     if (element.qtiClass === 'gapImg') {

--- a/views/js/qtiCreator/widgets/Widget.js
+++ b/views/js/qtiCreator/widgets/Widget.js
@@ -354,7 +354,9 @@ define([
 
                 //bind each individual event listener to the document
                 $document.on(eventNameToken.join('.'), function(e, data){
-                    callback.call(self, data);
+                    if (data.serial === self.serial) {
+                        callback.call(self, data);
+                    }
                 });
 
             });

--- a/views/js/qtiCreator/widgets/states/Deleting.js
+++ b/views/js/qtiCreator/widgets/states/Deleting.js
@@ -224,6 +224,19 @@ define([
 
         this.refactoredUnits = [];
 
+        // remove inner widgets
+        const container = this.widget.element;
+
+        if (container.getBody && container.getBody().elements) {
+            _.each(_.values(container.getBody().elements), function (elt) {
+                if (elt.metaData && elt.metaData.widget) {
+                    const widget = elt.metaData.widget
+                    widget.destroy();
+                    widget.element.remove();
+                }
+            });
+        }
+
         this.$elementToRemove.remove();//remove html from the dom
         this.widget.destroy();//remove what remains of the widget (almost nothing), call this after element remove
         this.widget.element.remove();//remove from model

--- a/views/js/qtiCreator/widgets/states/Deleting.js
+++ b/views/js/qtiCreator/widgets/states/Deleting.js
@@ -230,7 +230,7 @@ define([
         if (container.getBody && container.getBody().elements) {
             _.each(_.values(container.getBody().elements), function (elt) {
                 if (elt.metaData && elt.metaData.widget) {
-                    const widget = elt.metaData.widget
+                    const widget = elt.metaData.widget;
                     widget.destroy();
                     widget.element.remove();
                 }

--- a/views/js/qtiCreator/widgets/static/table/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/table/states/Active.js
@@ -68,6 +68,18 @@ define([
         }, 400);
     }
 
+    // delete all widgets from column or row
+    function deleteInnerWidgets(container, colRows) {
+        colRows.each(function () {
+            $(this).find('.widget-box').each(function () {
+                const serial = $(this).data('serial');
+                if (container.elements[serial]) {
+                    delete container.elements[serial];
+                }
+            });
+        });
+    }
+
     TableStateActive.prototype.initForm = function initForm(){
         var _widget     = this.widget,
             $form       = _widget.$form,
@@ -164,6 +176,9 @@ define([
                     deleteTitle: 'Delete column'
                 })
                     .on('delete', function() {
+                        const cols = getCurrentColCells(editor);
+                        deleteInnerWidgets(container, cols);
+
                         editor.execCommand('columnDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -194,7 +209,11 @@ define([
                     insertRow: true,
                     deleteTitle: 'Delete row'
                 })
+
                     .on('delete', function() {
+                        const rows = getCurrentRowCells(editor);
+                        deleteInnerWidgets(container, rows);
+
                         editor.execCommand('rowDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -359,6 +378,20 @@ define([
                 x: currentCell.cellIndex,
                 y: currentCell.parentNode.rowIndex
             };
+        }
+    }
+
+    function getCurrentRowCells(editor) {
+        const currentCellPos = getCurrentCellPos(editor);
+        if (currentCellPos) {
+            return tableModel.getRowCells(currentCellPos.y)
+        }
+    }
+
+    function getCurrentColCells(editor) {
+        const currentCellPos = getCurrentCellPos(editor);
+        if (currentCellPos) {
+            return tableModel.getColCells(currentCellPos.x)
         }
     }
 

--- a/views/js/qtiCreator/widgets/static/table/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/table/states/Active.js
@@ -68,21 +68,6 @@ define([
         }, 400);
     }
 
-    // delete all widgets from column or row
-    function deleteInnerWidgets(container, colRows) {
-        colRows.each(function () {
-            $(this).find('.widget-box').each(function () {
-                const serial = $(this).data('serial');
-                if (container.elements[serial]) {
-                    const wdg = container.elements[serial].metaData.widget;
-                    wdg.element.remove();
-                    wdg.destroy();
-                    delete container.elements[serial];
-                }
-            });
-        });
-    }
-
     TableStateActive.prototype.initForm = function initForm(){
         var _widget     = this.widget,
             $form       = _widget.$form,
@@ -179,9 +164,6 @@ define([
                     deleteTitle: 'Delete column'
                 })
                     .on('delete', function() {
-                        const cols = getCurrentColCells(editor);
-                        deleteInnerWidgets(container, cols);
-
                         editor.execCommand('columnDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -212,11 +194,7 @@ define([
                     insertRow: true,
                     deleteTitle: 'Delete row'
                 })
-
                     .on('delete', function() {
-                        const rows = getCurrentRowCells(editor);
-                        deleteInnerWidgets(container, rows);
-
                         editor.execCommand('rowDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -381,20 +359,6 @@ define([
                 x: currentCell.cellIndex,
                 y: currentCell.parentNode.rowIndex
             };
-        }
-    }
-
-    function getCurrentRowCells(editor) {
-        const currentCellPos = getCurrentCellPos(editor);
-        if (currentCellPos) {
-            return tableModel.getRowCells(currentCellPos.y)
-        }
-    }
-
-    function getCurrentColCells(editor) {
-        const currentCellPos = getCurrentCellPos(editor);
-        if (currentCellPos) {
-            return tableModel.getColCells(currentCellPos.x)
         }
     }
 

--- a/views/js/qtiCreator/widgets/static/table/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/table/states/Active.js
@@ -68,18 +68,6 @@ define([
         }, 400);
     }
 
-    // delete all widgets from column or row
-    function deleteInnerWidgets(container, colRows) {
-        colRows.each(function () {
-            $(this).find('.widget-box').each(function () {
-                const serial = $(this).data('serial');
-                if (container.elements[serial]) {
-                    delete container.elements[serial];
-                }
-            });
-        });
-    }
-
     TableStateActive.prototype.initForm = function initForm(){
         var _widget     = this.widget,
             $form       = _widget.$form,
@@ -176,9 +164,6 @@ define([
                     deleteTitle: 'Delete column'
                 })
                     .on('delete', function() {
-                        const cols = getCurrentColCells(editor);
-                        deleteInnerWidgets(container, cols);
-
                         editor.execCommand('columnDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -209,11 +194,7 @@ define([
                     insertRow: true,
                     deleteTitle: 'Delete row'
                 })
-
                     .on('delete', function() {
-                        const rows = getCurrentRowCells(editor);
-                        deleteInnerWidgets(container, rows);
-
                         editor.execCommand('rowDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -378,20 +359,6 @@ define([
                 x: currentCell.cellIndex,
                 y: currentCell.parentNode.rowIndex
             };
-        }
-    }
-
-    function getCurrentRowCells(editor) {
-        const currentCellPos = getCurrentCellPos(editor);
-        if (currentCellPos) {
-            return tableModel.getRowCells(currentCellPos.y)
-        }
-    }
-
-    function getCurrentColCells(editor) {
-        const currentCellPos = getCurrentCellPos(editor);
-        if (currentCellPos) {
-            return tableModel.getColCells(currentCellPos.x)
         }
     }
 

--- a/views/js/qtiCreator/widgets/static/table/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/table/states/Active.js
@@ -68,6 +68,21 @@ define([
         }, 400);
     }
 
+    // delete all widgets from column or row
+    function deleteInnerWidgets(container, colRows) {
+        colRows.each(function () {
+            $(this).find('.widget-box').each(function () {
+                const serial = $(this).data('serial');
+                if (container.elements[serial]) {
+                    const wdg = container.elements[serial].metaData.widget;
+                    wdg.element.remove();
+                    wdg.destroy();
+                    delete container.elements[serial];
+                }
+            });
+        });
+    }
+
     TableStateActive.prototype.initForm = function initForm(){
         var _widget     = this.widget,
             $form       = _widget.$form,
@@ -164,6 +179,9 @@ define([
                     deleteTitle: 'Delete column'
                 })
                     .on('delete', function() {
+                        const cols = getCurrentColCells(editor);
+                        deleteInnerWidgets(container, cols);
+
                         editor.execCommand('columnDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -194,7 +212,11 @@ define([
                     insertRow: true,
                     deleteTitle: 'Delete row'
                 })
+
                     .on('delete', function() {
+                        const rows = getCurrentRowCells(editor);
+                        deleteInnerWidgets(container, rows);
+
                         editor.execCommand('rowDelete');
                         updateTable(editor, $editableContainer);
                         hideTableActions();
@@ -359,6 +381,20 @@ define([
                 x: currentCell.cellIndex,
                 y: currentCell.parentNode.rowIndex
             };
+        }
+    }
+
+    function getCurrentRowCells(editor) {
+        const currentCellPos = getCurrentCellPos(editor);
+        if (currentCellPos) {
+            return tableModel.getRowCells(currentCellPos.y)
+        }
+    }
+
+    function getCurrentColCells(editor) {
+        const currentCellPos = getCurrentCellPos(editor);
+        if (currentCellPos) {
+            return tableModel.getColCells(currentCellPos.x)
         }
     }
 


### PR DESCRIPTION
### **Related issue:**
https://oat-sa.atlassian.net/browse/AUT-48

### **Description**

If add a table to text block and then add inline interactions to cells, response declarations are not removed from item XML if delete an entire column or a raw. 

**Steps to reproduce:**

1. Log in as admin
2. Go to Items tab and create a new item
3. Add Text block to the canvas
4. Add a table to the canvas (i.e. the table with 3 columns and 3 raws)
5. Add Inline choice or Text entry interactions to cells
6. Save
7. Remove one column or raw (to do it place a cursor to any cell and click appeared trash bin icon to delete column or raw)
8. Save
9.  Check saveItem request in browser

**Actual result**: response declarations for deleted interactions are still presented
**Expected result**: response declarations for deleted interaction are absent

**How to test:**
Check adding / deleting / undo delete tables, rows, columns, inner interactions in rubric blocks.

### **Environment**
http://test-anastasia.playground.kitchen.it.taocloud.org:44451