### PR TITLE
fix: cleanup the leftovers after resolving item reference

### DIFF
--- a/model/qti/XIncludeLoader.php
+++ b/model/qti/XIncludeLoader.php
@@ -71,6 +71,7 @@ class XIncludeLoader
                     $asset = $this->resolver->resolve($href);
                     $filePath = $asset->getMediaSource()->download($asset->getMediaIdentifier());
                     $this->loadXInclude($xinclude, $filePath);
+                    $this->removeTemporaryFile($filePath);
                 } catch (\tao_models_classes_FileNotFoundException $exception) {
                     if ($removeUnfoundHref) {
                         $xinclude->attr('href', '');
@@ -88,6 +89,13 @@ class XIncludeLoader
         }
 
         return $xincludes;
+    }
+
+    private function removeTemporaryFile(string $filePath): void
+    {
+        if (file_exists($filePath)) {
+            unlink($filePath);
+        }
     }
     
     /**


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-237

asset reference is left after publishing the delivery in /tmp folder, which contain an info about items and sections in the test