### PR TITLE
fix: remove 32 chars limit for identifiers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ extension to create QTI items for TAO
 ### QTI Identifier Validator Pattern - `ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN`
 
 QTI Item identifiers by default are normalized strings that accepts everything in the pattern
-`/^[a-zA-Z_]{1}[a-zA-Z0-9_\\.-]{0,31}$/u`. If for some reason you want to change this behavior, it's 
+`/^[a-zA-Z_]{1}[a-zA-Z0-9_\\.-]*$/u`. If for some reason you want to change this behavior, it's 
 possible by using the environment variable `ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN`
 with a different pattern. Example:
 
 ```shell script
 # Do not accept dots on the QTI Item identifier
-ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN='/^[a-zA-Z_]{1}[a-zA-Z0-9_-]{0,31}$/u'
+ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN='/^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$/u'
 ```
 This would mean that case the user tries to save or import an item with an identifier with dots, this would return an 
 error:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ extension to create QTI items for TAO
 ### QTI Identifier Validator Pattern - `ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN`
 
 QTI Item identifiers by default are normalized strings that accepts everything in the pattern
-`/^[a-zA-Z_]{1}[a-zA-Z0-9_\\.-]*$/u`. If for some reason you want to change this behavior, it's 
+`/^[a-zA-Z_]{1}[a-zA-Z0-9_\.-]*$/u`. If for some reason you want to change this behavior, it's 
 possible by using the environment variable `ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN`
 with a different pattern. Example:
 

--- a/model/qti/ServiceProvider/ItemIdentifierValidatorServiceProvider.php
+++ b/model/qti/ServiceProvider/ItemIdentifierValidatorServiceProvider.php
@@ -38,7 +38,7 @@ class ItemIdentifierValidatorServiceProvider implements ContainerServiceProvider
         /**
          * Please specify the QTI Identifier Validator Pattern that will be used to validate the item identifier
          * Ex: /^[a-zA-Z_]{1}[a-zA-Z0-9_-]{0,31}$/u
-         * The Default is /^[a-zA-Z_]{1}[a-zA-Z0-9_\\.-]{0,31}$/u
+         * The Default is /^[a-zA-Z_]{1}[a-zA-Z0-9_\\.-]*$/u
          */
         $parameters->set(
             ItemIdentifierValidator::DEFAULT_PATTERN_PARAMETER_NAME,

--- a/model/qti/ServiceProvider/ItemIdentifierValidatorServiceProvider.php
+++ b/model/qti/ServiceProvider/ItemIdentifierValidatorServiceProvider.php
@@ -38,7 +38,7 @@ class ItemIdentifierValidatorServiceProvider implements ContainerServiceProvider
         /**
          * Please specify the QTI Identifier Validator Pattern that will be used to validate the item identifier
          * Ex: /^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$/u
-         * The Default is /^[a-zA-Z_]{1}[a-zA-Z0-9_\\.-]*$/u
+         * The Default is /^[a-zA-Z_]{1}[a-zA-Z0-9_\.-]*$/u
          */
         $parameters->set(
             ItemIdentifierValidator::DEFAULT_PATTERN_PARAMETER_NAME,

--- a/model/qti/ServiceProvider/ItemIdentifierValidatorServiceProvider.php
+++ b/model/qti/ServiceProvider/ItemIdentifierValidatorServiceProvider.php
@@ -37,7 +37,7 @@ class ItemIdentifierValidatorServiceProvider implements ContainerServiceProvider
 
         /**
          * Please specify the QTI Identifier Validator Pattern that will be used to validate the item identifier
-         * Ex: /^[a-zA-Z_]{1}[a-zA-Z0-9_-]{0,31}$/u
+         * Ex: /^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$/u
          * The Default is /^[a-zA-Z_]{1}[a-zA-Z0-9_\\.-]*$/u
          */
         $parameters->set(

--- a/model/qti/validator/ItemIdentifierValidator.php
+++ b/model/qti/validator/ItemIdentifierValidator.php
@@ -32,7 +32,7 @@ class ItemIdentifierValidator
     public const ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN = 'ENV_QTI_IDENTIFIER_VALIDATOR_PATTERN';
 
     public const DEFAULT_PATTERN_PARAMETER_NAME = 'ItemIdentifierValidatorParameterName';
-    public const DEFAULT_PATTERN = '/^[a-zA-Z_]{1}[a-zA-Z0-9_\.-]{0,31}$/u';
+    public const DEFAULT_PATTERN = '/^[a-zA-Z_]{1}[a-zA-Z0-9_\.-]*$/u';
 
     /** @var string */
     private $pattern;

--- a/test/unit/model/qti/ItemTest.php
+++ b/test/unit/model/qti/ItemTest.php
@@ -51,7 +51,7 @@ class ItemTest extends TestCase
         $expectedItemQti = <<<ITEM_QTI
 <?xml version="1.0" encoding="UTF-8"?><assessmentItem
         xsi:schemaLocation=""
-     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2022.01">
+     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="">
 
     
     
@@ -67,7 +67,7 @@ ITEM_QTI;
 
 
         $item = new Item();
-        $itemQti = $item->toQTI();
+        $itemQti = $this->removeToolVersionAttribute($item->toQTI());
 
         self::assertEquals($expectedItemQti, $itemQti);
     }
@@ -77,7 +77,7 @@ ITEM_QTI;
         $expectedItemQti = <<<ITEM_QTI
 <?xml version="1.0" encoding="UTF-8"?><assessmentItem
         xsi:schemaLocation=""
-     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2022.01">
+     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="">
 
     
     
@@ -94,9 +94,19 @@ ITEM_QTI;
 
         $item = new Item();
         $item->getBody()->setAttribute('dir', 'rtl');
-        $itemQti = $item->toQTI();
+        $itemQti = $this->removeToolVersionAttribute($item->toQTI());
 
 
         self::assertEquals($expectedItemQti, $itemQti);
+    }
+
+    /**
+     * remove tool version because every release this value changes
+     * @param string $itemQti
+     * @return string
+     */
+    private function removeToolVersionAttribute(string $itemQti): string
+    {
+       return preg_replace('/toolVersion="[0-9]{4}\.[0-9]{2}"/u', 'toolVersion=""', $itemQti);
     }
 }

--- a/test/unit/model/qti/validator/ItemIdentifierValidatorTest.php
+++ b/test/unit/model/qti/validator/ItemIdentifierValidatorTest.php
@@ -50,7 +50,7 @@ class ItemIdentifierValidatorTest extends TestCase
 
     public function testValidationSuccessWithDifferentPattern(): void
     {
-        $subject = new ItemIdentifierValidator('/^[a-zA-Z_]{1}[a-zA-Z0-9_-]{0,31}$/u');
+        $subject = new ItemIdentifierValidator('/^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$/u');
 
         $this->item->expects($this->once())
             ->method('getAttributeValue')
@@ -76,7 +76,7 @@ class ItemIdentifierValidatorTest extends TestCase
     {
         $this->expectException(common_exception_Error::class);
 
-        $subject = new ItemIdentifierValidator('/^[a-zA-Z_]{1}[a-zA-Z0-9_-]{0,31}$/u');
+        $subject = new ItemIdentifierValidator('/^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$/u');
 
         $this->item->expects($this->once())
             ->method('getAttributeValue')

--- a/views/js/qtiCreator/helper/itemLoader.js
+++ b/views/js/qtiCreator/helper/itemLoader.js
@@ -30,7 +30,7 @@ define([
     const _generateIdentifier = function _generateIdentifier(uri) {
         const pos = uri.lastIndexOf('#');
         // identifier by default should be no more then 32
-        return uri.substr(pos + 1, qtiIdentifier.maxQtiIdLength);
+        return uri.substring(pos + 1, pos + 1 + qtiIdentifier.maxQtiIdLength);
     };
 
     const decodeHtml = function (str) {

--- a/views/js/qtiCreator/widgets/helpers/qtiIdentifier.js
+++ b/views/js/qtiCreator/widgets/helpers/qtiIdentifier.js
@@ -19,11 +19,11 @@
 define(['module', 'i18n'], function (module, __) {
     'use strict';
 
-    const qtiIdPattern = module.config().qtiIdPattern || '/^[a-zA-Z_]{1}[a-zA-Z0-9_.-]{0,31}$/u';
+    const qtiIdPattern = module.config().qtiIdPattern || '/^[a-zA-Z_]{1}[a-zA-Z0-9_.-]*$/u';
     const [, patternContent, flags] = qtiIdPattern.match(/^\/(.+)\/(\w*)$/);
 
     const invalidQtiIdMessage = __(
-        'Identifiers must start with a letter or an underscore and contain only letters, numbers, dots, underscores ( _ ), or hyphens ( - ), and no more than 32 characters.'
+        'Identifiers must start with a letter or an underscore and contain only letters, numbers, dots, underscores ( _ ), or hyphens ( - ).'
     );
     return {
         pattern: new RegExp(patternContent, flags),


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1612

Remove 32 chars limit for item Identifier