### PR TITLE
fix: deleted outcome declaration behaviour

### DIFF
--- a/views/js/qtiCreator/helper/changeTracker.js
+++ b/views/js/qtiCreator/helper/changeTracker.js
@@ -118,6 +118,7 @@ define([
                     if (
                         !$.contains(container, e.target) &&
                         !$(e.target).parents('#feedback-box').length &&
+                        !$(e.target).parents('.outcome-container').length &&
                         !$(e.target).hasClass('icon-close') &&
                         this.hasChanged()
                     ) {


### PR DESCRIPTION
Related to Issue: https://oat-sa.atlassian.net/browse/AUT-1033

Adding and deleting outcome declarations to an interaction results in NO pop up for unsaved changes .

**SETPS to test:** 
• Checkout to branch: fix/AUT-1033/no-warning-messages-when-leaving-test-with-changes-after-outcome-added
• Create an item and add an interaction
• Go to response and add an outcome declaration
• Try to leave the page clicking in `manage Items`
• Go back to response, delete the added outcome
• Try to leave the page in `manage items`

**ACTUAL RESULT:**
you are taken out of the interaction without pop up asking if you'd like to save the items and without saving.

**EXPECTED RESULT:**
A pop up should come up asking if you want to save the changes and only leaving the page when this is answered.

