### PR TITLE
fix(dependencies): update tao-item-runner-qti to 0.24.1

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
             "integrity": "sha512-3+kd6sH5yckD9iH3+IDnmTHctT0dFUx55vFfhlo8LvzyaE77I6Eci0uyOQpoDUMqRTzyw7tABBkNue0WkfAAsw=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.24.0.tgz",
-            "integrity": "sha512-1F2IsmAvbSF0Z7E1lZQ7W27egfVJBsQRGS0ejovVBd9LLaQOSLDMpTukUZg1gg/Ljk+iY35vPi7sHcxyZtQgWw=="
+            "version": "0.24.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.24.1.tgz",
+            "integrity": "sha512-MfGZNCA57ev9Tg0928rdMcE66X4/2+HDSOc7i1iYHvd8DtK7Ifw8EFg59jPzLnoiyIT9dD4RZjX3TR9ifSV1cA=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.7.1",
-        "@oat-sa/tao-item-runner-qti": "0.24.0"
+        "@oat-sa/tao-item-runner-qti": "0.24.1"
     }
 }


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/AUT-665
**Description:** Update `@oat-sa/tao-item-runner-qti` to use [v0.24.1](https://github.com/oat-sa/tao-item-runner-qti-fe/releases/tag/v0.24.1) with issue fix.

**Where to test**: http://test-adrian0.playground.kitchen.it.taocloud.org:41671/  (I created `AUT-665 test` item for testing)


![aut-665-2](https://user-images.githubusercontent.com/14041944/137484430-7d4070c1-cc47-45a1-aaff-28fe7de788ab.gif)
