### PR TITLE
fix: require oat-sa/lib-tao-qti 7.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "oat-sa/lib-tao-qti": "7.3.0",
+        "oat-sa/lib-tao-qti": "7.3.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",


### PR DESCRIPTION
## [TR-2459](https://oat-sa.atlassian.net/browse/TR-2459)

- fix: unify acceptable latency influence on `mmove` and `jump` behavior