### PR TITLE
fix: outcome declaration min accepts negative values

### DIFF
--- a/views/js/qtiCreator/tpl/outcomeEditor/listing.tpl
+++ b/views/js/qtiCreator/tpl/outcomeEditor/listing.tpl
@@ -42,7 +42,7 @@
             <label class="has-icon">{{__ "Value"}}</label>
             <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
             <div class="tooltip-content">{{__ "Defines the maximum magnitude of numeric outcome variables, the maximum must be a positive value and the minimum may be negative."}}</div>
-            <input name="normalMinimum" value="{{normalMinimum}}" data-increment="1" data-min="0" type="text" />
+            <input name="normalMinimum" value="{{normalMinimum}}" data-increment="1" type="text" />
             <label for="normalMaximum" class="spinner">{{__ "to"}}</label>
             <input name="normalMaximum" value="{{normalMaximum}}" data-increment="1" data-min="0" type="text" />
         </div>


### PR DESCRIPTION
**Related Issue:**  https://oat-sa.atlassian.net/browse/AUT-1002

Outcome declarations: min value can't be set to negative value

**Pre-requisite:** To have an item created.

**SETPS to test:**
	• Checkout to branch: fix/AUT-1002/outcome-declarations-negative-values
	• Open an item, click response and add and add an outcome
	• edit the outcome and try to put minimum below 0.
	• Negative values should be allowed
	• Check that max is always equal or higher than min and there is no other strange behavior

**Actual result:** min will not go below 0 with the arrows and will set itself back to 0 if entered manually
**Expected result:** Min will go below 0 in min input.

Testing env: http://test-silvia.playground.kitchen.it.taocloud.org:41441/