### PR TITLE
fix: check ckeditor in A-Block

### DIFF
--- a/views/cypress/tests/item-authoring-ckeditor.spec.js
+++ b/views/cypress/tests/item-authoring-ckeditor.spec.js
@@ -19,62 +19,54 @@
 import urls from '../utils/urls';
 import selectors from '../utils/selectors';
 
-import {
-    addABlock
-} from '../utils/authoring-add-interactions';
+import { addABlock } from '../utils/authoring-add-interactions';
+import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 
 describe('Item Authoring', () => {
-    const className = 'Test E2E class';
+    const className = `Test E2E class ${getRandomNumber()}`;
     const itemName = 'Test E2E item 1';
     /**
      * Log in
-     * Visit the page
+     * Visit Items page
      */
     before(() => {
-        cy.loginAsAdmin();
+        cy.setup(
+            selectors.treeRenderUrl,
+            selectors.editClassLabelUrl,
+            urls.items,
+            selectors.root
+        );
 
-        cy.intercept('POST', '**/edit*').as('edit');
-        cy.intercept('POST', `**/${selectors.editClassLabelUrl}`).as('editClassLabel');
-        cy.viewport(1000, 660);
-        cy.visit(urls.items);
-        cy.wait('@edit');
-
-        cy.get(selectors.root).then(root => {
-            if (!root.find(`li[title="${className}"] a`).length) {
-                cy.addClassToRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    className,
-                    selectors.editClassLabelUrl,
-                    selectors.treeRenderUrl,
-                    selectors.addSubClassUrl
-                );
-            }
-            cy.addNode(selectors.itemForm, selectors.addItem);
-            cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
-        });
+        cy.addClassToRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            className,
+            selectors.editClassLabelUrl,
+            selectors.treeRenderUrl,
+            selectors.addSubClassUrl
+        );
+        cy.addNode(selectors.itemForm, selectors.addItem);
+        cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
     });
-
+    /**
+     * Visit Items page
+     * Delete e2e class
+     */
     after(() => {
         cy.intercept('POST', '**/edit*').as('edit');
         cy.visit(urls.items);
         cy.wait('@edit');
 
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
+        cy.deleteClassFromRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            selectors.deleteClass,
+            selectors.deleteConfirm,
+            className,
+            selectors.deleteClassUrl,
+            selectors.resourceRelationsUrl,
+            true
+        );
     });
 
     /**
@@ -88,7 +80,7 @@ describe('Item Authoring', () => {
             });
         });
 
-        it('can add inline interactions to Block', () => {
+        it('can add A-Block', () => {
             cy.getSettled('.qti-item.item-editor-item.edit-active').should('exist');
             // open inline interactions panel
             cy.get('#sidebar-left-section-inline-interactions').click();

--- a/views/cypress/tests/item-authoring-ckeditor.spec.js
+++ b/views/cypress/tests/item-authoring-ckeditor.spec.js
@@ -1,0 +1,106 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+import urls from '../utils/urls';
+import selectors from '../utils/selectors';
+
+import {
+    addABlock
+} from '../utils/authoring-add-interactions';
+
+describe('Item Authoring', () => {
+    const className = 'Test E2E class';
+    const itemName = 'Test E2E item 1';
+    /**
+     * Log in
+     * Visit the page
+     */
+    before(() => {
+        cy.loginAsAdmin();
+
+        cy.intercept('POST', '**/edit*').as('edit');
+        cy.intercept('POST', `**/${selectors.editClassLabelUrl}`).as('editClassLabel');
+        cy.viewport(1000, 660);
+        cy.visit(urls.items);
+        cy.wait('@edit');
+
+        cy.get(selectors.root).then(root => {
+            if (!root.find(`li[title="${className}"] a`).length) {
+                cy.addClassToRoot(
+                    selectors.root,
+                    selectors.itemClassForm,
+                    className,
+                    selectors.editClassLabelUrl,
+                    selectors.treeRenderUrl,
+                    selectors.addSubClassUrl
+                );
+            }
+            cy.addNode(selectors.itemForm, selectors.addItem);
+            cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
+        });
+    });
+
+    after(() => {
+        cy.intercept('POST', '**/edit*').as('edit');
+        cy.visit(urls.items);
+        cy.wait('@edit');
+
+        cy.get(selectors.root).then(root => {
+            if (root.find(`li[title="${className}"] a`).length) {
+                cy.deleteClassFromRoot(
+                    selectors.root,
+                    selectors.itemClassForm,
+                    selectors.deleteClass,
+                    selectors.deleteConfirm,
+                    className,
+                    selectors.deleteClassUrl,
+                    selectors.resourceRelations,
+                    false,
+                    true
+                );
+            }
+        });
+    });
+
+    /**
+     * Tests
+     */
+    describe('Item authoring', () => {
+        it('can open item authoring', function () {
+            cy.get(selectors.authoring).click();
+            cy.location().should(loc => {
+                expect(`${loc.pathname}${loc.search}`).to.eq(urls.itemAuthoring);
+            });
+        });
+
+        it('can add inline interactions to Block', () => {
+            cy.getSettled('.qti-item.item-editor-item.edit-active').should('exist');
+            // open inline interactions panel
+            cy.get('#sidebar-left-section-inline-interactions').click();
+            addABlock();
+            // close inline interactions panel
+            cy.get('#sidebar-left-section-inline-interactions ._accordion').click();
+        });
+
+        it('CK Editor is present when added A-block is highlighted', () => {
+            cy.get('.widget-box.widget-block.widget-textBlock').click();
+            cy.getSettled('#toolbar-top .cke').should('be.visible');
+            cy.getSettled('#toolbar-top .cke .cke_toolbar').should('have.length', 5);
+        });
+    });
+});

--- a/views/cypress/tests/item-authoring-ckeditor.spec.js
+++ b/views/cypress/tests/item-authoring-ckeditor.spec.js
@@ -64,7 +64,6 @@ describe('Item Authoring', () => {
             selectors.deleteConfirm,
             className,
             selectors.deleteClassUrl,
-            selectors.resourceRelationsUrl,
             true
         );
     });

--- a/views/cypress/tests/item-authoring-response-processing.spec.js
+++ b/views/cypress/tests/item-authoring-response-processing.spec.js
@@ -21,9 +21,10 @@ import selectors from '../utils/selectors';
 
 import { addInteraction } from '../utils/authoring-add-interactions';
 import { addResponseProcessing } from '../utils/set-response';
+import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 
 describe('Item Authoring', () => {
-    const className = 'Test E2E class';
+    const className = `Test E2E class ${getRandomNumber()}`;
     const itemName = 'Test E2E item 1';
 
     const commonWidgetSelector = (qtiClass) => `.widget-box.widget-blockInteraction[data-qti-class="${qtiClass}"]`;
@@ -32,74 +33,52 @@ describe('Item Authoring', () => {
     const responseProcessingOption = ['match correct', 'map response', 'none'];
     /**
      * Log in
-     * Visit the page
+     * Visit Items page
      */
-    before(() => {
-        cy.loginAsAdmin();
+     before(() => {
+        cy.setup(
+            selectors.treeRenderUrl,
+            selectors.editClassLabelUrl,
+            urls.items,
+            selectors.root
+        );
 
-        cy.intercept('POST', '**/edit*').as('edit');
-        cy.intercept('POST', `**/${selectors.editClassLabelUrl}`).as('editClassLabel');
-        cy.viewport(1000, 660);
-        cy.visit(urls.items);
-        cy.wait('@edit');
-
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
+        cy.addClassToRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            className,
+            selectors.editClassLabelUrl,
+            selectors.treeRenderUrl,
+            selectors.addSubClassUrl
+        );
+        cy.addNode(selectors.itemForm, selectors.addItem);
+        cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
     });
     /**
-     * Go to Items page
-     * Delete 'Test E2E class' class/folder
+     * Visit Items page
+     * Delete e2e class
      */
-    after(() => {
+     after(() => {
         cy.intercept('POST', '**/edit*').as('edit');
         cy.visit(urls.items);
         cy.wait('@edit');
 
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
+        cy.deleteClassFromRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            selectors.deleteClass,
+            selectors.deleteConfirm,
+            className,
+            selectors.deleteClassUrl,
+            selectors.resourceRelationsUrl,
+            true
+        );
     });
     /**
      * Tests
      */
     describe('Item authoring', () => {
         it('can open item authoring', function () {
-            cy.addClassToRoot(
-                selectors.root,
-                selectors.itemClassForm,
-                className,
-                selectors.editClassLabelUrl,
-                selectors.treeRenderUrl,
-                selectors.addSubClassUrl
-            );
-            cy.addNode(selectors.itemForm, selectors.addItem);
-            cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
-
             cy.get(selectors.authoring).click();
             cy.location().should(loc => {
                 expect(`${loc.pathname}${loc.search}`).to.eq(urls.itemAuthoring);

--- a/views/cypress/tests/item-authoring-response-processing.spec.js
+++ b/views/cypress/tests/item-authoring-response-processing.spec.js
@@ -70,7 +70,6 @@ describe('Item Authoring', () => {
             selectors.deleteConfirm,
             className,
             selectors.deleteClassUrl,
-            selectors.resourceRelationsUrl,
             true
         );
     });

--- a/views/cypress/tests/item-authoring-set-response.spec.js
+++ b/views/cypress/tests/item-authoring-set-response.spec.js
@@ -25,9 +25,10 @@ import {
     addGraphicInteractions
 } from '../utils/authoring-add-interactions';
 import { setResponse } from '../utils/set-response';
+import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 
 describe('Item Authoring', () => {
-    const className = 'Test E2E class';
+    const className = `Test E2E class ${getRandomNumber()}`;
     const itemName = 'Test E2E item 1';
 
     const commonWidgetSelector = (qtiClass) => `.widget-box.widget-blockInteraction[data-qti-class="${qtiClass}"]`;
@@ -52,59 +53,48 @@ describe('Item Authoring', () => {
         graphicGapMatchInteraction: 'graphicGapMatchInteraction',
         selectPointInteraction: 'selectPointInteraction'
     };
-    /**
+       /**
      * Log in
-     * Visit the page
+     * Visit Items page
      */
     before(() => {
-        cy.loginAsAdmin();
+        cy.setup(
+            selectors.treeRenderUrl,
+            selectors.editClassLabelUrl,
+            urls.items,
+            selectors.root
+        );
 
-        cy.intercept('POST', '**/edit*').as('edit');
-        cy.intercept('POST', `**/${selectors.editClassLabelUrl}`).as('editClassLabel');
-        cy.viewport(1000, 660);
-        cy.visit(urls.items);
-        cy.wait('@edit');
-
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
+        cy.addClassToRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            className,
+            selectors.editClassLabelUrl,
+            selectors.treeRenderUrl,
+            selectors.addSubClassUrl
+        );
+        cy.addNode(selectors.itemForm, selectors.addItem);
+        cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
     });
     /**
-     * Go to Items page
-     * Delete 'Test E2E class' class/folder
+     * Visit Items page
+     * Delete e2e class
      */
     after(() => {
         cy.intercept('POST', '**/edit*').as('edit');
         cy.visit(urls.items);
         cy.wait('@edit');
 
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
+        cy.deleteClassFromRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            selectors.deleteClass,
+            selectors.deleteConfirm,
+            className,
+            selectors.deleteClassUrl,
+            selectors.resourceRelationsUrl,
+            true
+        );
     });
     /**
      * Tests

--- a/views/cypress/tests/item-authoring-set-response.spec.js
+++ b/views/cypress/tests/item-authoring-set-response.spec.js
@@ -92,7 +92,6 @@ describe('Item Authoring', () => {
             selectors.deleteConfirm,
             className,
             selectors.deleteClassUrl,
-            selectors.resourceRelationsUrl,
             true
         );
     });

--- a/views/cypress/tests/item-authoring.spec.js
+++ b/views/cypress/tests/item-authoring.spec.js
@@ -73,7 +73,6 @@ describe('Item Authoring', () => {
             selectors.deleteConfirm,
             className,
             selectors.deleteClassUrl,
-            selectors.resourceRelationsUrl,
             true
         );
     });

--- a/views/cypress/tests/item-authoring.spec.js
+++ b/views/cypress/tests/item-authoring.spec.js
@@ -29,60 +29,53 @@ import {
     addGraphicInteractions,
     removeGraphicInteractions
 } from '../utils/authoring-add-interactions';
+import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 
 describe('Item Authoring', () => {
-    const className = 'Test E2E class';
+    const className = `Test E2E class ${getRandomNumber()}`;
     const itemName = 'Test E2E item 1';
     /**
      * Log in
-     * Visit the page
+     * Visit Items page
      */
     before(() => {
-        cy.loginAsAdmin();
+        cy.setup(
+            selectors.treeRenderUrl,
+            selectors.editClassLabelUrl,
+            urls.items,
+            selectors.root
+        );
 
-        cy.intercept('POST', '**/edit*').as('edit');
-        cy.intercept('POST', `**/${selectors.editClassLabelUrl}`).as('editClassLabel');
-        cy.viewport(1000, 660);
-        cy.visit(urls.items);
-        cy.wait('@edit');
-
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
+        cy.addClassToRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            className,
+            selectors.editClassLabelUrl,
+            selectors.treeRenderUrl,
+            selectors.addSubClassUrl
+        );
+        cy.addNode(selectors.itemForm, selectors.addItem);
+        cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
     });
-
+    /**
+     * Visit Items page
+     * Delete e2e class
+     */
     after(() => {
         cy.intercept('POST', '**/edit*').as('edit');
         cy.visit(urls.items);
         cy.wait('@edit');
 
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
+        cy.deleteClassFromRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            selectors.deleteClass,
+            selectors.deleteConfirm,
+            className,
+            selectors.deleteClassUrl,
+            selectors.resourceRelationsUrl,
+            true
+        );
     });
 
     /**

--- a/views/cypress/tests/item-preview.spec.js
+++ b/views/cypress/tests/item-preview.spec.js
@@ -20,41 +20,22 @@ import urls from '../utils/urls';
 import selectors from '../utils/selectors';
 
 import { addInteraction } from '../utils/authoring-add-interactions';
+import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 
 describe('Item preview', () => {
-    const className = 'Test E2E class';
+    const className = `Test E2E class ${getRandomNumber()}`;
     const itemName = 'Test E2E item 1';
     /**
      * Log in
      * Visit the page
      */
     before(() => {
-        cy.loginAsAdmin();
-
-        cy.intercept('POST', '**/edit*').as('edit');
-        cy.intercept('POST', `**/${selectors.editClassLabelUrl}`).as('editClassLabel');
-        cy.viewport(1000, 660);
-        cy.visit(urls.items);
-        cy.wait('@edit');
-
-        cy.get(selectors.root).then(root => {
-            if (root.find(`li[title="${className}"] a`).length) {
-                cy.deleteClassFromRoot(
-                    selectors.root,
-                    selectors.itemClassForm,
-                    selectors.deleteClass,
-                    selectors.deleteConfirm,
-                    className,
-                    selectors.deleteClassUrl,
-                    selectors.resourceRelations,
-                    false,
-                    true
-                );
-            }
-        });
-    });
-
-    it('creates item', () => {
+        cy.setup(
+            selectors.treeRenderUrl,
+            selectors.editClassLabelUrl,
+            urls.items,
+            selectors.root
+        );
         cy.addClassToRoot(
             selectors.root,
             selectors.itemClassForm,
@@ -66,7 +47,27 @@ describe('Item preview', () => {
         cy.addNode(selectors.itemForm, selectors.addItem);
         cy.renameSelectedNode(selectors.itemForm, selectors.editItemUrl, itemName);
     });
+    /**
+     * Visit Items page
+     * Delete e2e class
+     */
+    after(() => {
+        cy.intercept('POST', '**/edit*').as('edit');
+        cy.visit(urls.items);
+        cy.wait('@edit');
 
+        cy.deleteClassFromRoot(
+            selectors.root,
+            selectors.itemClassForm,
+            selectors.deleteClass,
+            selectors.deleteConfirm,
+            className,
+            selectors.deleteClassUrl,
+            selectors.resourceRelationsUrl,
+            false,
+            true
+        );
+    });
     it('Authors item', () => {
         cy.get(selectors.authoring).click();
         cy.location().should(loc => {
@@ -103,19 +104,5 @@ describe('Item preview', () => {
         cy.get('.qti-choiceInteraction').should('exist');
         cy.get('[data-control="close"] .icon-close').should('exist');
         cy.get('[data-control="close"] .icon-close').click();
-    });
-
-    it('Deletes class', () => {
-        cy.deleteClassFromRoot(
-            selectors.root,
-            selectors.itemClassForm,
-            selectors.deleteClass,
-            selectors.deleteConfirm,
-            className,
-            selectors.deleteClassUrl,
-            selectors.resourceRelations,
-            false,
-            true
-        );
     });
 });

--- a/views/cypress/tests/item-preview.spec.js
+++ b/views/cypress/tests/item-preview.spec.js
@@ -63,8 +63,6 @@ describe('Item preview', () => {
             selectors.deleteConfirm,
             className,
             selectors.deleteClassUrl,
-            selectors.resourceRelationsUrl,
-            false,
             true
         );
     });

--- a/views/cypress/utils/authoring-add-interactions.js
+++ b/views/cypress/utils/authoring-add-interactions.js
@@ -50,16 +50,22 @@ const undoSelector = '.feedback-info.popup a.undo';
 const closeUndoSelector = '.feedback-info.popup .icon-close';
 
 /**
- * Add A-Block and then all inline interactions on it
+ * Add A-Block
  */
-export function addBlockAndInlineInteractions() {
+ export function addABlock() {
     cy.log('ADDING A-BLOCK INTERACTION');
     const blockSelector = `[data-qti-class="${blockContainer}"]`;
     cy.dragAndDrop(blockSelector, dropSelector);
     // check that widget is initialized
     cy.getSettled(`${dropSelector} .widget-box.edit-active${blockSelector}`).should('exist');
     cy.log('A-BLOCK IS ADDED');
+}
 
+/**
+ * Add A-Block and then all inline interactions on it
+ */
+export function addBlockAndInlineInteractions() {
+    addABlock();
     for (const interaction in inlineInteractions) {
         cy.log('ADDING INTERACTION', interaction);
         const interactionSelector = `[data-qti-class="${inlineInteractions[interaction]}"]`;

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -18,7 +18,9 @@ export default {
     previewSubmitButton: '[data-control="submit"]',
 
     root: '[data-uri="http://www.tao.lu/Ontologies/TAOItem.rdf#Item"]',
-    resourceRelations: 'tao/ResourceRelations',
+    resourceRelationsUrl: 'tao/ResourceRelations',
 
     treeRenderUrl: 'taoItems/Items',
+    itemPreviewUrl: '**/taoQtiTestPreviewer/Previewer/getItem*',
+    itemSubmitUrl: '**/taoQtiTestPreviewer/Previewer/submitItem*'
 };

--- a/views/cypress/utils/set-response.js
+++ b/views/cypress/utils/set-response.js
@@ -125,7 +125,7 @@ export function setResponse(widgetSelector, widgetActiveSelector, qtiClass) {
  */
 
 function previewItem () {
-    cy.intercept('GET', urls.itemPreview).as('preview');
+    cy.intercept('GET', selectors.itemPreviewUrl).as('preview');
     cy.get(selectors.previewItemButton).should('not.have.class', 'disabled');
     cy.get(selectors.previewItemButton).click({force :true});
     cy.wait('@preview');
@@ -152,6 +152,7 @@ export function addResponseProcessing(
 ) {
     cy.log('ADD RESPONSE PROCESSING', widgetSelector, qtiClass);
     cy.getSettled(widgetSelector).find( selectors.selectInteractionResponse).click({force: true});
+    cy.intercept('POST', selectors.itemSubmitUrl).as('submitItem');
 
     switch (responseProcessingOption) {
         case 'match correct':
@@ -162,6 +163,7 @@ export function addResponseProcessing(
             //chose correct response
             cy.getSettled('ol').find('li[data-identifier="choice_3"]').last().click({force:true});
             cy.get(selectors.previewSubmitButton).click({force: true});
+            cy.wait('@submitItem').its('response.body').its('success').should('eq', true);
             cy.getSettled('[class="log-message"]').contains('SCORE: (float) 1');
             //chose wrong response
             cy.getSettled('ol').find('li[data-identifier="choice_3"]').last().click({force:true});
@@ -203,6 +205,7 @@ export function addResponseProcessing(
             //check correct response
             cy.getSettled('ol').find('li[data-identifier="choice_3"]').last().click({force:true});
             cy.get(selectors.previewSubmitButton).click({force: true});
+            cy.wait('@submitItem').its('response.body').its('success').should('eq', true);
             cy.getSettled('[class="log-message"]').contains('SCORE: (float) 2');
             //check wrong response
             cy.getSettled('ol').find('li[data-identifier="choice_3"]').last().click({force:true});
@@ -228,6 +231,7 @@ export function addResponseProcessing(
             previewItem();
             cy.getSettled('ol').find('li[data-identifier="choice_3"]').last().click({force:true});
             cy.get(selectors.previewSubmitButton).click({force: true});
+            cy.wait('@submitItem').its('response.body').its('success').should('eq', true);
             cy.getSettled('[class="log-message"]').should('not.contain','SCORE:');
             cy.getSettled('[class="log-message"]').contains('(identifier) [choice_3]');
             cy.get('[class="rgt navi-box"]').find('[data-control="close"]').click({force: true});

--- a/views/cypress/utils/urls.js
+++ b/views/cypress/utils/urls.js
@@ -1,5 +1,4 @@
 export default {
     items: '/tao/Main/index?structure=items&ext=taoItems&section=manage_items',
-    itemAuthoring: '/tao/Main/index?structure=items&ext=taoItems&section=authoring',
-    itemPreview: '**/taoQtiTestPreviewer/Previewer/getItem*'
+    itemAuthoring: '/tao/Main/index?structure=items&ext=taoItems&section=authoring'
 };


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1169
Depends https://github.com/oat-sa/tao-core/pull/3230

1. Added new test for CKeditor `views/cypress/tests/item-authoring-ckeditor.spec.js`
2. Stabilised old tests

How to test:
1. remove temporary delivery tests `ltiDeliveryProvider/views/cypress` `taoQtiTest/views/cypress/test/delivery` or exclude them
2. `cd tao/views`
3. `npm run cy:run`