### PR TITLE
feat(e2e): added response processing options

### DIFF
--- a/views/cypress/tests/item-authoring-response-processing.spec.js
+++ b/views/cypress/tests/item-authoring-response-processing.spec.js
@@ -19,24 +19,15 @@
 import urls from '../utils/urls';
 import selectors from '../utils/selectors';
 
-import {
-    addBlockAndInlineInteractions,
-    addCommonInteractions,
-    addGraphicInteractions
-} from '../utils/authoring-add-interactions';
-import { setResponse } from '../utils/set-response';
+import { addInteraction } from '../utils/authoring-add-interactions';
+import { addResponseProcessing } from '../utils/set-response';
 
 describe('Item Authoring', () => {
     const className = 'Test E2E class';
     const itemName = 'Test E2E item 1';
 
     const commonWidgetSelector = (qtiClass) => `.widget-box.widget-blockInteraction[data-qti-class="${qtiClass}"]`;
-    const inlineWidgetSelector = (qtiClass) => `.widget-box.${qtiClass}-placeholder`;
-    const inlineWidgetActiveSelector = (qtiClass) => `.widget-box.widget-inline.widget-${qtiClass}`;
-    const inlineInteractions = {
-        inlineChoiceInteraction: 'inlineChoiceInteraction',
-        textEntryInteraction: 'textEntryInteraction',
-    };
+
     const interactions = {
         choice: 'choiceInteraction',
         order: 'orderInteraction',
@@ -52,6 +43,7 @@ describe('Item Authoring', () => {
         graphicGapMatchInteraction: 'graphicGapMatchInteraction',
         selectPointInteraction: 'selectPointInteraction'
     };
+    const responseProcessingOptions = ['match correct', 'map response', 'none'];
     /**
      * Log in
      * Visit the page
@@ -127,42 +119,30 @@ describe('Item Authoring', () => {
                 expect(`${loc.pathname}${loc.search}`).to.eq(urls.itemAuthoring);
             });
         });
-        it('can add interactions', function () {
-            cy.getSettled('.qti-item.item-editor-item.edit-active').should('exist');
-            // open inline interactions panel
-            cy.get('#sidebar-left-section-inline-interactions').click();
-            addBlockAndInlineInteractions();
-            // close inline interactions panel
-            cy.get('#sidebar-left-section-inline-interactions ._accordion').click();
-            addCommonInteractions();
-            // open graphic interactions panel
-            cy.get('#sidebar-left-section-graphic-interactions').click();
-            addGraphicInteractions();
+        it('can add single interaction to an item', function () {
 
-            cy.get('#item-editor-scoll-container').scrollTo('top');
+            addInteraction("choice");
         });
-
-        it('can set response to interactions', () => {
-            for (const interaction in inlineInteractions) {
-                cy.log('SETING RESPONSE IN INTERACTION', interaction);
-                setResponse(
-                    inlineWidgetSelector(inlineInteractions[interaction]),
-                    inlineWidgetActiveSelector(inlineInteractions[interaction]),
-                    inlineInteractions[interaction]
-                );
-                cy.log(interaction, 'RESPONSE IS SET');
-            }
-            for (const interaction in interactions) {
-                cy.log('SETING RESPONSE IN INTERACTION', interaction);
-                setResponse(
-                    commonWidgetSelector(interactions[interaction]),
-                    commonWidgetSelector(interactions[interaction]),
-                    interactions[interaction]
-                );
-                cy.log(interaction, 'RESPONSE IS SET');
-            }
+        it('can add  match correct response processing to item', function () {
+            addResponseProcessing(
+                commonWidgetSelector(interactions.choice),
+                interactions.choice,
+                responseProcessingOptions[0]
+            );
         });
-
+        it('can add map response response processing to item', function () {
+            addResponseProcessing(
+                commonWidgetSelector(interactions.choice),
+                interactions.choice,
+                responseProcessingOptions[1]
+            );
+        }); it('can add none to response processing to item', function () {
+            addResponseProcessing(
+                commonWidgetSelector(interactions.choice),
+                interactions.choice,
+                responseProcessingOptions[2]
+            );
+        });
         it('can save item with responses in interactions', () => {
             cy.intercept('POST', '**/saveItem*').as('saveItem');
             cy.get('[data-testid="save-the-item"]').click();

--- a/views/cypress/tests/item-authoring-response-processing.spec.js
+++ b/views/cypress/tests/item-authoring-response-processing.spec.js
@@ -28,22 +28,8 @@ describe('Item Authoring', () => {
 
     const commonWidgetSelector = (qtiClass) => `.widget-box.widget-blockInteraction[data-qti-class="${qtiClass}"]`;
 
-    const interactions = {
-        choice: 'choiceInteraction',
-        order: 'orderInteraction',
-        asociate: 'associateInteraction',
-        match: 'matchInteraction',
-        hottext: 'hottextInteraction',
-        gapMatch: 'gapMatchInteraction',
-        slider: 'sliderInteraction',
-        extendedText: 'extendedTextInteraction',
-        hotspotInteraction: 'hotspotInteraction',
-        graphicOrderInteraction: 'graphicOrderInteraction',
-        graphicAssociateInteraction: 'graphicAssociateInteraction',
-        graphicGapMatchInteraction: 'graphicGapMatchInteraction',
-        selectPointInteraction: 'selectPointInteraction'
-    };
-    const responseProcessingOptions = ['match correct', 'map response', 'none'];
+    const choice= 'choiceInteraction';
+    const responseProcessingOption = ['match correct', 'map response', 'none'];
     /**
      * Log in
      * Visit the page
@@ -125,22 +111,23 @@ describe('Item Authoring', () => {
         });
         it('can add  match correct response processing to item', function () {
             addResponseProcessing(
-                commonWidgetSelector(interactions.choice),
-                interactions.choice,
-                responseProcessingOptions[0]
+                commonWidgetSelector(choice),
+                choice,
+                responseProcessingOption[0]
             );
         });
         it('can add map response response processing to item', function () {
             addResponseProcessing(
-                commonWidgetSelector(interactions.choice),
-                interactions.choice,
-                responseProcessingOptions[1]
+                commonWidgetSelector(choice),
+                choice,
+                responseProcessingOption[1]
             );
-        }); it('can add none to response processing to item', function () {
+        });
+        it('can add none to response processing to item', function () {
             addResponseProcessing(
-                commonWidgetSelector(interactions.choice),
-                interactions.choice,
-                responseProcessingOptions[2]
+                commonWidgetSelector(choice),
+                choice,
+                responseProcessingOption[2]
             );
         });
         it('can save item with responses in interactions', () => {

--- a/views/cypress/tests/item-authoring-set-response.spec.js
+++ b/views/cypress/tests/item-authoring-set-response.spec.js
@@ -22,9 +22,10 @@ import selectors from '../utils/selectors';
 import {
     addBlockAndInlineInteractions,
     addCommonInteractions,
+    addInteraction,
     addGraphicInteractions
 } from '../utils/authoring-add-interactions';
-import { setResponse } from '../utils/set-response';
+import {addResponseProcessing, setResponse} from '../utils/set-response';
 
 describe('Item Authoring', () => {
     const className = 'Test E2E class';
@@ -52,7 +53,7 @@ describe('Item Authoring', () => {
         graphicGapMatchInteraction: 'graphicGapMatchInteraction',
         selectPointInteraction: 'selectPointInteraction'
     };
-
+    const responseProcessigOptions = ['Match correct', 'map response', 'none'];
     /**
      * Log in
      * Visit the page
@@ -168,6 +169,45 @@ describe('Item Authoring', () => {
             cy.intercept('POST', '**/saveItem*').as('saveItem');
             cy.get('[data-testid="save-the-item"]').click();
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
+        });
+        it('can add single interaction to an item', function () {
+            cy.get('[data-testid="manage-items"]').click();
+            cy.getSettled('[id="item-new"]').click();
+
+            cy.get('[id="item-authoring"]').click();
+            addInteraction("choice");
+        });
+        it('can add  match correct response processing to item', function () {
+            addResponseProcessing(
+                urls.itemPreview,
+                selectors.previewItemButton,
+                selectors.previewSubmitButton,
+                selectors.selectInteractionResponse,
+                commonWidgetSelector(interactions.choice),
+                interactions.choice,
+                responseProcessigOptions[0]
+            );
+        });
+        it('can add map response response processing to item', function () {
+            addResponseProcessing(
+                urls.itemPreview,
+                selectors.previewItemButton,
+                selectors.previewSubmitButton,
+                selectors.selectInteractionResponse,
+                commonWidgetSelector(interactions.choice),
+                interactions.choice,
+                responseProcessigOptions[1]
+            );
+        }); it('can add none to response processing to item', function () {
+            addResponseProcessing(
+                urls.itemPreview,
+                selectors.previewItemButton,
+                selectors.previewSubmitButton,
+                selectors.selectInteractionResponse,
+                commonWidgetSelector(interactions.choice),
+                interactions.choice,
+                responseProcessigOptions[2]
+            );
         });
     });
 });

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -1,5 +1,6 @@
 export default {
     addItem: '[data-context="resource"][data-action="instanciate"]',
+    selectInteractionResponse: '[data-state="answer"]',
     authoring: '[data-context="instance"][data-action="launchEditor"]',
     addSubClassUrl: 'taoItems/Items/addSubClass',
 
@@ -12,6 +13,9 @@ export default {
 
     itemForm: 'form[action="/taoItems/Items/editItem"]',
     itemClassForm: 'form[action="/taoItems/Items/editClassLabel"]',
+
+    previewItemButton: '[data-testid="preview-the-item"]',
+    previewSubmitButton: '[data-control="submit"]',
 
     root: '[data-uri="http://www.tao.lu/Ontologies/TAOItem.rdf#Item"]',
     resourceRelations: 'tao/ResourceRelations',

--- a/views/cypress/utils/set-response.js
+++ b/views/cypress/utils/set-response.js
@@ -148,12 +148,12 @@ function saveItem() {
 export function addResponseProcessing(
     widgetSelector,
     qtiClass,
-    responseProcessingOptions
+    responseProcessingOption
 ) {
     cy.log('ADD RESPONSE PROCESSING', widgetSelector, qtiClass);
     cy.getSettled(widgetSelector).find( selectors.selectInteractionResponse).click({force: true});
 
-    switch (responseProcessingOptions) {
+    switch (responseProcessingOption) {
         case 'match correct':
             cy.get('ol').find('li[data-identifier="choice_3"]').click({force: true});
             cy.get('[id="s2id_responseProcessing"]').click({force: true});
@@ -172,7 +172,7 @@ export function addResponseProcessing(
             break;
 
         case 'map response':
-            cy.log('This is case ', responseProcessingOptions);
+            cy.log('This is case ', responseProcessingOption);
             cy.getSettled(widgetSelector).find(selectors.selectInteractionResponse).click({force: true});
             cy.get('[id="s2id_responseProcessing"]').click();
             cy.get('div[class="select2-drop select2-display-none select2-drop-active"]').last().click();

--- a/views/cypress/utils/set-response.js
+++ b/views/cypress/utils/set-response.js
@@ -119,6 +119,11 @@ export function setResponse(widgetSelector, widgetActiveSelector, qtiClass) {
     cy.get(`${widgetActiveSelector} button.widget-ok`).click({ force: true });
 }
 
+/**
+ * Triggers item preview
+ * verfies that interaction is present in preview
+ */
+
 function previewItem () {
     cy.intercept('GET', urls.itemPreview).as('preview');
     cy.get(selectors.previewItemButton).should('not.have.class', 'disabled');
@@ -126,6 +131,10 @@ function previewItem () {
     cy.wait('@preview');
     cy.get('.qti-choiceInteraction').should('exist');
 }
+/**
+ * Saves Item
+ * verifies its success
+ */
 
 function saveItem() {
     cy.intercept('POST', '**/saveItem*').as('saveItem');
@@ -223,6 +232,4 @@ export function addResponseProcessing(
             cy.getSettled('[class="log-message"]').contains('(identifier) [choice_3]');
             cy.get('[class="rgt navi-box"]').find('[data-control="close"]').click({force: true});
     }
-
-
 }

--- a/views/cypress/utils/urls.js
+++ b/views/cypress/utils/urls.js
@@ -1,4 +1,5 @@
 export default {
     items: '/tao/Main/index?structure=items&ext=taoItems&section=manage_items',
-    itemAuthoring: '/tao/Main/index?structure=items&ext=taoItems&section=authoring'
+    itemAuthoring: '/tao/Main/index?structure=items&ext=taoItems&section=authoring',
+    itemPreview: '**/taoQtiTestPreviewer/Previewer/getItem*'
 };


### PR DESCRIPTION
**End to end testing.**
Related to: https://oat-sa.atlassian.net/browse/AUT-966

Description of changes:
Creation of E2E tests for all response processing options.

How to run locally:
Checkout to feat/AUT-966/e2e-Item-authoring-response-processing

run tests from tao core extn:
npm run cy:open - to run in browser
or npm run cy:run - for headless execution

**All tests should pass:**
![image](https://user-images.githubusercontent.com/60346520/139873484-e3e3f424-0573-4515-8e4c-f74be76152de.png)



