### PR TITLE
fix: support for custom youtube links

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
@@ -29,9 +29,8 @@ define([
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/media',
     'ui/mediaEditor/mediaEditorComponent',
-    'ui/resourcemgr',
-    'ui/tooltip'
-], function ($, _, __, stateFactory, Question, formElement, formTpl, mediaEditorComponent) {
+    'util/urlParser'
+], function ($, _, __, stateFactory, Question, formElement, formTpl, mediaEditorComponent, urlParser) {
     'use strict';
     /**
      * media Editor instance if has been initialized
@@ -289,6 +288,7 @@ define([
 
             data: function data(boundInteraction, attrValue, attrName) {
                 let value;
+                let youTubeUrl;
                 if (interaction.object.attr(attrName) !== attrValue) {
                     interaction.object.attr(attrName, attrValue);
                     interaction.object.removeAttr('width');
@@ -297,6 +297,11 @@ define([
                     value = $.trim(attrValue).toLowerCase();
 
                     if (/^http(s)?:\/\/(www\.)?youtu/.test(value)) {
+                        if (attrValue.indexOf('&' > 0)) {
+                            youTubeUrl = new URL(attrValue);
+                            youTubeUrl.searchParams.delete('ab_channel');
+                            this.value = youTubeUrl.toString();
+                        }
                         interaction.object.attr('type', 'video/youtube');
                         switchToVideo();
                     } else if (/audio/.test(interaction.object.attr('type'))) {

--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
@@ -29,8 +29,9 @@ define([
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/media',
     'ui/mediaEditor/mediaEditorComponent',
-    'util/urlParser'
-], function ($, _, __, stateFactory, Question, formElement, formTpl, mediaEditorComponent, urlParser) {
+    'ui/resourcemgr',
+    'ui/tooltip'
+], function ($, _, __, stateFactory, Question, formElement, formTpl, mediaEditorComponent) {
     'use strict';
     /**
      * media Editor instance if has been initialized
@@ -289,6 +290,7 @@ define([
             data: function data(boundInteraction, attrValue, attrName) {
                 let value;
                 let youTubeUrl;
+                let parsedUrl;
                 if (interaction.object.attr(attrName) !== attrValue) {
                     interaction.object.attr(attrName, attrValue);
                     interaction.object.removeAttr('width');
@@ -299,8 +301,9 @@ define([
                     if (/^http(s)?:\/\/(www\.)?youtu/.test(value)) {
                         if (attrValue.indexOf('&' > 0)) {
                             youTubeUrl = new URL(attrValue);
-                            youTubeUrl.searchParams.delete('ab_channel');
-                            this.value = youTubeUrl.toString();
+                            parsedUrl = new URL(youTubeUrl.origin + youTubeUrl.pathname);
+                            parsedUrl.searchParams.append('v', youTubeUrl.searchParams.get('v'));
+                            this.value = parsedUrl.toJSON();
                         }
                         interaction.object.attr('type', 'video/youtube');
                         switchToVideo();

--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
@@ -30,7 +30,8 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/media',
     'ui/mediaEditor/mediaEditorComponent',
     'ui/resourcemgr',
-    'ui/tooltip'
+    'ui/tooltip',
+    'url-polyfill'
 ], function ($, _, __, stateFactory, Question, formElement, formTpl, mediaEditorComponent) {
     'use strict';
     /**
@@ -303,7 +304,7 @@ define([
                             youTubeUrl = new URL(attrValue);
                             parsedUrl = new URL(youTubeUrl.origin + youTubeUrl.pathname);
                             parsedUrl.searchParams.append('v', youTubeUrl.searchParams.get('v'));
-                            this.value = parsedUrl.toJSON();
+                            this.value = parsedUrl.toString();
                         }
                         interaction.object.attr('type', 'video/youtube');
                         switchToVideo();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-8

Whenever user is trying to add the video from YouTube to the Media Interaction by link, there's an error on QTI model occurs on attempt to save the item. YouTube custom links, containing the name of the channel (f.e. https://www.youtube.com/watch?v=-xKM3mGt2pE&ab_channel=ahaVEVO, channel name part is "...&ab_channel=ahaVEVO") are not accepted. But if the name section ('&ab_channel=ahaVEVO') is deleted, the video is added and interaction can be saved.

**Steps to reproduce:**

1. Go to Items tab.
2. Create a new item and go to it's Authoring. 
3. Add Media interaction to the canvas.
4. Close resource manager and add copied YouTube link to the link field.
5. Click 'Save'.

**Actual result:** Error message '`The item has not been saved! An error occurred at the level of the QTI model.`' appears and 2 
   errors show up in browser console (1st - upon adding youtube link, 2nd - after clicking Save button). Item is not saved.

**Expected results:** The item is saved successfully with info pop up message '`Your item has been saved`.'.

**Environment**
http://tao-test-alshoja.playground.kitchen.it.taocloud.org:46031
OS: Windows 10
Browser: All browsers

