### PR TITLE
feat/TR-2853/facilitate-inline-asset-replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",
-        "oat-sa/tao-core" : ">=48.29.0",
+        "oat-sa/tao-core" : ">=48.64.0",
         "oat-sa/extension-tao-item" : ">=11.11.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",
         "oat-sa/tao-core" : ">=48.64.0",
-        "oat-sa/extension-tao-item" : ">=11.11.2"
+        "oat-sa/extension-tao-item" : ">=11.20.1"
     },
     "autoload": {
         "psr-4": {

--- a/migrations/Version202111261148531101_taoQtiItem.php
+++ b/migrations/Version202111261148531101_taoQtiItem.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiItem\model\compile\QtiItemCompilerAssetBlacklist;
+
+final class Version202111261148531101_taoQtiItem extends AbstractMigration
+{
+    private const BASE64_DATA_PATTERN = '/^data:[^\/]+\/[^;]+(;charset=[\w]+)?;base64,/';
+
+    public function getDescription(): string
+    {
+        return 'Removes base64 data pattern from item compilation asset blacklist.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($this->getServiceManager()->has(QtiItemCompilerAssetBlacklist::SERVICE_ID)) {
+            $service = $this->getServiceManager()->get(QtiItemCompilerAssetBlacklist::SERVICE_ID);
+            $currentBlacklist = $service->getOption(QtiItemCompilerAssetBlacklist::BLACKLIST);
+            $updatedBlacklist = [];
+            foreach ($currentBlacklist as $item) {
+                if ($item !== self::BASE64_DATA_PATTERN) {
+                    $updatedBlacklist[] = $item;
+                }
+            }
+            $service->setOption(QtiItemCompilerAssetBlacklist::BLACKLIST, $updatedBlacklist);
+            $this->getServiceManager()->register(QtiItemCompilerAssetBlacklist::SERVICE_ID, $service);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($this->getServiceManager()->has(QtiItemCompilerAssetBlacklist::SERVICE_ID)) {
+            $service = $this->getServiceManager()->get(QtiItemCompilerAssetBlacklist::SERVICE_ID);
+            $blacklist = $service->getOption(QtiItemCompilerAssetBlacklist::BLACKLIST);
+
+            if (!in_array(self::BASE64_DATA_PATTERN, $blacklist, true)) {
+                $blacklist[] = self::BASE64_DATA_PATTERN;
+            }
+            $service->setOption(QtiItemCompilerAssetBlacklist::BLACKLIST, $blacklist);
+            $this->getServiceManager()->register(QtiItemCompilerAssetBlacklist::SERVICE_ID, $service);
+        }
+    }
+}

--- a/scripts/install/RegisterItemCompilerBlacklist.php
+++ b/scripts/install/RegisterItemCompilerBlacklist.php
@@ -44,7 +44,6 @@ class RegisterItemCompilerBlacklist extends InstallAction
         $assetBlacklistService = new QtiItemCompilerAssetBlacklist([
             QtiItemCompilerAssetBlacklist::BLACKLIST => [
                 '/^https?:\/\/(www\.youtube\.[a-zA-Z]*|youtu\.be)\//',
-                '/^data:[^\/]+\/[^;]+(;charset=[\w]+)?;base64,/'
             ]
         ]);
 


### PR DESCRIPTION
Allow inline base64 encoded assets to be replaced.
 
Related to : https://oat-sa.atlassian.net/browse/TR-2853
 
Removed base64 asset pattern from replacement blacklist and updated item asset compiler to allow inline asset replacement if configured.
 

  
#### How to test

Preconfigurd environment should be mentioned in the related ticket, otherwise to test locally:

- Create a shared stimulus with and embedded picture, video or audio.
- Create and item with previously created shared stimulus
- Create a test with previously created item
- Configure `config/taoQtiItem/ItemAssetReplacer.conf.php` with an implemention that would replace base64 assets. Example implementation is `NullQtiItemAssetReplacer`, make sure that `shouldBeReplace` would return `true` for base64 assets, and that `replace(...)` would `return $packetAsset->setReplacedBy(SOMETHING_EASY_TO_IDENTIFY);`
- Publish a delivery from the previously created test, the inline assets should be replaced successfuly.
- Launch the delivery and inspect the asset, check that it matches `SOMETHING_EASY_TO_IDENTIFY`

  
#### Dependencies
 
Requires :
 - [x] https://github.com/oat-sa/tao-core/pull/3252
 - [x] https://github.com/oat-sa/extension-tao-item/pull/550
 