### PR TITLE
Fix/tr-1432/bump required lib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "7.1.4",
+        "oat-sa/lib-tao-qti": "dev-feat/TR-1432/bump-required-sdk-version as 7.1.8",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "dev-feat/TR-1432/bump-required-sdk-version as 7.1.8",
+        "oat-sa/lib-tao-qti": "dev-feat/TR-1432/bump-required-sdk-version as 7.1.8-dev",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "dev-feat/TR-1432/bump-required-sdk-version as 7.1.8-dev",
+        "oat-sa/lib-tao-qti": "7.2.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",


### PR DESCRIPTION
Bump required `lib-tao-qti` version.

Related to https://oat-sa.atlassian.net/browse/TR-1432