### PR TITLE
fix: root class name for imported passage

### DIFF
--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -591,7 +591,7 @@ class ImportService extends ConfigurableService
                     $path = $this->retrieveFullPathLabels($itemClass);
                     // Uses the first created item's label as the leaf class.
                     if (is_array($path)) {
-                        $path[] = $rdfItem->getLabel();
+                        array_unshift($path, $rdfItem->getLabel());
                     }
                     /** Shared stimulus handler */
                     $sharedStimulusHandler = new SharedStimulusAssetHandler();


### PR DESCRIPTION
[https://oat-sa.atlassian.net/browse/AUT-739](https://oat-sa.atlassian.net/browse/AUT-739?focusedCommentId=148433
)
When importing a test containing an item with a passage, the passage saved in subclass with name:
before fix:
![image](https://user-images.githubusercontent.com/18700632/130576971-992e8440-525b-47a1-90a3-ef022aab1a89.png)
after fix:
![image](https://user-images.githubusercontent.com/18700632/130577181-e8de1a35-4f94-423f-bb60-5ea77aca167e.png)
