### PR TITLE
fix: remove upperbound value if max field is 0

### DIFF
--- a/views/js/qtiCreator/widgets/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/helpers/formElement.js
@@ -291,10 +291,12 @@ define([
                 if (name === 'upperBound' && this.disabled) {
                     // if the field is disabled, the corresponding attribute should be removed.
                     element[options.attrMethodNames.remove](name);
-                } else if (!options.allowNull && (value === 0 || !isActualNumber)) {
-                    //if a null attribute is not allowed, should be removed.
-                    element[options.attrMethodNames.remove](name);
-                } else  {
+
+                } else if (!value && (element.is('orderInteraction') || element.is('graphicOrderInteraction'))) {
+
+                    element[options.attrMethodNames.remove](name); //to be removed for order interactions
+
+                } else {
                     element[options.attrMethodNames.set](name, value); //required
                 }
 

--- a/views/js/qtiCreator/widgets/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/helpers/formElement.js
@@ -279,9 +279,7 @@ define([
 
             callbacks[attributeNameMax] = function (element, value, name) {
 
-                let isActualNumber;
                 value = options.floatVal ? parseFloat(value) : parseInt(value, 10) || 0;
-                isActualNumber = !isNaN(value);
 
                 if (element.is('interaction')) {
                     //update response

--- a/views/js/qtiCreator/widgets/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/helpers/formElement.js
@@ -278,7 +278,10 @@ define([
             };
 
             callbacks[attributeNameMax] = function (element, value, name) {
+
+                let isActualNumber;
                 value = options.floatVal ? parseFloat(value) : parseInt(value, 10) || 0;
+                isActualNumber = !isNaN(value);
 
                 if (element.is('interaction')) {
                     //update response
@@ -288,15 +291,15 @@ define([
                 if (name === 'upperBound' && this.disabled) {
                     // if the field is disabled, the corresponding attribute should be removed.
                     element[options.attrMethodNames.remove](name);
-                } else if (!value && (element.is('orderInteraction') || element.is('graphicOrderInteraction'))) {
-                    element[options.attrMethodNames.remove](name); //to be removed for order interactions
-                } else {
+                } else if (!options.allowNull && (value === 0 || !isActualNumber)) {
+                    //if a null attribute is not allowed, should be removed.
+                    element[options.attrMethodNames.remove](name);
+                } else  {
                     element[options.attrMethodNames.set](name, value); //required
                 }
 
                 options.callback(element, value, name);
             };
-
             return callbacks;
         }
     };

--- a/views/js/qtiCreator/widgets/interactions/helpers/answerState.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/answerState.js
@@ -276,7 +276,6 @@ define([
                     value: _.parseInt(response.getMappingAttribute('upperBound')) || 0,
                     helpMessage: __('Maximal score for this interaction.')
                 },
-                lowerThreshold: 0, // the same as unchecked
                 upperThreshold: Number.MAX_SAFE_INTEGER,
                 syncValues: true
             });


### PR DESCRIPTION
Related Issue:  https://oat-sa.atlassian.net/browse/AUT-12

Select point interaction response Scoring defaults to 0 even if correct when tickbox is set to 0.
IU allows the score max to go to 0 even when the box is ticked.

FIXES:
Scoring issue => conditional in formElement changed to add value 0 to the conditions that  remove upperbound.
IU issue = > Removing a threshold set to 0 in minMaxComponentFactory.

SETPS to test:
1. Create a new item
2. Add a Select Point interaction into it
3. Define a response area with score=1
4. Define max score range value
5. Save the item (you may find a QTI sample of the state below  )
6. When maximum Score checked try to go below one.
8. Undefine max score range value by unchecking the corresponding checkbox
9. Save the item (you may find a QTI sample of the state below  )
10. Preview the item
11. Select the correct response
12. Submit the response
13. Response should contain the right score.

Actual result: incrementor allows 0 even with the box ticked, Score is 0 even if right answer in that case.
Expected result: incrementor doesn't allow going down from one if box ticked, result is always given points when answer is correct.