### PR TITLE
feat: use Any kind as a wildcard type

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
@@ -63,11 +63,11 @@ define([
             // THEN only -- Any kind of file -- is shown in the selection box.
             types[0].selected = true;
         } else {
-            for (let i in types) {
-                if (_.indexOf(preselected, types[i].mime) >= 0) {
-                    types[i].selected = true;
+            types.forEach(type => {
+                if (preselected.indexOf(type.mime) >= 0) {
+                    type.selected = true;
                 }
-            }
+            });
         }
 
         $form.html(

--- a/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
@@ -52,9 +52,11 @@ define([
 
         const config = module.config();
 
-        if (preselected.length === 0 && config.defaultList && config.defaultList.length > 0) {
+        // set default list only for new added interaction
+        if (_widget.$container.data('new') && config.defaultList && config.defaultList.length > 0) {
             preselected = preselected.concat(config.defaultList);
             uploadHelper.setExpectedTypes(interaction, config.defaultList);
+            _widget.$container.data('new', false);
         }
 
         if (preselected.length === 0) {

--- a/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
 
@@ -28,6 +28,8 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/upload'
 ], function (module, _, __, stateFactory, Question, formElement, uploadHelper, formTpl) {
     'use strict';
+
+    const ANY_KIND = 'any/kind';
     const UploadInteractionStateQuestion = stateFactory.extend(Question);
 
     UploadInteractionStateQuestion.prototype.initForm = function () {
@@ -39,18 +41,24 @@ define([
         // Pre-select a value in the types combo box if needed.
         let preselected = uploadHelper.getExpectedTypes(interaction);
 
+        types.unshift({ mime: ANY_KIND, label: __('-- Any kind of file --') });
+
+        if (preselected.includes(ANY_KIND)) {
+            // Kill the attribute if it is empty or has any/kind
+            delete interaction.attributes.type;
+            interaction.attr('class', '');
+            // WHEN loading the item in Authoring
+            // AND (the file types contains only -- Any kind of file -- OR the file types contains no type at all)
+            // THEN only -- Any kind of file -- is shown in the selection box.
+            types[0].selected = true;
+            preselected = [];
+        }
+
         const config = module.config();
 
         if (preselected.length === 0 && config.defaultList && config.defaultList.length > 0) {
             preselected = preselected.concat(config.defaultList);
             uploadHelper.setExpectedTypes(interaction, config.defaultList);
-        }
-
-        types.unshift({ "mime" : "any/kind", "label" : __("-- Any kind of file --") });
-
-        if (interaction.attr('type') === '') {
-            // Kill the attribute if it is empty.
-            delete interaction.attributes.type;
         }
 
         for (let i in types) {
@@ -74,8 +82,23 @@ define([
         });
 
         // -- type callback.
-        callbacks.type = function (interactionChanged, attrValue) {
-            uploadHelper.setExpectedTypes(interactionChanged, attrValue);
+        callbacks.type = function (interactionChanged, newTypes) {
+            if (!newTypes.includes(ANY_KIND)) {
+                uploadHelper.setExpectedTypes(interactionChanged, newTypes);
+            } else {
+                const currentTypes = interaction.attr('type');
+                if (!currentTypes || currentTypes.includes(ANY_KIND) && newTypes.length > 1) {
+                    // WHEN the Author adds another type THEN the type -- Any kind of file -- is removed.
+                    const typesWithoutAny = newTypes.filter(value => value !== ANY_KIND);
+                    uploadHelper.setExpectedTypes(interactionChanged, typesWithoutAny);
+                    $select.select2('val', typesWithoutAny);
+                } else {
+                    // WHEN -- Any kind of file -- type is added THEN only -- Any kind of file -- is shown in the selection box.
+                    interactionChanged.removeAttr('type');
+                    interactionChanged.attr('class', '');
+                    $select.select2('val', [ANY_KIND]);
+                }
+            }
         };
 
         //init data change callbacks

--- a/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/uploadInteraction/states/Question.js
@@ -43,7 +43,7 @@ define([
 
         types.unshift({ mime: ANY_KIND, label: __('-- Any kind of file --') });
 
-        if (preselected.includes(ANY_KIND)) {
+        if (interaction.attr('type') === '' || preselected.includes(ANY_KIND)) {
             // Kill the attribute if it is empty or has any/kind
             interaction.removeAttr('type');
             interaction.removeAttr('class');

--- a/views/js/qtiCreator/widgets/item/Widget.js
+++ b/views/js/qtiCreator/widgets/item/Widget.js
@@ -254,6 +254,8 @@ define([
                                 widget = elt.data('widget');
                                 if (Element.isA(elt, 'blockInteraction')) {
                                     $widgetNewElem = widget.$container;
+                                    // set flag new for upload interaction to set default list of mime types
+                                    $widgetNewElem.data('new', true);
                                 } else {
                                     //leave the container in place
                                     $widgetNewElem = widget.$original;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1893

**Changes:** instead of saving type `any/kind` - result XML will be without `type` and `class`
```
<uploadInteraction responseIdentifier="RESPONSE"><prompt  />
</uploadInteraction>
```

**Acceptance Criteria:**

AC1a: Loading an item with -- Any kind of file -- selected
GIVEN an item with a File Upload interaction
WHEN loading the item in Authoring
   AND the file types contain -- Any kind of file --
THEN only -- Any kind of file -- is shown in the selection box.

AC1b: Loading an item with no type selected
GIVEN an item with a File Upload interaction
WHEN loading the item in Authoring
   AND (the file types contains only -- Any kind of file -- OR the file types contains no type at all)
THEN only -- Any kind of file -- is shown in the selection box.

AC2: Selecting -- Any kind of file --
GIVEN a File Upload interaction has been added to the current item
WHEN -- Any kind of file -- type is added
THEN only -- Any kind of file -- is shown in the selection box.

AC3: Other types remove -- Any kind of file --
GIVEN (AC1a OR AC1b OR AC2)
WHEN the Author adds another type
THEN the type -- Any kind of file -- is removed.