### PR TITLE
fix: rollback item content on wrong metadata\unknown errors

### DIFF
--- a/model/import/CsvItem.php
+++ b/model/import/CsvItem.php
@@ -45,7 +45,7 @@ class CsvItem implements ItemInterface
     /** @var ParsedChoice[] */
     private $choices;
 
-    /** @var Metadata[] */
+    /** @var ParsedMetadatum[] */
     private $metadata;
 
     public function __construct(

--- a/model/import/CsvItemImportHandler.php
+++ b/model/import/CsvItemImportHandler.php
@@ -159,7 +159,7 @@ class CsvItemImportHandler extends ConfigurableService
 
             $this->getLogger()->warning(
                 sprintf(
-                    'Tabular import: rollback line `%s` created with uri: `%s`, label: %s',
+                    'Tabular import: line `%s` rollback item with uri `%s` and label %s',
                     $lineNumber,
                     $item->getUri(),
                     $item->getLabel()

--- a/model/import/CsvItemImportHandler.php
+++ b/model/import/CsvItemImportHandler.php
@@ -158,9 +158,10 @@ class CsvItemImportHandler extends ConfigurableService
 
             $this->getLogger()->warning(
                 sprintf(
-                    'Tabular import: rollback line `%s` created with uri `%s`',
+                    'Tabular import: rollback line `%s` created with uri: `%s`, label: %s',
                     $lineNumber,
-                    $item->getUri()
+                    $item->getUri(),
+                    $item->getLabel()
                 )
             );
         }

--- a/model/import/CsvItemImportHandler.php
+++ b/model/import/CsvItemImportHandler.php
@@ -80,6 +80,7 @@ class CsvItemImportHandler extends ConfigurableService
                     $itemValidatorResults->addErrorReport($lineNumber, $error);
                     $errorReportsImport++;
                 }
+                unset($itemImportReport);
             } catch (InvalidMetadataException $exception) {
                 $error = new InvalidImportException();
                 $error->addError($lineNumber, $exception->getMessage());

--- a/model/import/CsvItemImportHandler.php
+++ b/model/import/CsvItemImportHandler.php
@@ -23,12 +23,12 @@ declare(strict_types=1);
 namespace oat\taoQtiItem\model\import;
 
 use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
 use helpers_TimeOutHelper;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\reporting\Report;
 use oat\oatbox\reporting\ReportInterface;
 use oat\oatbox\service\ConfigurableService;
-use oat\tao\helpers\form\ElementMapFactory;
 use oat\taoQtiItem\model\import\Metadata\MetadataResolver;
 use oat\taoQtiItem\model\import\Parser\CsvParser;
 use oat\taoQtiItem\model\import\Parser\Exception\InvalidImportException;
@@ -36,9 +36,9 @@ use oat\taoQtiItem\model\import\Parser\Exception\InvalidMetadataException;
 use oat\taoQtiItem\model\import\Parser\ParserInterface;
 use oat\taoQtiItem\model\import\Template\ItemsQtiTemplateRender;
 use oat\taoQtiItem\model\qti\ImportService;
-use oat\taoQtiItem\model\qti\metadata\MetadataValidator;
 use tao_models_classes_dataBinding_GenerisFormDataBinder;
 use tao_models_classes_dataBinding_GenerisFormDataBindingException;
+use taoItems_models_classes_ItemsService;
 use Throwable;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 
@@ -83,6 +83,9 @@ class CsvItemImportHandler extends ConfigurableService
             } catch (InvalidMetadataException $exception) {
                 $error = new InvalidImportException();
                 $error->addError($lineNumber, $exception->getMessage());
+                if (isset($itemImportReport)) {
+                    $this->rollbackItem($itemImportReport, $lineNumber);
+                }
 
                 $itemValidatorResults->addErrorReport($lineNumber, $error);
                 $errorReportsImport++;
@@ -91,8 +94,9 @@ class CsvItemImportHandler extends ConfigurableService
                     sprintf('Tabular import: import failure %s', $exception->getMessage())
                 );
 
-                // Ask business if we want to revert what was imported (probably, yes)
-                //FIXME Rollback any DB + FS change
+                if (isset($itemImportReport)){
+                    $this->rollbackItem($itemImportReport, $lineNumber);
+                }
 
                 $errorReportsImport++;
 
@@ -120,6 +124,11 @@ class CsvItemImportHandler extends ConfigurableService
         return $this->getServiceLocator()->get(ImportService::SERVICE_ID);
     }
 
+    private function getItemService(): taoItems_models_classes_ItemsService
+    {
+        return $this->getServiceLocator()->get(taoItems_models_classes_ItemsService::class);
+    }
+
     private function getTemplateProcessor(): ItemsQtiTemplateRender
     {
         return $this->getServiceLocator()->get(ItemsQtiTemplateRender::class);
@@ -138,5 +147,22 @@ class CsvItemImportHandler extends ConfigurableService
         $itemRdf  = $itemImportReport->getData();
         $binder   = new tao_models_classes_dataBinding_GenerisFormDataBinder($itemRdf);
         $binder->bind($metaData);
+    }
+
+    private function rollbackItem(ReportInterface $itemImportReport, int $lineNumber): void
+    {
+        $item = $itemImportReport->getData();
+
+        if ($item instanceof core_kernel_classes_Resource) {
+            $this->getItemService()->deleteResource($item);
+
+            $this->getLogger()->warning(
+                sprintf(
+                    'Tabular import: rollback line `%s` created with uri `%s`',
+                    $lineNumber,
+                    $item->getUri()
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
Whenever metadata validation fails or known error happens - item RDF is rollbacked, if created already