### PR TITLE
fix: correct checkboxes disabled when reentering response in match in…

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/matchInteraction/states/Map.js
+++ b/views/js/qtiCreator/widgets/interactions/matchInteraction/states/Map.js
@@ -18,11 +18,12 @@ define([
 
         //finally, apply defined correct response and response mapping:
         responseWidget.setResponse(interaction, _.values(response.getCorrect()));
-
-        matchInteractionArea
-            .prop('disabled', true)
-            .prop('checked', false)
-            .addClass('disabled');
+            if(!interaction.metaData.responseMappingMode) {
+                 matchInteractionArea
+                    .prop('disabled', true)
+                    .prop('checked', false)
+                    .addClass('disabled');
+            }
 
        //change the correct state
         interactionContainer.on('metaChange', function(meta) {

--- a/views/js/qtiCreator/widgets/interactions/matchInteraction/states/Map.js
+++ b/views/js/qtiCreator/widgets/interactions/matchInteraction/states/Map.js
@@ -18,12 +18,6 @@ define([
 
         //finally, apply defined correct response and response mapping:
         responseWidget.setResponse(interaction, _.values(response.getCorrect()));
-            if(!interaction.metaData.responseMappingMode) {
-                 matchInteractionArea
-                    .prop('disabled', true)
-                    .prop('checked', false)
-                    .addClass('disabled');
-            }
 
        //change the correct state
         interactionContainer.on('metaChange', function(meta) {


### PR DESCRIPTION
Related Issue: https://oat-sa.atlassian.net/browse/AUT-885
checkbox is disabled when re-entering response.

Pre-requisite: To have an item created with a Match interaction

SETPS to test:

- Checkout to branch fix/AUT-885/checkboxes-not-available-after-reentering-response
- Open the Match interaction Item & click response
- Choose "Map response" from drop down menu (Response Processing)
- Tick checkbox "Define correct response"
- Define correct response and the score
- Save and preview.
- Close "Preview" window and go back to Response Properties.

**Actual result:** Checkbox 'Define correct response' is ticked, previously defined correct response does not persist, user cannot select any of checkboxes as response.
**Expected result:** Previously defined correct response persists. Checkboxes are not grayed and user can select any of them as response. Checkbox 'Define correct response' is ticked.
Testing env: http://test-silvia.playground.kitchen.it.taocloud.org:41441