### PR TITLE
Fix AUT-192 - update tao-item-runner-qti to 0.13.0-5 version

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-+7l2uG0+6idJoxUZTojRLmZQvMgC0Z5BpIoWfbvgdM2Z/TiPHFk8PoLfn7VAOfkHl0CFTmgjHDI8N6Up5s0DGg=="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.13.0-4",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.13.0-4.tgz",
-      "integrity": "sha512-eHSUTiX4001wceq52rzHUT/I5z3yW3NuJv7Kb78EB4mmG1K/SMiJXyxUcOJ9hwJRVqMCR2ecX5nCODj1Wz6WDw=="
+      "version": "0.13.0-5",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.13.0-5.tgz",
+      "integrity": "sha512-nwHld0emUSkymsQ6LC1gAdrDFvNAM4NcSU3VvgPHNOWU/JPBTk0NhBitWFMX3GqDwfvXZSE///MaEy00CKtrow=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.6.1",
-    "@oat-sa/tao-item-runner-qti": "0.13.0-4"
+    "@oat-sa/tao-item-runner-qti": "0.13.0-5"
   }
 }


### PR DESCRIPTION
Update `tao-item-runner-qti` to `0.13.0-5` version
Backport of the fix: [AUT-192](https://oat-sa.atlassian.net/browse/AUT-192)
Related PR: https://github.com/oat-sa/tao-item-runner-qti-fe/pull/208/files