### PR TITLE
fix: Remove shared stimulus toolbar icon in hottext interaction

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/hottextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/hottextInteraction/states/Question.js
@@ -95,7 +95,8 @@ define([
                 data: {
                     container: container,
                     widget: _widget
-                }
+                },
+                qtiInclude: false
             });
         }
     };


### PR DESCRIPTION
AUT-106:Related to:
https://oat-sa.atlassian.net/browse/AUT-106

Description of changes:
while the author is editing the Hottext interaction, the Shared Stimulus icon in the toolbar should be disabled hidden and not accessible.
Configured  qtiInclude as false by default for shared stimulus in hottext interaction question.js

How to run locally:

Checkout feature/AUT-106/hottextInteraction-disable-sharedStimulus-inCkeditor
Create an item
Add a new Hottext interaction
Put focus on the prompt input, you should be able to see an icon with the shared Stimulus
Put focus on the interaction choice input, the shared Stimulus icon should disappear.

Expected Result: 
The icon is visible when in the prompt input and it disappears when on the interaction choice input.

Testing env:
http://test-silvia.playground.kitchen.it.taocloud.org:41441