### PR TITLE
Fix/AUT-1885/allow renamed response identifier

### DIFF
--- a/views/js/qtiCreator/model/mixin/editableInteraction.js
+++ b/views/js/qtiCreator/model/mixin/editableInteraction.js
@@ -26,29 +26,26 @@ define([
     'taoQtiItem/qtiCreator/model/variables/ResponseDeclaration',
     'taoQtiItem/qtiCreator/model/helper/event',
     'taoQtiItem/qtiCreator/model/helper/response'
-], function(_, Element, ResponseDeclaration, event, responseHelper){
+], function (_, Element, ResponseDeclaration, event, responseHelper) {
     'use strict';
 
-    var methods = {
-
+    const methods = {
         /**
          * Remove a choice from the interaction
          *
          * @param {string|choice} choice
          * @returns {object} this
          */
-        removeChoice : function removeChoice(choice){
-
-            var serial = '', c;
-            if(typeof(choice) === 'string'){
+        removeChoice: function removeChoice(choice) {
+            let serial = '';
+            if (typeof choice === 'string') {
                 serial = choice;
-            }else if(Element.isA(choice, 'choice')){
+            } else if (Element.isA(choice, 'choice')) {
                 serial = choice.getSerial();
             }
-            if(this.choices[serial]){
-
+            if (this.choices[serial]) {
                 //remove choice
-                c = this.choices[serial];
+                const c = this.choices[serial];
                 delete this.choices[serial];
 
                 //update the response
@@ -61,28 +58,28 @@ define([
         },
 
         createOutcomeDeclarationIfNotExists(outcomeIdentifier, buildIdentifier) {
-          const item = this.getRootElement();
-          let outcome = item.getOutcomeDeclaration(outcomeIdentifier);
+            const item = this.getRootElement();
+            let outcome = item.getOutcomeDeclaration(outcomeIdentifier);
 
-          if(!outcome){
-              outcome = item.createOutcomeDeclaration({
-                  cardinality : 'single',
-                  baseType : 'float'
-              });
+            if (!outcome) {
+                outcome = item.createOutcomeDeclaration({
+                    cardinality: 'single',
+                    baseType: 'float'
+                });
 
-              buildIdentifier
-                ? outcome.buildIdentifier(outcomeIdentifier, false)
-                : outcome.attr('identifier', outcomeIdentifier);
-          }
+                buildIdentifier
+                    ? outcome.buildIdentifier(outcomeIdentifier, false)
+                    : outcome.attr('identifier', outcomeIdentifier);
+            }
         },
 
-        createResponse : function createResponse(attrs, template){
+        createResponse: function createResponse(attrs, template) {
             const response = new ResponseDeclaration();
             const responseProcessing = this.rootElement.responseProcessing;
             const processingType = responseProcessing && responseProcessing.processingType;
             let item, renderer;
 
-            if(attrs){
+            if (attrs) {
                 response.attr(attrs);
             }
 
@@ -93,11 +90,7 @@ define([
 
             //assign responseIdentifier only after attaching it to the item to generate a unique id
             response.buildIdentifier('RESPONSE', false);
-            response.setTemplate(
-                processingType === 'custom'
-                    ? 'CUSTOM'
-                    : template || 'MATCH_CORRECT'
-            );
+            response.setTemplate(processingType === 'custom' ? 'CUSTOM' : template || 'MATCH_CORRECT');
             this.attr('responseIdentifier', response.id());
 
             //adding a response processing template require the outcome SCORE:
@@ -115,7 +108,7 @@ define([
 
             //set renderer
             renderer = this.getRenderer();
-            if(renderer){
+            if (renderer) {
                 response.setRenderer(renderer);
             }
 
@@ -124,21 +117,19 @@ define([
 
         /**
          * To be called before deleting the interaction
+         * @returns {Object} this - interaction
          */
-        deleteResponse : function deleteResponse(){
-
-            var response = this.getResponseDeclaration();
-            if(response){
+        deleteResponse: function deleteResponse() {
+            const response = this.getResponseDeclaration();
+            if (response) {
                 this.getRootElement().deleteResponseDeclaration(response);
             }
             this.removeAttr('responseIdentifier');
             return this;
         },
 
-        beforeRemove : function beforeRemove(){
+        beforeRemove: function beforeRemove() {
             const item = this.getRootElement();
-            const serial = this.serial,
-                interactions = item.getInteractions();
             const perInteractionRp = item.metaData.widget.options.perInteractionRp;
 
             // remove interaction outcome

--- a/views/js/qtiCreator/model/mixin/editableInteraction.js
+++ b/views/js/qtiCreator/model/mixin/editableInteraction.js
@@ -148,28 +148,6 @@ define([
 
             //delete its response
             this.deleteResponse();
-
-            //when there is only one interaction remaining, its reponseIdentifier must be RESPONSE to be able to use one of the standard rp
-            if(_.size(interactions) === 2){
-                _.forEach(interactions, (interaction) => {
-
-                    var response = interaction.getResponseDeclaration();
-
-                    //find the other interaction, which will be the last remaining one
-                    if(response && interaction.serial !== serial && interaction.qtiClass !== 'endAttemptInteraction'){
-                        // rename interaction outcome
-                        if (perInteractionRp) {
-                            item.removeOutcome(`SCORE_${interaction.attributes.responseIdentifier}`);
-
-                            this.createOutcomeDeclarationIfNotExists('SCORE_RESPONSE');
-                        }
-
-
-                        interaction.attr('responseIdentifier', 'RESPONSE');
-                        response.id('RESPONSE');
-                    }
-                });
-            }
         }
     };
 

--- a/views/js/test/qtiCreator/model/interactions/mixin/editableInteraction/test.js
+++ b/views/js/test/qtiCreator/model/interactions/mixin/editableInteraction/test.js
@@ -110,7 +110,7 @@ define([
             });
     });
 
-    QUnit.test('beforeRemove', function (assert) {
+    QUnit.test('beforeRemove - renamed response identifier will not change', function (assert) {
         const ready = assert.async();
         const $container = $('#fixture-render');
         const config = {
@@ -132,7 +132,7 @@ define([
 
                 firstInteraction.createResponse();
                 secondInteraction.createResponse();
-                const outcomeIdentifier = `SCORE_RESPONSE`;
+                const outcomeIdentifier = `SCORE_RESPONSE_2`;
 
                 firstInteraction.beforeRemove();
 
@@ -143,14 +143,14 @@ define([
 
                 assert.equal(
                     secondInteraction.attributes.responseIdentifier,
-                    'RESPONSE',
-                    'if there is only one interaction left changes its identifier to RESPONSE'
-                )
+                    'RESPONSE_2',
+                    'if there is only one interaction left, its identifier stays RESPONSE_2'
+                );
 
                 assert.equal(
                     outcome.attributes.identifier,
-                    'SCORE_RESPONSE',
-                    'if there is only one interaction left changes its response outcome identifier to SCORE_RESPOSE'
+                    'SCORE_RESPONSE_2',
+                    'if there is only one interaction left, its response outcome identifier stays SCORE_RESPOSE_2'
                 );
 
                 instance.destroy();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1885

**Steps to reproduce**

- Create an item
- Add a first choice interaction
- Rename the response identifier of the interaction from RESPONSE to MY_CUSTOM_ID
- Add a second choice interaction
- Delete the second interaction

**Current behavior**
The response identifier of the first interaction is RESPONSE
**Expected behavior**
The response identifier of the first interaction is still MY_CUSTOM_ID