### PR TITLE
fix: failing to save A block with table when adding scroll

### DIFF
--- a/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
+++ b/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
@@ -74,7 +74,7 @@ define(['jquery', 'util/typeCaster'], function ($, typeCaster) {
             const $form = widget.$form;
             let $wrapper =
                 wrapType === 'inner'
-                    ? widget.$container.children('[data-html-editable]').children(`.${wrapperTextCls}`)
+                    ? widget.$container.children('[data-html-editable]').first(`.${wrapperTextCls}`)
                     : widget.$container.parent(`.${wrapperIncludeCls}`);
 
             if (!$wrapper.length) {

--- a/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
+++ b/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
@@ -74,7 +74,7 @@ define(['jquery', 'util/typeCaster'], function ($, typeCaster) {
             const $form = widget.$form;
             let $wrapper =
                 wrapType === 'inner'
-                    ? widget.$container.find('[data-html-editable]').children(`.${wrapperTextCls}`)
+                    ? widget.$container.find('[data-html-editable]=true:not(.html-editable-shield)').children(`.${wrapperTextCls}`)
                     : widget.$container.parent(`.${wrapperIncludeCls}`);
 
             if (!$wrapper.length) {

--- a/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
+++ b/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
@@ -74,7 +74,7 @@ define(['jquery', 'util/typeCaster'], function ($, typeCaster) {
             const $form = widget.$form;
             let $wrapper =
                 wrapType === 'inner'
-                    ? widget.$container.find('[data-html-editable]=true:not(.html-editable-shield)').children(`.${wrapperTextCls}`)
+                    ? widget.$container.find('[data-html-editable]').first(`.${wrapperTextCls}`)
                     : widget.$container.parent(`.${wrapperIncludeCls}`);
 
             if (!$wrapper.length) {

--- a/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
+++ b/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
@@ -74,14 +74,14 @@ define(['jquery', 'util/typeCaster'], function ($, typeCaster) {
             const $form = widget.$form;
             let $wrapper =
                 wrapType === 'inner'
-                    ? widget.$container.find('[data-html-editable]').first(`.${wrapperTextCls}`)
+                    ? widget.$container.children('[data-html-editable]').children(`.${wrapperTextCls}`)
                     : widget.$container.parent(`.${wrapperIncludeCls}`);
 
             if (!$wrapper.length) {
                 $wrapper =
                     wrapType === 'inner'
                         ? widget.$container
-                              .find('[data-html-editable]')
+                              .children('[data-html-editable]')
                               .wrapInner(`<div class="${wrapperTextCls}" />`)
                               .children()
                         : widget.$container.wrap(`<div class="${wrapperIncludeCls}" />`).parent();


### PR DESCRIPTION
Related to Issue: https://oat-sa.atlassian.net/browse/AUT-726

**A-block with table inside no saving when enabling scrolling.**
pre-requisites: create an item with and A block inside 

**SETPS to test:**
• Checkout to branch: fix/AUT-726/A-block-with-table-fail-when-adding-scroll
• Go into the authoring of the Item created
•add a table inside and save

**ACTUAL RESULT:**
Unable to save. error on the level of Qti model

**EXPECTED RESULT:**
A block with table and scroll enabled saves correctly.

![image](https://user-images.githubusercontent.com/60346520/148208212-fd3ebbba-e37f-466e-ac0a-a62a0b7ad44d.png)

ENV to test: http://test-silvia.playground.kitchen.it.taocloud.org:41441