### PR TITLE
Fix/aut 1123/update hottext min max tresholds on edit

### DIFF
--- a/views/js/qtiCreator/model/interactions/HottextInteraction.js
+++ b/views/js/qtiCreator/model/interactions/HottextInteraction.js
@@ -62,6 +62,9 @@ define([
                 
                 //trigger event
                 event.deleted(c, this);
+
+                // trigger delete event
+                $(document).trigger('choiceDeleted.qti-widget', {interaction: this});
             }
             
             return this;

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -218,7 +218,7 @@ define([
             updateThresholds : function updateThresholds(lower, upper) {
                 var config = this.getConfig();
                 var fieldOptions;
-                if(_.isNumber(lower) && _.isNumber(upper) && upper > lower) {
+                if(_.isNumber(lower) && _.isNumber(upper) && upper >= lower) {
                     config.lowerThreshold = _.parseInt(lower);
                     config.upperThreshold = _.parseInt(upper);
 

--- a/views/js/qtiCreator/widgets/interactions/hottextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/hottextInteraction/states/Question.js
@@ -273,6 +273,9 @@ define([
                     newHottextWidget.destroy();
                     newHottextWidget = newHottextElt.data('widget');
                     newHottextWidget.changeState('choice');
+
+                    // trigger create event
+                    $(document).trigger('choiceCreated.qti-widget', {interaction});
                 }
             }
         );


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/AUT-1123

**Where to test:** http://test-adrian0.playground.kitchen.it.taocloud.org:41671/

**Description:** 
This issue was caused by a more general problem that prevents sync between number of available choices and threshold for allowed choices min/max; you need to exit edit mode and get back in to get those thresholds updated:

![broken](https://user-images.githubusercontent.com/14041944/135223018-7df18412-bc90-4a1f-931a-398e73df0119.gif)



On `views/js/qtiCreator/widgets/interactions/hottextInteraction/states/Question.js:127` there is this event listener:

```javascript
        minMaxComponentFactory($form.find('.min-max-panel'), {
            min: { value: _.parseInt(interaction.attr('minChoices')) || 0 },
            max: { value: _.parseInt(interaction.attr('maxChoices')) || 0 },
            upperThreshold: _.size(interaction.getChoices())
        }).on('render', function () {
            widget.on('choiceCreated choiceDeleted', data => {
                if (data.interaction.serial === interaction.serial) {
                    this.updateThresholds(1, _.size(interaction.getChoices()));
                }
            });
        });
```

But seems that `choiceCreated ` and `choiceDeleted` were never called, so added event tiggers on choice creation and choice deletion.

Also `views/js/qtiCreator/widgets/component/minMax/minMax.js@updateThresholds` was not updating the tresholds if `upper ===  lower`; this causes that when having two options and deleting one (so `upper === lower === 1`) the tresholds were not updated and remained as `2` instead of be updated to `1`.

This is new behavior:

![fixed](https://user-images.githubusercontent.com/14041944/135223532-199221f4-7177-4693-bc39-2aaabd03e219.gif)

**Limitation:** There is an already existing problem that makes options not yet synced in case user removes a choice by editing and removing some portion of text containing choices. User still needs to exit edit mode and come back in for get thresholds synced. Changes on `ckeditor` are needed. I was able to make it work but then new problems came when undoing the change, so don't know if this exceeds current ticket:

![limitation](https://user-images.githubusercontent.com/14041944/135224644-cae47a56-d7fc-4736-8981-be829de85131.gif)

