### PR TITLE
fix/AUT-2015/Hotspot show set score in spots

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Map.js
+++ b/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Map.js
@@ -125,7 +125,7 @@ define([
         _.forEach(interaction.getChoices(), function (choice) {
             const shape = interaction.paper.getById(choice.serial);
             const $popup = grahicScorePopup(interaction.paper, shape, $imageBox, isResponsive);
-            let scoreDefault = false;
+            let scoreDefault = true;
             if (mapEntries[choice.id()]) {
                 scoreDefault = false;
             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2015

**How to test:**

- Go to Item Authoring
- Add Hotspot
- Add spots
- Map response selected in response
- Adding scores for spots
- Switch to Question state
- Switch to Response state
- Spots should contain right score

<img width="806" alt="image" src="https://user-images.githubusercontent.com/25976342/159923212-4223fe8e-8619-4f2a-a40b-eb7f9fbfb915.png">
