### PR TITLE
fix:taging to pull Req in npm Package

### DIFF
--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.7.1",
-        "@oat-sa/tao-item-runner-qti": "0.21.8"
+        "@oat-sa/tao-item-runner-qti": "git://github.com/oat-sa/tao-item-runner-qti-fe#fix/AUT-560/tables-added-to-passage-not-displayed"
     }
 }


### PR DESCRIPTION
**Related Issue :** https://oat-sa.atlassian.net/browse/AUT-560 
If user added the Table via CK Editor to the Passage during it's authoring, this Table will not display if the passage containing it will be added to the item during Item Authoring.

**Preconditions**: Passage containing table is created.

**Steps to reproduce:**

- Go to Items tab.
- 
- Create a new item and go to it's authoring.
- 
- Add any interaction to the canvas.
- 
- Add a Passage containing Table to this interaction.

**Actual result:** The Passage is added, the Table is not displayed in Item Authoring page.
**Expected result:** The Passage is added, all of it's contend is displayed including Table.

Env : http://tao-test-alshoja.playground.kitchen.it.taocloud.org:46031/