### PR TITLE
fix: id attributes get translated

### DIFF
--- a/views/js/portableElementRegistry/factory/ciRegistry.js
+++ b/views/js/portableElementRegistry/factory/ciRegistry.js
@@ -44,7 +44,7 @@ define([
                         description : pciModel.description,
                         qtiClass : 'customInteraction.' + pciModel.typeIdentifier, //custom interaction is block type
                         tags : _.union(['Custom Interactions'], pciModel.tags),
-                        group : 'custom-interaction'
+                        group : 'custom-interactions'
                     };
                 }
             }

--- a/views/js/portableElementRegistry/factory/ciRegistry.js
+++ b/views/js/portableElementRegistry/factory/ciRegistry.js
@@ -33,7 +33,7 @@ define([
 
         return portableElementRegistry({
             getAuthoringData : function getAuthoringData(typeIdentifier, options){
-                var pciModel;
+                let pciModel;
                 options = _.defaults(options || {}, {version : 0, enabledOnly : false});
                 pciModel = this.get(typeIdentifier, options.version);
                 if(pciModel && pciModel.creator && pciModel.creator.hook && pciModel.creator.icon && (pciModel.enabled || !options.enabledOnly)){
@@ -43,7 +43,8 @@ define([
                         short : pciModel.short,
                         description : pciModel.description,
                         qtiClass : 'customInteraction.' + pciModel.typeIdentifier, //custom interaction is block type
-                        tags : _.union(['Custom Interactions'], pciModel.tags)
+                        tags : _.union(['Custom Interactions'], pciModel.tags),
+                        group : 'custom-interaction'
                     };
                 }
             }

--- a/views/js/qtiCreator/editor/interactionsToolbar.js
+++ b/views/js/qtiCreator/editor/interactionsToolbar.js
@@ -48,19 +48,19 @@ define([
         interactiontoolbarready : 'interactiontoolbarready.qti-widget'
     };
 
-    function getGroupId(groupLabel){
-        return groupLabel.replace(/\W+/g, '-').toLowerCase();
+    function getGroupId(groupName){
+        return groupName.replace(/\W+/g, '-').toLowerCase();
     }
 
-    function getGroupSectionId(groupLabel){
-        return 'sidebar-left-section-' + getGroupId(groupLabel);
+    function getGroupSectionId(groupName){
+        return 'sidebar-left-section-' + getGroupId(groupName);
     }
 
-    function addGroup($sidebar, groupLabel){
+    function addGroup($sidebar, groupName, groupLabel){
 
-        var groupId = getGroupSectionId(groupLabel);
+        let groupId = getGroupSectionId(groupName);
 
-        var $section = $(insertSectionTpl({
+        let $section = $(insertSectionTpl({
             id : groupId,
             label : groupLabel
         }));
@@ -83,9 +83,9 @@ define([
         $sidebar.trigger(_events.interactiontoolbarready);//interactiontoolbarready.qti-widget
     }
 
-    function getGroup($sidebar, groupLabel){
+    function getGroup($sidebar, groupName){
 
-        var groupId = getGroupSectionId(groupLabel);
+        let groupId = getGroupSectionId(groupName);
         return $sidebar.find('#' + groupId);
     }
 
@@ -127,9 +127,10 @@ define([
             throw 'the interaction is already in the sidebar';
         }
         
-        var groupLabel = interactionAuthoringData.tags[0] || '',
+        let groupName = interactionAuthoringData.group,
+            groupLabel = interactionAuthoringData.tags[0] || '',
             subGroupId = interactionAuthoringData.tags[1],
-            $group = getGroup($sidebar, groupLabel),
+            $group = getGroup($sidebar, groupName),
             tplData = {
                 qtiClass : interactionAuthoringData.qtiClass,
                 disabled : !!interactionAuthoringData.disabled,
@@ -146,7 +147,7 @@ define([
 
         if(!$group.length){
             //the group does not exist yet : create a <section> for the group
-            $group = addGroup($sidebar, groupLabel);
+            $group = addGroup($sidebar, groupName, groupLabel);
         }
 
         if(subGroupId && _subgroups[subGroupId]){
@@ -155,10 +156,10 @@ define([
 
         if(!$group.length){
             //the group does not exist yet : create a <section> for the group
-            $group = addGroup($sidebar, groupLabel);
+            $group = addGroup($sidebar, groupName, groupLabel);
         }
         
-        var $interaction = $(insertInteractionTpl(tplData));
+        let $interaction = $(insertInteractionTpl(tplData));
         $group.find('.tool-list').append($interaction);
         
         return $interaction;

--- a/views/js/qtiCreator/editor/interactionsToolbar.js
+++ b/views/js/qtiCreator/editor/interactionsToolbar.js
@@ -48,20 +48,20 @@ define([
         interactiontoolbarready : 'interactiontoolbarready.qti-widget'
     };
 
-    function getGroupId(groupName){
-        return groupName.replace(/\W+/g, '-').toLowerCase();
+    function getGroupId(groupId){
+        return groupId.replace(/\W+/g, '-').toLowerCase();
     }
 
-    function getGroupSectionId(groupName){
-        return 'sidebar-left-section-' + getGroupId(groupName);
+    function getGroupSectionId(groupId){
+        return 'sidebar-left-section-' + getGroupId(groupId);
     }
 
-    function addGroup($sidebar, groupName, groupLabel){
+    function addGroup($sidebar, groupId, groupLabel){
 
-        let groupId = getGroupSectionId(groupName);
+        const groupSectionId = getGroupSectionId(groupId);
 
-        let $section = $(insertSectionTpl({
-            id : groupId,
+        const $section = $(insertSectionTpl({
+            id : groupSectionId,
             label : groupLabel
         }));
 
@@ -83,10 +83,10 @@ define([
         $sidebar.trigger(_events.interactiontoolbarready);//interactiontoolbarready.qti-widget
     }
 
-    function getGroup($sidebar, groupName){
+    function getGroup($sidebar, groupId){
 
-        let groupId = getGroupSectionId(groupName);
-        return $sidebar.find('#' + groupId);
+        const groupSectionId = getGroupSectionId(groupId);
+        return $sidebar.find('#' + groupSectionId);
     }
 
     function isReady($sidebar){
@@ -126,11 +126,10 @@ define([
         if(exists($sidebar, interactionAuthoringData.qtiClass)){
             throw 'the interaction is already in the sidebar';
         }
-        
-        let groupName = interactionAuthoringData.group,
+
+      const groupId = interactionAuthoringData.group,
             groupLabel = interactionAuthoringData.tags[0] || '',
             subGroupId = interactionAuthoringData.tags[1],
-            $group = getGroup($sidebar, groupName),
             tplData = {
                 qtiClass : interactionAuthoringData.qtiClass,
                 disabled : !!interactionAuthoringData.disabled,
@@ -140,6 +139,8 @@ define([
                 short : interactionAuthoringData.short,
                 dev : false
             };
+        let $group = getGroup($sidebar, groupId);
+
 
         if(subGroupId && _subgroups[subGroupId]){
             tplData.subGroup = subGroupId;
@@ -147,7 +148,7 @@ define([
 
         if(!$group.length){
             //the group does not exist yet : create a <section> for the group
-            $group = addGroup($sidebar, groupName, groupLabel);
+            $group = addGroup($sidebar, groupId, groupLabel);
         }
 
         if(subGroupId && _subgroups[subGroupId]){
@@ -156,7 +157,7 @@ define([
 
         if(!$group.length){
             //the group does not exist yet : create a <section> for the group
-            $group = addGroup($sidebar, groupName, groupLabel);
+            $group = addGroup($sidebar, groupId, groupLabel);
         }
         
         let $interaction = $(insertInteractionTpl(tplData));

--- a/views/js/qtiCreator/helper/qtiElements.js
+++ b/views/js/qtiCreator/helper/qtiElements.js
@@ -312,7 +312,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 icon : 'icon-choice',
                 short : __('Choice'),
                 qtiClass : 'choiceInteraction',
-                tags:[tagTitles.commonInteractions, 'mcq']
+                tags:[tagTitles.commonInteractions, 'mcq'],
+                group: 'common-interactions'
             },
             orderInteraction : {
                 label : __('Order Interaction'),
@@ -320,7 +321,9 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Arrange a list of choices in the correct order.'),
                 short : __('Order'),
                 qtiClass : 'orderInteraction',
-                tags:[tagTitles.commonInteractions, 'ordering']
+                tags:[tagTitles.commonInteractions, 'ordering'],
+                group: 'common-interactions'
+
             },
             associateInteraction : {
                 label : __('Associate Interaction'),
@@ -328,7 +331,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Create pair(s) from a series of choices.'),
                 short : __('Associate'),
                 qtiClass : 'associateInteraction',
-                tags:[tagTitles.commonInteractions, 'association']
+                tags:[tagTitles.commonInteractions, 'association'],
+                group: 'common-interactions'
             },
             matchInteraction : {
                 label : __('Match Interaction'),
@@ -336,7 +340,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Create association(s) between two sets of choices displayed in a table (row and column).'),
                 short : __('Match'),
                 qtiClass : 'matchInteraction',
-                tags:[tagTitles.commonInteractions, 'association']
+                tags:[tagTitles.commonInteractions, 'association'],
+                group: 'common-interactions'
             },
             hottextInteraction : {
                 label : __('Hottext Interaction'),
@@ -344,7 +349,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Select one or more text parts (hottext) within a text.'),
                 short : __('Hottext'),
                 qtiClass : 'hottextInteraction',
-                tags:[tagTitles.commonInteractions, 'text']
+                tags:[tagTitles.commonInteractions, 'text'],
+                group: 'common-interactions'
             },
             gapMatchInteraction : {
                 label : __('Gap Match Interaction'),
@@ -352,7 +358,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __(' Fill in the gaps in a text from a set of choices.'),
                 short : __('Gap Match'),
                 qtiClass : 'gapMatchInteraction',
-                tags:[tagTitles.commonInteractions, 'text', 'association']
+                tags:[tagTitles.commonInteractions, 'text', 'association'],
+                group: 'common-interactions'
             },
             sliderInteraction : {
                 label : __('Slider Interaction'),
@@ -360,7 +367,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description :__('Select a value within a numerical range.'),
                 short : __('Slider'),
                 qtiClass : 'sliderInteraction',
-                tags:[tagTitles.commonInteractions, 'special']
+                tags:[tagTitles.commonInteractions, 'special'],
+                group: 'common-interactions'
             },
             extendedTextInteraction : {
                 label : __('Extended Text Interaction'),
@@ -368,7 +376,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Collect open-ended information in one or more text area(s) (strings or numeric values).'),
                 short : __('Extended Text'),
                 qtiClass : 'extendedTextInteraction',
-                tags:[tagTitles.commonInteractions, 'text']
+                tags:[tagTitles.commonInteractions, 'text'],
+                group: 'common-interactions'
             },
             uploadInteraction : {
                 label : __('File Upload Interaction'),
@@ -376,7 +385,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Upload a file (e.g. document, picture...) as a response.'),
                 short : __('File Upload'),
                 qtiClass : 'uploadInteraction',
-                tags:[tagTitles.commonInteractions, 'special']
+                tags:[tagTitles.commonInteractions, 'special'],
+                group: 'common-interactions'
             },
             mediaInteraction : {
                 label : __('Media Interaction'),
@@ -384,7 +394,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Control the playing parameters (auto-start, loop) of a video or audio file and report the number of time it has been played.'),
                 short : __('Media'),
                 qtiClass : 'mediaInteraction',
-                tags:[tagTitles.commonInteractions, 'media']
+                tags:[tagTitles.commonInteractions, 'media'],
+                group: 'common-interactions'
             },
             _container : {
                 label : __('Text Block'),
@@ -392,7 +403,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Block contains the content (stimulus) of the item such as text or image. It is also required for Inline Interactions.'),
                 short : __('Block'),
                 qtiClass : '_container',
-                tags:[tagTitles.inlineInteractions, 'text']
+                tags:[tagTitles.inlineInteractions, 'text'],
+                group: 'inline-interactions'
             },
             inlineChoiceInteraction : {
                 label : __('Inline Choice Interaction'),
@@ -400,7 +412,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Select a choice from a drop-down list.'),
                 short : __('Inline Choice'),
                 qtiClass : 'inlineChoiceInteraction',
-                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'mcq']
+                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'mcq'],
+                group: 'inline-interactions'
             },
             textEntryInteraction : {
                 label : __('Text Entry Interaction'),
@@ -408,7 +421,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Collect open-ended information in a short text input (strings or numeric values).'),
                 short : __('Text Entry'),
                 qtiClass : 'textEntryInteraction',
-                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'text']
+                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'text'],
+                group: 'inline-interactions'
             },
             endAttemptInteraction : {
                 label : __('End Attempt Interaction'),
@@ -416,7 +430,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Trigger the end of the item attempt.'),
                 short : __('End Attempt'),
                 qtiClass : 'endAttemptInteraction',
-                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'button', 'submit']
+                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'button', 'submit'],
+                group: 'inline-interactions'
             },
             hotspotInteraction : {
                 label : __('Hotspot Interaction'),
@@ -424,7 +439,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Select one or more areas (hotspots) displayed on an picture.'),
                 short : __('Hotspot'),
                 qtiClass : 'hotspotInteraction',
-                tags:[tagTitles.graphicInteractions, 'mcq']
+                tags:[tagTitles.graphicInteractions, 'mcq'],
+                group: 'graphic-interactions'
             },
             graphicOrderInteraction : {
                 label : __('Graphic Order Interaction'),
@@ -432,7 +448,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Order the areas (hotspots) displayed on a picture.'),
                 short : __('Order'),
                 qtiClass : 'graphicOrderInteraction',
-                tags:[tagTitles.graphicInteractions, 'ordering']
+                tags:[tagTitles.graphicInteractions, 'ordering'],
+                group: 'graphic-interactions'
             },
             graphicAssociateInteraction : {
                 label : __('Graphic Associate Interaction'),
@@ -440,7 +457,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Create association(s) between areas (hotspots) displayed on a picture.'),
                 short : __('Associate'),
                 qtiClass : 'graphicAssociateInteraction',
-                tags:[tagTitles.graphicInteractions, 'association']
+                tags:[tagTitles.graphicInteractions, 'association'],
+                group: 'graphic-interactions'
             },
             graphicGapMatchInteraction : {
                 label : __('Graphic Gap Match Interaction'),
@@ -448,7 +466,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Fill in the gaps on a picture with a set of image choices.'),
                 short : __('Gap Match'),
                 qtiClass : 'graphicGapMatchInteraction',
-                tags:[tagTitles.graphicInteractions, 'association']
+                tags:[tagTitles.graphicInteractions, 'association'],
+                group: 'graphic-interactions'
             },
             selectPointInteraction : {
                 label : __('Select Point Interaction'),
@@ -456,7 +475,8 @@ define(['jquery', 'lodash', 'i18n'], function($, _, __){
                 description : __('Position one or more points on a picture (response areas are not displayed).'),
                 short : __('Select Point'),
                 qtiClass : 'selectPointInteraction',
-                tags:[tagTitles.graphicInteractions]
+                tags:[tagTitles.graphicInteractions],
+                group: 'graphic-interactions'
             }
         };
     };


### PR DESCRIPTION
Related Issue: https://oat-sa.atlassian.net/browse/AUT-773

id attributes get translated

Pre-requisite: To have an item created.

SETPS to test:
• Checkout to branch: fix/AUT-773/id-attributes-get-translated
• change the language
• go inside an item authoring
• Group name on the left should be on the selected language ( common interactions, inline interactions, graphic interactions, custom interactions.)
• All interactions should be displayed correctly
• Inspect elements in the  dev tools: Group id shouldn't change independently of the language

Actual result: <section id are different depending on language
![image](https://user-images.githubusercontent.com/60346520/135067173-2ad3a34d-2b25-42f5-a344-50884fdf3c1c.png)


Expected result: section id's are always in English independently of the language that the item is set in
![image](https://user-images.githubusercontent.com/60346520/135066480-0c9ce42a-d62b-4ab0-b4f6-d1b4c4182652.png)

Testing env: http://test-silvia.playground.kitchen.it.taocloud.org:41441/