### PR TITLE
chore: bump version of `oat-sa/lib-tao-qti` to `7.2.2` from `5.5.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "5.5.0",
+        "oat-sa/lib-tao-qti": "7.2.2",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/composer-npm-bridge": "^0.3.0",
         "naneau/semver": "~0.0.7"

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,18 +1,39 @@
 {
-  "name": "@oat-sa/tao-qti-item",
-  "version": "0.3.1",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@oat-sa/tao-item-runner": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.6.1.tgz",
-      "integrity": "sha512-+7l2uG0+6idJoxUZTojRLmZQvMgC0Z5BpIoWfbvgdM2Z/TiPHFk8PoLfn7VAOfkHl0CFTmgjHDI8N6Up5s0DGg=="
+    "name": "@oat-sa/tao-qti-item",
+    "version": "0.3.1",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@oat-sa/tao-qti-item",
+            "version": "0.3.1",
+            "license": "GPL-2.0",
+            "dependencies": {
+                "@oat-sa/tao-item-runner": "0.6.1",
+                "@oat-sa/tao-item-runner-qti": "0.15.1"
+            }
+        },
+        "node_modules/@oat-sa/tao-item-runner": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.6.1.tgz",
+            "integrity": "sha512-+7l2uG0+6idJoxUZTojRLmZQvMgC0Z5BpIoWfbvgdM2Z/TiPHFk8PoLfn7VAOfkHl0CFTmgjHDI8N6Up5s0DGg=="
+        },
+        "node_modules/@oat-sa/tao-item-runner-qti": {
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.15.1.tgz",
+            "integrity": "sha512-F9UO65s6UQ2nzc4ljEsWRGSFs0onD0pQ2Q1VxjEGiSHzqspvypavx7/CrkKCtlomoK+mClSaJS0tvZ/8rubKRQ=="
+        }
     },
-    "@oat-sa/tao-item-runner-qti": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.15.1.tgz",
-      "integrity": "sha512-F9UO65s6UQ2nzc4ljEsWRGSFs0onD0pQ2Q1VxjEGiSHzqspvypavx7/CrkKCtlomoK+mClSaJS0tvZ/8rubKRQ=="
+    "dependencies": {
+        "@oat-sa/tao-item-runner": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.6.1.tgz",
+            "integrity": "sha512-+7l2uG0+6idJoxUZTojRLmZQvMgC0Z5BpIoWfbvgdM2Z/TiPHFk8PoLfn7VAOfkHl0CFTmgjHDI8N6Up5s0DGg=="
+        },
+        "@oat-sa/tao-item-runner-qti": {
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.15.1.tgz",
+            "integrity": "sha512-F9UO65s6UQ2nzc4ljEsWRGSFs0onD0pQ2Q1VxjEGiSHzqspvypavx7/CrkKCtlomoK+mClSaJS0tvZ/8rubKRQ=="
+        }
     }
-  }
 }


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-1869

## Summary
This PR aims to bump the `lib-tao-qti` to the version required to be ported for NCCER env.