### PR TITLE
fix: prevent default on click

### DIFF
--- a/views/js/qtiCreator/plugins/panel/outcomeEditor.js
+++ b/views/js/qtiCreator/plugins/panel/outcomeEditor.js
@@ -327,7 +327,8 @@ define([
                         $outcomeContainer.remove();
                         item.remove('outcomes', $outcomeContainer.data('serial'));
                     })
-                    .on(`click${_ns}`, '.adder', function () {
+                    .on(`click${_ns}`, '.adder', function (e) {
+                        e.preventDefault();
                         //add new outcome
                         const newOutcome = new OutcomeDeclaration({
                             cardinality: 'single',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1852

**Steps to reproduce:**

- Go to 'Items' tab.
- Click 'New item' and go to Authoring mode.
- Drag'n'drop any interaction on the canvas and go to Response.
- In Response Properties click 'Add an outcome'.
- Click 'Save' and then 'Manage items' to leave Authoring.

**Actual result:** The Authoring page is not closed, the canvas collapses into thin white line and the interaction disappears. To leave user must click 'Manage users' second time.
**Expected result:** User leaves Authoring page freely.