### PR TITLE
Fix/ADF-480/Fix permissions to view buttons

### DIFF
--- a/controller/QtiCreator.php
+++ b/controller/QtiCreator.php
@@ -77,6 +77,7 @@ class QtiCreator extends tao_actions_CommonModule
      * @throws common_exception_Error
      *
      * @requiresRight id WRITE
+     * @requiresRight classUri WRITE
      */
     public function createItem()
     {


### PR DESCRIPTION
**Relates to:** _[ADF-480](https://oat-sa.atlassian.net/browse/ADF-480)_

---

**How to test:**
1. Create new role `Test Takers Author` with included `Test Takers Manager` role;
2. Create a new user (e.g `Test User`) with the following list of roles:  
a. Item Author;
b. Test Author;
c. Test Takers Author (our new role);
3. Go to Items and create a new class;
4. Change Access Rights for this class:
a. Add `Global Manager` role and set `GRANT` access level to him;
b. Set `READ` access level to `Back Office` role;
5. Create a new item in this class;
6. Change Access Rights for this item: set `GRANT` access level to our new user (`Test User`);
7. Log in as Test User and select this item.

**Previous behavior:** _user can see `New class`, `Import`, `New item` buttons._
**Current behavior:** _user cannot see `New class`, `Import`, `New item` buttons._

```diff
! Repeat steps 3 - 7 for: Tests, Test-takers, Assets.
```
---

**Companion PRs:**
* https://github.com/oat-sa/tao-core/pull/3012
* https://github.com/oat-sa/extension-tao-item/pull/488
* https://github.com/oat-sa/extension-tao-mediamanager/pull/294
* https://github.com/oat-sa/extension-tao-test/pull/375
* https://github.com/oat-sa/extension-tao-testtaker/pull/190