### PR TITLE
fix: include lib-tao-qti 7.2.1 to include QTI-SDK fix.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "7.2.0",
+        "oat-sa/lib-tao-qti": "7.2.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",


### PR DESCRIPTION
Aims at including `lib-tao-qti` `v7.2.1` in order to bring in the latest QTI-SDK fixes.