### PR TITLE
fix: wrong selector for wrapper

### DIFF
--- a/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
+++ b/views/js/qtiCreator/widgets/static/helpers/itemScrollingMethods.js
@@ -74,7 +74,7 @@ define(['i18n', 'jquery', 'util/typeCaster'], function (__, $, typeCaster) {
             const $form = widget.$form;
             let $wrapper =
                 wrapType === 'inner'
-                    ? widget.$container.children('[data-html-editable]').first(`.${wrapperTextCls}`)
+                    ? widget.$container.children('[data-html-editable]').children(`.${wrapperTextCls}`)
                     : widget.$container.parent(`.${wrapperIncludeCls}`);
 
             if (!$wrapper.length) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-726

Jquery `.first` doesn't have selector https://api.jquery.com/first/

**How to reproduce:**

- Create item with A block
- Add content, table
- Click "enable scrolling"
- Save item

**Actual:** Item is saved, however enable scrolling is not selected
**Expected:** Item is saved AND enable scrolling is also selected/saved. 