### PR TITLE
[AUT-1538] Fixed failed to export passage with no stylesheet

### DIFF
--- a/model/Export/Stylesheet/AssetStylesheetLoader.php
+++ b/model/Export/Stylesheet/AssetStylesheetLoader.php
@@ -58,7 +58,7 @@ class AssetStylesheetLoader extends ConfigurableService
                         $stylesheetPath,
                         $property
                     ),
-                    ["exception" => $exception, 'stylesheet' => $stylesheetPath, 'property' => $property]
+                    ['exception' => $exception, 'stylesheet' => $stylesheetPath, 'property' => $property]
                 );
             }
         }

--- a/test/integration/update/ItemUpdateInlineFeedbackTest.php
+++ b/test/integration/update/ItemUpdateInlineFeedbackTest.php
@@ -106,6 +106,7 @@ class ItemUpdateInlineFeedbackTest extends TaoPhpUnitTestRunner
     private function normalizeXmlStrings($s)
     {
         $s = preg_replace('/\stoolVersion="[0-9\.]*-sprint[0-9]*"/', '', $s);
+        $s = preg_replace('/\stoolVersion="[0-9\.]+"/', '', $s);
         // Normalize line endings
         // Convert all line-endings to UNIX format
         $s = str_replace("\r\n", "\n", $s);


### PR DESCRIPTION
This ticket is intended to fix the issue: https://oat-sa.atlassian.net/browse/AUT-1538

The issue happens when an item is exported with a passage which has not stylesheet. The solution proposed is to do not return an exception for this expected case.