### PR TITLE
Feature/TR-1810/Disable the media preview under Firefox 87+ when having a media interaction with WebM

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
             "integrity": "sha512-3+kd6sH5yckD9iH3+IDnmTHctT0dFUx55vFfhlo8LvzyaE77I6Eci0uyOQpoDUMqRTzyw7tABBkNue0WkfAAsw=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "0.21.11",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.21.11.tgz",
-            "integrity": "sha512-gcw9IBSORm+XnNrqaDsgHuFtcQ4Va5m6RZTiUhBOn/kQR3IeGG0JQuktyT3E8spSaGST5268+gGvvAPF5QKLmQ=="
+            "version": "github:oat-sa/tao-item-runner-qti-fe#6ec8d9f1d027abd4da9cb033ddb4d782b63a31a4",
+            "from": "github:oat-sa/tao-item-runner-qti-fe#feature/TR-1810/disable-media-player-preview-under-firefox"
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.7.1",
-        "@oat-sa/tao-item-runner-qti": "0.21.11"
+        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#feature/TR-1810/disable-media-player-preview-under-firefox"
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1810

Requires: 
 - [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/211
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/346
 - [ ] https://github.com/oat-sa/tao-core/pull/3070
 - [ ] Once the companion PR is merged, update the package.json and the composer.json files accordingly

Disable the media preview when this is Firefox 87+ and the media interaction targets a WebM content.

**How to test:**
- Have a test containing media interactions, especially with video media. You need to have at least a video in WebM format. But other formats should also be checked as well.
- Check the behavior under various browsers: under Firefox, from version 87 on, if the media is WebM, the preview should be disabled, otherwise it should be presented