### PR TITLE
Fix/AUT-811/delete child widgets

### DIFF
--- a/views/js/qtiCreator/tpl/toolbars/simpleChoice.content.tpl
+++ b/views/js/qtiCreator/tpl/toolbars/simpleChoice.content.tpl
@@ -1,4 +1,4 @@
-<div class="mini-tlb" data-edit="question" data-for="{{serial}}">
+<div class="mini-tlb" data-edit="question" data-for="{{choiceSerial}}">
     <div class="rgt tlb-button" title="Delete" data-role="delete">
         <span class="icon-bin"></span>
     </div>

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -66,8 +66,12 @@ define(['jquery'], function($) {
             var $container = widget.$container;
 
             $container.find('[data-role="delete"]').on('mousedown', function(e) {
-                e.stopPropagation();
-                widget.changeState('deleting');
+                if ($container.hasClass('edit-choice')) {
+                    // condition prevent removing choice in case user deliting inner element (math, image)
+                    // in case editing element inside will be no class .edit-choice
+                    e.stopPropagation();
+                    widget.changeState('deleting');
+                }
             });
         }
     };

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -63,9 +63,11 @@ define(['jquery'], function ($) {
             const $container = widget.$container;
 
             $container.find('[data-role="delete"]').on('mousedown', function (e) {
-                if ($container.hasClass('edit-choice')) {
+                if (
+                    $container.hasClass('edit-choice') ||
+                    $(e.target).closest('.mini-tlb').data('for') === widget.element.serial
+                ) {
                     // condition prevent removing choice in case user deliting inner element (math, image)
-                    // in case editing element inside will be no class .edit-choice
                     e.stopPropagation();
                     widget.changeState('deleting');
                 }

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -13,19 +13,17 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
  */
-define(['jquery'], function($) {
-
-    var formElementHelper = {
-        initShufflePinToggle: function(widget) {
-
-            var $container = widget.$container,
+define(['jquery'], function ($) {
+    const formElementHelper = {
+        initShufflePinToggle: function (widget) {
+            const $container = widget.$container,
                 choice = widget.element,
                 interaction = choice.getInteraction(),
                 $shuffleToggle = $container.find('[data-role="shuffle-pin"]');
 
-            var toggleVisibility = function(show) {
+            const toggleVisibility = function (show) {
                 if (show === 'true') {
                     $shuffleToggle.show();
                 } else {
@@ -36,8 +34,8 @@ define(['jquery'], function($) {
                 });
             };
 
-            $shuffleToggle.off('mousedown').on('mousedown', function(e) {
-                var $icon = $(this).children();
+            $shuffleToggle.off('mousedown').on('mousedown', function (e) {
+                let $icon = $(this).children();
                 e.stopPropagation();
 
                 if ($icon.length === 0) {
@@ -55,17 +53,16 @@ define(['jquery'], function($) {
             toggleVisibility(interaction.attr('shuffle'));
 
             //listen to interaction property change
-            widget.on('attributeChange', function(data) {
+            widget.on('attributeChange', function (data) {
                 if (data.element.serial === interaction.serial && data.key === 'shuffle') {
                     toggleVisibility(data.value);
                 }
             });
         },
-        initDelete: function(widget) {
+        initDelete: function (widget) {
+            const $container = widget.$container;
 
-            var $container = widget.$container;
-
-            $container.find('[data-role="delete"]').on('mousedown', function(e) {
+            $container.find('[data-role="delete"]').on('mousedown', function (e) {
                 if ($container.hasClass('edit-choice')) {
                     // condition prevent removing choice in case user deliting inner element (math, image)
                     // in case editing element inside will be no class .edit-choice

--- a/views/js/qtiCreator/widgets/helpers/deletingState.js
+++ b/views/js/qtiCreator/widgets/helpers/deletingState.js
@@ -102,6 +102,9 @@ define(['lodash', 'jquery', 'tpl!taoQtiItem/qtiCreator/tpl/notifications/deletin
             _bindEvents($messageBox);
 
             return $messageBox;
+        },
+        confirmDeletion: function ($messageBox) {
+            _confirmDeletion($messageBox, 0);
         }
     };
 

--- a/views/js/qtiCreator/widgets/helpers/deletingState.js
+++ b/views/js/qtiCreator/widgets/helpers/deletingState.js
@@ -24,20 +24,23 @@ define(['lodash', 'jquery', 'tpl!taoQtiItem/qtiCreator/tpl/notifications/deletin
     'use strict';
 
     const _timeout = 10000;
+    let undoDeleting = false;
 
     const _destroy = function _destroy($messageBox) {
         $('body').off('.deleting');
         $messageBox.remove();
+        undoDeleting = false;
     };
 
     const undo = function undo($messageBox) {
+        undoDeleting = true;
         $messageBox.trigger('undo.deleting');
         _destroy($messageBox);
     };
 
     const _confirmDeletion = function ($messageBox, fadeDelay) {
         //only allow deletion if the message has not already been deleted yet
-        if ($messageBox.length && $.contains(document, $messageBox[0])) {
+        if (!undoDeleting && $messageBox.length && $.contains(document, $messageBox[0])) {
             $messageBox.trigger('confirm.deleting');
             $messageBox.fadeOut(fadeDelay, function () {
                 _destroy($messageBox);

--- a/views/js/qtiCreator/widgets/states/Deleting.js
+++ b/views/js/qtiCreator/widgets/states/Deleting.js
@@ -39,6 +39,7 @@ define([
     }, function exit(){
 
         this.showWidget();
+        deletingHelper.confirmDeletion(this.messageBox);
         this.widget.element.data('deleting', false);
         $('body').off('.deleting');
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-811

Fix in commit https://github.com/oat-sa/extension-tao-itemqti/pull/1909/commits/2bb44715344d8be67a3ef6d5c4242c4f23b6d6b6

**How to test:**
- Go to Items tab.
- Create a new item and go to it's authoring.
- Add any Common interaction with choices in the canvas (f.e. Choice).
- Add Math Expression or Image/Media to the choice box.
- Delete added media/expression and leave interaction area (click Done or click area outside the interaction).
-  Deleted element does not appear anymore.