### PR TITLE
chore: update item runner dependency

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "0.29.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.29.1.tgz",
-            "integrity": "sha512-pra6yhNSDrRNCNXgdAk+D8RtlPM2RBVSUHJKCX/92OFhq3T7bgeOUJFU7Mq3Vb03f0tcZ4cf4VGPUv/JA6naTw=="
+            "version": "0.29.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.29.2.tgz",
+            "integrity": "sha512-MxhDLEXtzj5nd+nFeIThCv+az/GbXQOI1Hl0rc4ZV4r09Yo6hH0Pdu4Uas/eLdW0mtThrfY5QSNMJUDL1sLbYQ=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "0.29.1"
+        "@oat-sa/tao-item-runner-qti": "0.29.2"
     }
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3112

 - Update `@oat-sa/tao-item-runner-qti` dependency to `0.29.2` to fix support of IME in extended text interaction with max length