### PR TITLE
ADF-635: E2E testing - Group renameSelected command

### DIFF
--- a/views/cypress/tests/item-authoring.spec.js
+++ b/views/cypress/tests/item-authoring.spec.js
@@ -68,7 +68,7 @@ describe('Items', () => {
                 selectors.addSubClassUrl
             );
             cy.addNode(selectors.itemForm, selectors.addItem);
-            cy.renameSelectedItem(selectors.itemForm, selectors.editItemUrl, itemName);
+            cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
 
             cy.get(selectors.authoring).click();
             cy.location().should((loc) => {


### PR DESCRIPTION
Jira task: https://oat-sa.atlassian.net/browse/ADF-635

Turns out that the renameSelected command had already been refactored in task https://oat-sa.atlassian.net/browse/AUT-1035. But two tests were failing after that, so this is now the fix of that refactor.

PR related to: https://github.com/oat-sa/tao-core/pull/3132