### PR TITLE
fix: clean inserted text

### DIFF
--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -1,19 +1,41 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA;
+ *
+ */
+
 define([
     'jquery',
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/choices/states/Question',
     'taoQtiItem/qtiCreator/widgets/choices/helpers/formElement',
     'lodash'
-], function($, stateFactory, QuestionState, formElement, _){
+], function ($, stateFactory, QuestionState, formElement, _) {
     'use strict';
-    const ChoiceStateQuestion = stateFactory.extend(QuestionState, function initStateQuestion(){
-        this.buildEditor();
-    }, function exitStateQuestion(){
-        this.destroyEditor();
-    });
+    const ChoiceStateQuestion = stateFactory.extend(
+        QuestionState,
+        function initStateQuestion() {
+            this.buildEditor();
+        },
+        function exitStateQuestion() {
+            this.destroyEditor();
+        }
+    );
 
-    ChoiceStateQuestion.prototype.createToolbar = function(){
-
+    ChoiceStateQuestion.prototype.createToolbar = function () {
         const _widget = this.widget,
             $toolbar = _widget.$container.find('td:last');
 
@@ -24,40 +46,39 @@ define([
         return $toolbar;
     };
 
-    ChoiceStateQuestion.prototype.buildEditor = function(){
-
+    ChoiceStateQuestion.prototype.buildEditor = function () {
         const _widget = this.widget;
 
-        _widget.$container.find('.editable-content')
+        _widget.$container
+            .find('.editable-content')
             .attr('contentEditable', true)
-            .on('keyup.qti-widget', _.throttle(function(){
+            .on(
+                'keyup.qti-widget',
+                _.throttle(function () {
+                    //update model
+                    _widget.element.val(_.escape($(this).text()));
 
-                //update model
-                _widget.element.val(_.escape($(this).text()));
-
-                //update placeholder
-                _widget.$original.width($(this).width());
-
-            }, 200)).on('focus.qti-widget', function(){
-
+                    //update placeholder
+                    _widget.$original.width($(this).width());
+                }, 200)
+            )
+            .on('focus.qti-widget', function () {
                 _widget.changeState('choice');
-
-            }).on('keypress.qti-widget', function(e){
-
-                if(e.which === 13){
+            })
+            .on('keypress.qti-widget', function (e) {
+                if (e.which === 13) {
                     e.preventDefault();
                     $(this).blur();
                     _widget.changeState('question');
                 }
-
-            }).on('input.qti-widget', function(){
+            })
+            .on('input.qti-widget', function () {
                 // clean format of paste text
                 $(this).html($(this).text());
             });
     };
 
-    ChoiceStateQuestion.prototype.destroyEditor = function(){
-
+    ChoiceStateQuestion.prototype.destroyEditor = function () {
         this.widget.$container.find('.editable-content')
             .removeAttr('contentEditable')
             .off('keyup.qti-widget');

--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -6,8 +6,7 @@ define([
     'lodash'
 ], function($, stateFactory, QuestionState, formElement, _){
     'use strict';
-
-    var ChoiceStateQuestion = stateFactory.extend(QuestionState, function initStateQuestion(){
+    const ChoiceStateQuestion = stateFactory.extend(QuestionState, function initStateQuestion(){
         this.buildEditor();
     }, function exitStateQuestion(){
         this.destroyEditor();
@@ -15,7 +14,7 @@ define([
 
     ChoiceStateQuestion.prototype.createToolbar = function(){
 
-        var _widget = this.widget,
+        const _widget = this.widget,
             $toolbar = _widget.$container.find('td:last');
 
         //set toolbar button behaviour:
@@ -27,7 +26,7 @@ define([
 
     ChoiceStateQuestion.prototype.buildEditor = function(){
 
-        var _widget = this.widget;
+        const _widget = this.widget;
 
         _widget.$container.find('.editable-content')
             .attr('contentEditable', true)
@@ -51,6 +50,9 @@ define([
                     _widget.changeState('question');
                 }
 
+            }).on('input.qti-widget', function(){
+                // clean format of paste text
+                $(this).html($(this).text());
             });
     };
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1961

**Steps to Reproduce**
- Create an item with RTL language.
- Add a text block.
- Add an Inline Choice interaction.
- Click on Edit choices.
- Add a new choice.
- Copy a text with big font size from an external source (e.g. google translate).
- Paste the copied text as the new choice content.

**Actual Result**
Font size of newly added choice is bigger than existing choices:
**Expected Result**
Font size of newly added choice is identical to existing choices.