### PR TITLE
AUT-1034 move requestTimeout to cypress.json configs

### DIFF
--- a/views/cypress/tests/item-authoring.spec.js
+++ b/views/cypress/tests/item-authoring.spec.js
@@ -35,9 +35,7 @@ describe('Items', () => {
         cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel')
 
         cy.visit(urls.items);
-        cy.wait('@edit', {
-            requestTimeout: 10000
-        });
+        cy.wait('@edit');
 
         cy.get(selectors.root).then(root => {
             if ((root.find(`li[title="${className}"] a`).length)) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1034

We have explicitly defined a specific time for most of our request interception/waiting. 
i.e: .wait('@editItem', { requestTimeout: 10000 }) 

We should make this requestTimeout of 10000ms the norm by defining it as a default in cypress.json and removing each explicit mention of it in our .wait() function calls.

**How to test:**
Run cypress and check that updated tests pass without errors after updating default request timeout.