### PR TITLE
Backport/AUT-1100/add xinclude handler to pci assets exporter

### DIFF
--- a/model/qti/AssetParser.php
+++ b/model/qti/AssetParser.php
@@ -332,6 +332,9 @@ class AssetParser
                 foreach ($xml->xpath('//audio') as $audio) {
                     $this->addAsset('audio', (string)$audio['src']);
                 }
+                foreach ($xml->xpath('//include') as $xinclude) {
+                    $this->addAsset('xinclude', (string)$xinclude['href']);
+                }
             }
         }
     }


### PR DESCRIPTION
Related to: 
https://oat-sa.atlassian.net/browse/AUT-1314
https://oat-sa.atlassian.net/browse/AUT-1100

Backport of https://github.com/oat-sa/extension-tao-itemqti/pull/1906 to October Release