### PR TITLE
Backport/TR-1810/Disable media player preview under firefox

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return [
     'name'        => 'taoQtiItem',
     'label'       => 'QTI item model',
     'license'     => 'GPL-2.0',
-    'version'     => '25.7.2.5',
+    'version'     => '25.7.2.7',
     'author'      => 'Open Assessment Technologies',
     'requires' => [
         'taoItems' => '>=10.8.2',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha1-LPZJM8C73gRKZYXi/8OMvoMx+Xg="
     },
     "@oat-sa/tao-item-runner-qti": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.10.6.tgz",
-      "integrity": "sha512-QKxsCngoRnqoxBvAHbgODuR6VUBcZKkMQzhZAFBqedXWQ0f4SS+J4KvrEx/OJXOJWpVnfZVtyyGrrUg5lMGJLA=="
+      "version": "github:oat-sa/tao-item-runner-qti-fe#2a5f9cbe28b292631b14c1d96583e1560f7b3c19",
+      "from": "github:oat-sa/tao-item-runner-qti-fe#backport/TR-1810/disable-media-player-preview-under-firefox"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@oat-sa/tao-item-runner": "0.4.0",
-    "@oat-sa/tao-item-runner-qti": "0.10.6"
+    "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#backport/TR-1810/disable-media-player-preview-under-firefox"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1810

Requires: 
 - [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/212
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/347
 - [ ] https://github.com/oat-sa/tao-core/pull/3077
 - [ ] Once the companion PR is merged, update the package.json and the composer.json files accordingly

Backport of #1855  to Sprint 134.5.100
Also fixes a version issue as the tag `25.7.2.6` was not having the version updated.

Disable the media preview when this is Firefox 87+ and the media interaction targets a WebM content.

**How to test:**
- Have a test containing media interactions, especially with video media. You need to have at least a video in WebM format. But other formats should also be checked as well.
- Check the behavior under various browsers: under Firefox, from version 87 on, if the media is WebM, the preview should be disabled, otherwise it should be presented