### PR TITLE
Filter out interactions from the panel based on their visibility

### DIFF
--- a/views/js/portableElementRegistry/factory/ciRegistry.js
+++ b/views/js/portableElementRegistry/factory/ciRegistry.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2016-2022 (original work) Open Assessment Technologies SA;
  *
  */
 define([
@@ -21,7 +21,7 @@ define([
     'i18n',
     'taoQtiItem/portableElementRegistry/factory/factory',
     'taoQtiItem/qtiCreator/helper/qtiElements'
-], function (_, __, portableElementRegistry, qtiElements){
+], function (_, __, portableElementRegistry, qtiElements) {
     'use strict';
 
     /**
@@ -30,31 +30,46 @@ define([
      *
      * @returns {Object} registry instance
      */
-    return function customInteractionRegistry(){
-
+    return function customInteractionRegistry() {
         return portableElementRegistry({
-            getAuthoringData : function getAuthoringData(typeIdentifier, options){
-                let pciModel;
-                options = _.defaults(options || {}, {version : 0, enabledOnly : false});
-                pciModel = this.get(typeIdentifier, options.version);
-                if(pciModel && pciModel.creator && pciModel.creator.hook && pciModel.creator.icon && (pciModel.enabled || !options.enabledOnly)){
+            /**
+             * Get the authoring information for a given custom interaction
+             * @param {string} typeIdentifier - the interaction type identifier
+             * @param {Object} [options]
+             * @param {string|number} [options.version] - the interaction version
+             * @param {boolean} [options.enabledOnly] - to only get interaction enabled && visible
+             * @returns {Object} the authoring info
+             */
+            getAuthoringData(typeIdentifier, options = {}) {
+                options = _.defaults(options || {}, { version: 0, enabledOnly: false });
+                const pciModel = this.get(typeIdentifier, options.version);
+                const qtiClass = `customInteraction.${pciModel.typeIdentifier}`;
+                if (
+                    pciModel &&
+                    pciModel.creator &&
+                    pciModel.creator.hook &&
+                    pciModel.creator.icon &&
+                    ((pciModel.enabled && qtiElements.isVisible(qtiClass)) || !options.enabledOnly)
+                ) {
                     return {
-                        label : pciModel.label, //currently no translation available
-                        icon : pciModel.creator.icon.replace(new RegExp('^' + typeIdentifier + '\/'), pciModel.baseUrl),
-                        short : pciModel.short,
-                        description : pciModel.description,
-                        qtiClass : 'customInteraction.' + pciModel.typeIdentifier, //custom interaction is block type
-                        tags : _.union([__('Custom Interactions')], pciModel.tags),
-                        group : 'custom-interactions'
+                        label: pciModel.label, //currently no translation available
+                        icon: pciModel.creator.icon.replace(new RegExp('^' + typeIdentifier + '/'), pciModel.baseUrl),
+                        short: pciModel.short,
+                        description: pciModel.description,
+                        qtiClass, //custom interaction is block type
+                        tags: _.union([__('Custom Interactions')], pciModel.tags),
+                        group: 'custom-interactions'
                     };
                 }
             }
-        }).on('creatorsloaded', function(){
-            var creators = this.getLatestCreators();
-            _.forEach(creators, function(creator, typeIdentifier){
-                qtiElements.classes['customInteraction.' + typeIdentifier] = {parents : ['customInteraction'], qti : true};
+        }).on('creatorsloaded', function () {
+            const creators = this.getLatestCreators();
+            _.forEach(creators, function (creator, typeIdentifier) {
+                qtiElements.classes[`customInteraction.${typeIdentifier}`] = {
+                    parents: ['customInteraction'],
+                    qti: true
+                };
             });
         });
     };
-
 });

--- a/views/js/portableElementRegistry/factory/ciRegistry.js
+++ b/views/js/portableElementRegistry/factory/ciRegistry.js
@@ -53,7 +53,7 @@ define([
                 ) {
                     return {
                         label: pciModel.label, //currently no translation available
-                        icon: pciModel.creator.icon.replace(new RegExp('^' + typeIdentifier + '/'), pciModel.baseUrl),
+                        icon: pciModel.creator.icon.replace(new RegExp(`^${typeIdentifier}/`), pciModel.baseUrl),
                         short: pciModel.short,
                         description: pciModel.description,
                         qtiClass, //custom interaction is block type

--- a/views/js/qtiCreator/editor/interactionsPanel.js
+++ b/views/js/qtiCreator/editor/interactionsPanel.js
@@ -36,7 +36,6 @@ define([
      */
     return function setUpInteractionPanel($container) {
         const interactions = qtiElements.getAvailableAuthoringElements();
-        //const availableInteractions = qtiElements.getAvailableAuthoringElements();
 
         for (const typeId in ciRegistry.getAllVersions()) {
             const data = ciRegistry.getAuthoringData(typeId, { enabledOnly: true });

--- a/views/js/qtiCreator/editor/interactionsPanel.js
+++ b/views/js/qtiCreator/editor/interactionsPanel.js
@@ -26,9 +26,8 @@ define([
     'taoQtiItem/qtiCreator/editor/interactionsToolbar',
     'taoQtiItem/qtiCreator/helper/panel',
     'taoQtiItem/qtiCreator/helper/qtiElements',
-    'taoQtiItem/portableElementRegistry/ciRegistry',
-    'services/features'
-], function (interactionsToolbar, panel, qtiElements, ciRegistry, featuresService) {
+    'taoQtiItem/portableElementRegistry/ciRegistry'
+], function (interactionsToolbar, panel, qtiElements, ciRegistry) {
     'use strict';
 
     /**
@@ -36,16 +35,8 @@ define([
      * @param {jQueryElement} $container - the panel container
      */
     return function setUpInteractionPanel($container) {
-        const availableInteractions = qtiElements.getAvailableAuthoringElements();
-
-        //filter out interaction not visible
-        const interactions = Object.keys(availableInteractions).reduce((acc, interactionId) => {
-            //we assume the key looks like `item/interaction/associate`
-            if (featuresService.isVisible(`item/interaction/${interactionId.replace(/Interaction$/, '')}`)) {
-                acc[interactionId] = availableInteractions[interactionId];
-            }
-            return acc;
-        }, {});
+        const interactions = qtiElements.getAvailableAuthoringElements();
+        //const availableInteractions = qtiElements.getAvailableAuthoringElements();
 
         for (const typeId in ciRegistry.getAllVersions()) {
             const data = ciRegistry.getAuthoringData(typeId, { enabledOnly: true });

--- a/views/js/qtiCreator/helper/qtiElements.js
+++ b/views/js/qtiCreator/helper/qtiElements.js
@@ -13,474 +13,503 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA ;
  */
 /**
- * @author Sam <sams@taotesting.com>
- * @requires jquery
- * @requires lodash
+ * Utility to retrieve and manipualte QTI Elements
  */
-define(['jquery', 'lodash', 'i18n'], function($, _, __){
-    "use strict";
+define(['jquery', 'lodash', 'i18n'], function ($, _, __) {
+    'use strict';
 
-    var QtiElements = {};
+    const QtiElements = {
+        classes: {
+            //abstract classes:
+            itemBody: { parents: ['bodyElement'], contains: ['block'], abstract: true },
+            atomicBlock: {
+                parents: ['blockStatic', 'bodyElement', 'flowStatic'],
+                contains: ['inline'],
+                abstract: true
+            },
+            atomicInline: {
+                parents: ['bodyElement', 'flowStatic', 'inlineStatic'],
+                contains: ['inline'],
+                abstract: true
+            },
+            simpleBlock: { parents: ['blockStatic', 'bodyElement', 'flowStatic'], contains: ['block'], abstract: true },
+            simpleInline: {
+                parents: ['bodyElement', 'flowStatic', 'inlineStatic'],
+                contains: ['inline'],
+                abstract: true
+            },
+            flowStatic: { parents: ['flow'], abstract: true },
+            blockStatic: { parents: ['block'], abstract: true },
+            inlineStatic: { parents: ['inline'], abstract: true },
+            flow: { parents: ['objectFlow'], abstract: true },
+            tableCell: { parents: ['bodyElement'], contains: ['flow'], abstract: true },
+            //html-derived qti elements:
+            caption: { parents: ['bodyElement'], contains: ['inline'], xhtml: true },
+            col: { parents: ['bodyElement'], xhtml: true },
+            colgroup: { parents: ['bodyElement'], contains: ['col'], xhtml: true },
+            div: { parents: ['blockStatic', 'bodyElement', 'flowStatic'], contains: ['flow'], xhtml: true },
+            dl: { parents: ['blockStatic', 'bodyElement', 'flowStatic'], contains: ['dlElement'], xhtml: true },
+            dt: { parents: ['dlElement'], contains: ['inline'], xhtml: true },
+            dd: { parents: ['dlElement'], contains: ['flow'], xhtml: true },
+            hr: { parents: ['blockStatic', 'bodyElement', 'flowStatic'], xhtml: true },
+            math: { parents: ['blockStatic', 'flowStatic', 'inlineStatic'], xhtml: true },
+            li: { parents: ['bodyElement'], contains: ['flow'], xhtml: true },
+            ol: { parents: ['blockStatic', 'bodyElement', 'flowStatic'], contains: ['li'], xhtml: true },
+            ul: { parents: ['blockStatic', 'bodyElement', 'flowStatic'], contains: ['li'], xhtml: true },
+            object: { parents: ['bodyElement', 'flowStatic', 'inlineStatic'], contains: ['objectFlow'], xhtml: true },
+            param: { parents: ['objectFlow'], xhtml: true },
+            table: {
+                parents: ['blockStatic', 'bodyElement', 'flowStatic'],
+                contains: ['caption', 'col', 'colgroup', 'thead', 'tfoot', 'tbody'],
+                xhtml: true
+            },
+            tbody: { parents: ['bodyElement'], contains: ['tr'], xhtml: true },
+            tfoot: { parents: ['bodyElement'], contains: ['tr'], xhtml: true },
+            thead: { parents: ['bodyElement'], contains: ['tr'], xhtml: true },
+            td: { parents: ['tableCell'], xhtml: true },
+            th: { parents: ['tableCell'], xhtml: true },
+            tr: { parents: ['bodyElement'], contains: ['tableCell'], xhtml: true },
+            a: { parents: ['simpleInline'], xhtml: true },
+            abbr: { parents: ['simpleInline'], xhtml: true },
+            acronym: { parents: ['simpleInline'], xhtml: true },
+            b: { parents: ['simpleInline'], xhtml: true },
+            big: { parents: ['simpleInline'], xhtml: true },
+            cite: { parents: ['simpleInline'], xhtml: true },
+            code: { parents: ['simpleInline'], xhtml: true },
+            dfn: { parents: ['simpleInline'], xhtml: true },
+            em: { parents: ['simpleInline'], xhtml: true },
+            i: { parents: ['simpleInline'], xhtml: true },
+            kbd: { parents: ['simpleInline'], xhtml: true },
+            q: { parents: ['simpleInline'], xhtml: true },
+            samp: { parents: ['simpleInline'], xhtml: true },
+            small: { parents: ['simpleInline'], xhtml: true },
+            span: { parents: ['simpleInline'], xhtml: true },
+            strong: { parents: ['simpleInline'], xhtml: true },
+            sub: { parents: ['simpleInline'], xhtml: true },
+            sup: { parents: ['simpleInline'], xhtml: true },
+            tt: { parents: ['simpleInline'], xhtml: true },
+            var: { parents: ['simpleInline'], xhtml: true },
+            blockquote: { parents: ['simpleBlock'], xhtml: true },
+            address: { parents: ['atomicBlock'], xhtml: true },
+            h1: { parents: ['atomicBlock'], xhtml: true },
+            h2: { parents: ['atomicBlock'], xhtml: true },
+            h3: { parents: ['atomicBlock'], xhtml: true },
+            h4: { parents: ['atomicBlock'], xhtml: true },
+            h5: { parents: ['atomicBlock'], xhtml: true },
+            h6: { parents: ['atomicBlock'], xhtml: true },
+            p: { parents: ['atomicBlock'], xhtml: true },
+            pre: { parents: ['atomicBlock'], xhtml: true },
+            img: { parents: ['atomicInline'], xhtml: true, attributes: ['src', 'alt', 'longdesc', 'height', 'width'] },
+            br: { parents: ['atomicInline'], xhtml: true },
+            //qti elements:
+            infoControl: { parents: ['blockStatic', 'bodyElement', 'flowStatic'], qti: true },
+            textRun: { parents: ['inlineStatic', 'flowstatic'], qti: true },
+            feedbackInline: { parents: ['simpleInline', 'feedbackElement'], qti: true },
+            feedbackBlock: { parents: ['simpleBlock'], qti: true },
+            rubricBlock: { parents: ['simpleBlock'], qti: true }, //strange qti 2.1 exception, marked as simpleBlock instead of
+            blockInteraction: { parents: ['block', 'flow', 'interaction'], qti: true },
+            inlineInteraction: { parents: ['inline', 'flow', 'interaction'], qti: true },
+            gap: { parents: ['inlineStatic'], qti: true },
+            hottext: { parents: ['flowstatic', 'inlineStatic'], contains: ['inlineStatic'], qti: true },
+            printedVariable: { parents: ['bodyElement', 'flowStatic', 'inlineStatic', 'textOrVariable'], qti: true },
+            prompt: { parents: ['bodyElement'], contains: ['inlineStatic'], qti: true },
+            templateElement: { parents: ['bodyElement'], qti: true },
+            templateBlock: {
+                parents: ['blockStatic', 'flowStatic', 'templateElement'],
+                contains: ['blockStatic'],
+                qti: true
+            },
+            templateInline: {
+                parents: ['inlineStatic', 'flowStatic', 'templateElement'],
+                contains: ['inlineStatic'],
+                qti: true
+            },
+            choiceInteraction: { parents: ['blockInteraction'], qti: true },
+            associateInteraction: { parents: ['blockInteraction'], qti: true },
+            orderInteraction: { parents: ['blockInteraction'], qti: true },
+            matchInteraction: { parents: ['blockInteraction'], qti: true },
+            hottextInteraction: { parents: ['blockInteraction'], qti: true },
+            gapMatchInteraction: { parents: ['blockInteraction'], qti: true },
+            mediaInteraction: { parents: ['blockInteraction'], qti: true },
+            sliderInteraction: { parents: ['blockInteraction'], qti: true },
+            uploadInteraction: { parents: ['blockInteraction'], qti: true },
+            drawingInteraction: { parents: ['blockInteraction'], qti: true },
+            graphicInteraction: { parents: ['blockInteraction'], qti: true },
+            hotspotInteraction: { parents: ['graphicInteraction'], qti: true },
+            graphicAssociateInteraction: { parents: ['graphicInteraction'], qti: true },
+            graphicOrderInteraction: { parents: ['graphicInteraction'], qti: true },
+            graphicGapMatchInteraction: { parents: ['graphicInteraction'], qti: true },
+            selectPointInteraction: { parents: ['graphicInteraction'], qti: true },
+            textEntryInteraction: { parents: ['stringInteraction', 'inlineInteraction'], qti: true },
+            extendedTextInteraction: { parents: ['stringInteraction', 'blockInteraction'], qti: true },
+            inlineChoiceInteraction: { parents: ['inlineInteraction'], qti: true },
+            endAttemptInteraction: { parents: ['inlineInteraction'], qti: true },
+            customInteraction: { parents: ['block', 'flow', 'interaction'], qti: true },
+            _container: { parents: ['block'], qti: true } //a pseudo class introduced in TAO
+        },
 
-    QtiElements.classes = {
-        //abstract classes:
-        'itemBody' : {'parents' : ['bodyElement'], 'contains' : ['block'], 'abstract' : true},
-        'atomicBlock' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'contains' : ['inline'], 'abstract' : true},
-        'atomicInline' : {'parents' : ['bodyElement', 'flowStatic', 'inlineStatic'], 'contains' : ['inline'], 'abstract' : true},
-        'simpleBlock' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'contains' : ['block'], 'abstract' : true},
-        'simpleInline' : {'parents' : ['bodyElement', 'flowStatic', 'inlineStatic'], 'contains' : ['inline'], 'abstract' : true},
-        'flowStatic' : {'parents' : ['flow'], 'abstract' : true},
-        'blockStatic' : {'parents' : ['block'], 'abstract' : true},
-        'inlineStatic' : {'parents' : ['inline'], 'abstract' : true},
-        'flow' : {'parents' : ['objectFlow'], 'abstract' : true},
-        'tableCell' : {'parents' : ['bodyElement'], 'contains' : ['flow'], 'abstract' : true},
-        //html-derived qti elements:
-        'caption' : {'parents' : ['bodyElement'], 'contains' : ['inline'], 'xhtml' : true},
-        'col' : {'parents' : ['bodyElement'], 'xhtml' : true},
-        'colgroup' : {'parents' : ['bodyElement'], 'contains' : ['col'], 'xhtml' : true},
-        'div' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'contains' : ['flow'], 'xhtml' : true},
-        'dl' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'contains' : ['dlElement'], 'xhtml' : true},
-        'dt' : {'parents' : ['dlElement'], 'contains' : ['inline'], 'xhtml' : true},
-        'dd' : {'parents' : ['dlElement'], 'contains' : ['flow'], 'xhtml' : true},
-        'hr' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'xhtml' : true},
-        'math' : {'parents' : ['blockStatic', 'flowStatic', 'inlineStatic'], 'xhtml' : true},
-        'li' : {'parents' : ['bodyElement'], 'contains' : ['flow'], 'xhtml' : true},
-        'ol' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'contains' : ['li'], 'xhtml' : true},
-        'ul' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'contains' : ['li'], 'xhtml' : true},
-        'object' : {'parents' : ['bodyElement', 'flowStatic', 'inlineStatic'], 'contains' : ['objectFlow'], 'xhtml' : true},
-        'param' : {'parents' : ['objectFlow'], 'xhtml' : true},
-        'table' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'contains' : ['caption', 'col', 'colgroup', 'thead', 'tfoot', 'tbody'], 'xhtml' : true},
-        'tbody' : {'parents' : ['bodyElement'], 'contains' : ['tr'], 'xhtml' : true},
-        'tfoot' : {'parents' : ['bodyElement'], 'contains' : ['tr'], 'xhtml' : true},
-        'thead' : {'parents' : ['bodyElement'], 'contains' : ['tr'], 'xhtml' : true},
-        'td' : {'parents' : ['tableCell'], 'xhtml' : true},
-        'th' : {'parents' : ['tableCell'], 'xhtml' : true},
-        'tr' : {'parents' : ['bodyElement'], 'contains' : ['tableCell'], 'xhtml' : true},
-        'a' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'abbr' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'acronym' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'b' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'big' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'cite' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'code' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'dfn' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'em' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'i' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'kbd' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'q' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'samp' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'small' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'span' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'strong' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'sub' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'sup' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'tt' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'var' : {'parents' : ['simpleInline'], 'xhtml' : true},
-        'blockquote' : {'parents' : ['simpleBlock'], 'xhtml' : true},
-        'address' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'h1' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'h2' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'h3' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'h4' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'h5' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'h6' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'p' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'pre' : {'parents' : ['atomicBlock'], 'xhtml' : true},
-        'img' : {'parents' : ['atomicInline'], 'xhtml' : true, attributes : ['src', 'alt', 'longdesc', 'height', 'width']},
-        'br' : {'parents' : ['atomicInline'], 'xhtml' : true},
-        //qti elements:
-        'infoControl' : {'parents' : ['blockStatic', 'bodyElement', 'flowStatic'], 'qti' : true},
-        'textRun' : {'parents' : ['inlineStatic', 'flowstatic'], 'qti' : true},
-        'feedbackInline' : {'parents' : ['simpleInline', 'feedbackElement'], 'qti' : true},
-        'feedbackBlock' : {'parents' : ['simpleBlock'], 'qti' : true},
-        'rubricBlock' : {'parents' : ['simpleBlock'], 'qti' : true}, //strange qti 2.1 exception, marked as simpleBlock instead of
-        'blockInteraction' : {'parents' : ['block', 'flow', 'interaction'], 'qti' : true},
-        'inlineInteraction' : {'parents' : ['inline', 'flow', 'interaction'], 'qti' : true},
-        'gap' : {'parents' : ['inlineStatic'], 'qti' : true},
-        'hottext' : {'parents' : ['flowstatic', 'inlineStatic'], 'contains' : ['inlineStatic'], 'qti' : true},
-        'printedVariable' : {'parents' : ['bodyElement', 'flowStatic', 'inlineStatic', 'textOrVariable'], 'qti' : true},
-        'prompt' : {'parents' : ['bodyElement'], 'contains' : ['inlineStatic'], 'qti' : true},
-        'templateElement' : {'parents' : ['bodyElement'], 'qti' : true},
-        'templateBlock' : {'parents' : ['blockStatic', 'flowStatic', 'templateElement'], 'contains' : ['blockStatic'], 'qti' : true},
-        'templateInline' : {'parents' : ['inlineStatic', 'flowStatic', 'templateElement'], 'contains' : ['inlineStatic'], 'qti' : true},
-        'choiceInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'associateInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'orderInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'matchInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'hottextInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'gapMatchInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'mediaInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'sliderInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'uploadInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'drawingInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'graphicInteraction' : {'parents' : ['blockInteraction'], 'qti' : true},
-        'hotspotInteraction' : {'parents' : ['graphicInteraction'], 'qti' : true},
-        'graphicAssociateInteraction' : {'parents' : ['graphicInteraction'], 'qti' : true},
-        'graphicOrderInteraction' : {'parents' : ['graphicInteraction'], 'qti' : true},
-        'graphicGapMatchInteraction' : {'parents' : ['graphicInteraction'], 'qti' : true},
-        'selectPointInteraction' : {'parents' : ['graphicInteraction'], 'qti' : true},
-        'textEntryInteraction' : {'parents' : ['stringInteraction', 'inlineInteraction'], 'qti' : true},
-        'extendedTextInteraction' : {'parents' : ['stringInteraction', 'blockInteraction'], 'qti' : true},
-        'inlineChoiceInteraction' : {'parents' : ['inlineInteraction'], 'qti' : true},
-        'endAttemptInteraction' : {'parents' : ['inlineInteraction'], 'qti' : true},
-        'customInteraction' : {'parents' : ['block', 'flow', 'interaction'], 'qti' : true},
-        '_container' : {'parents' : ['block'], 'qti' : true}//a pseudo class introduced in TAO
-    };
+        cache: { containable: {}, children: {}, parents: {} },
 
-    QtiElements.cache = {containable : {}, children : {}, parents : {}};
-
-    QtiElements.getAllowedContainersElements = function(qtiClass, $container){
-        var classes = QtiElements.getAllowedContainers(qtiClass);
-        var jqSelector = '';
-        for(var i in classes){
-            if(!classes[i].qti){
-                //html element:
-                jqSelector += classes[i] + ', ';
-            }
-        }
-
-        if(jqSelector){
-            jqSelector = jqSelector.substring(0, jqSelector.length - 2);
-        }
-
-        return $(jqSelector, $container ? $container : $(document)).filter(':not([data-qti-type])');
-    };
-
-    QtiElements.getAllowedContainers = function(qtiClass){
-        var ret;
-        if(QtiElements.cache.containable[qtiClass]){
-            ret = QtiElements.cache.containable[qtiClass];
-        }else{
-            ret = [];
-            var parents = QtiElements.getParentClasses(qtiClass, true);
-            for(var aClass in QtiElements.classes){
-                var model = QtiElements.classes[aClass];
-                if(model.contains){
-                    var intersect = _.intersection(model.contains, parents);
-                    if(intersect.length){
-                        if(!model.abstract){
-                            ret.push(aClass);
-                        }
-                        ret = _.union(ret, QtiElements.getChildClasses(aClass, true));
-                    }
+        getAllowedContainersElements(qtiClass, $container) {
+            const classes = QtiElements.getAllowedContainers(qtiClass);
+            let jqSelector = '';
+            for (let i in classes) {
+                if (!classes[i].qti) {
+                    //html element:
+                    jqSelector += `${classes[i]}, `;
                 }
             }
-            QtiElements.cache.containable[qtiClass] = ret;
-        }
 
-        return ret;
-    };
+            if (jqSelector) {
+                jqSelector = jqSelector.substring(0, jqSelector.length - 2);
+            }
 
-    QtiElements.getAllowedContents = function(qtiClass, recursive, checked){
+            return $(jqSelector, $container ? $container : $(document)).filter(':not([data-qti-type])');
+        },
 
-        var ret = [];
-        checked = checked || {};
+        getAllowedContainers(qtiClass) {
+            let ret;
+            if (QtiElements.cache.containable[qtiClass]) {
+                ret = QtiElements.cache.containable[qtiClass];
+            } else {
+                ret = [];
+                const parents = QtiElements.getParentClasses(qtiClass, true);
+                for (let aClass in QtiElements.classes) {
+                    const model = QtiElements.classes[aClass];
+                    if (model.contains) {
+                        const intersect = _.intersection(model.contains, parents);
+                        if (intersect.length) {
+                            if (!model.abstract) {
+                                ret.push(aClass);
+                            }
+                            ret = _.union(ret, QtiElements.getChildClasses(aClass, true));
+                        }
+                    }
+                }
+                QtiElements.cache.containable[qtiClass] = ret;
+            }
 
-        var model = QtiElements.classes[qtiClass];
-        if(model && model.contains){
-            for(var i in model.contains){
-                var contain = model.contains[i];
-                if(!checked[contain]){
-                    checked[contain] = true;
+            return ret;
+        },
 
-                    //qtiClass can contain everything defined as its contents
-                    ret.push(contain);
+        getAllowedContents(qtiClass, recursive, checked) {
+            let ret = [];
+            checked = checked || {};
 
-                    //qtiClass can also contain subclass of its contents
-                    var children = QtiElements.getChildClasses(contain, true);
-                    for(var i in children){
-                        var child = children[i];
-                        if(!checked[child]){
-                            checked[child] = true;
+            const model = QtiElements.classes[qtiClass];
+            if (model && model.contains) {
+                for (let i in model.contains) {
+                    const contain = model.contains[i];
+                    if (!checked[contain]) {
+                        checked[contain] = true;
 
-                            ret.push(child);
+                        //qtiClass can contain everything defined as its contents
+                        ret.push(contain);
 
-                            //adding children allowed contents depends on the option "recursive"
-                            if(recursive){
-                                ret = _.union(ret, QtiElements.getAllowedContents(child, true, checked));
+                        //qtiClass can also contain subclass of its contents
+                        const children = QtiElements.getChildClasses(contain, true);
+                        for (let j in children) {
+                            const child = children[j];
+                            if (!checked[child]) {
+                                checked[child] = true;
+
+                                ret.push(child);
+
+                                //adding children allowed contents depends on the option "recursive"
+                                if (recursive) {
+                                    ret = _.union(ret, QtiElements.getAllowedContents(child, true, checked));
+                                }
                             }
                         }
-                    }
 
-                    //adding allowed contents of qtiClass' allowed contents depends on the option "recursive"
-                    if(recursive){
-                        ret = _.union(ret, QtiElements.getAllowedContents(contain, true, checked));
+                        //adding allowed contents of qtiClass' allowed contents depends on the option "recursive"
+                        if (recursive) {
+                            ret = _.union(ret, QtiElements.getAllowedContents(contain, true, checked));
+                        }
                     }
-
                 }
             }
-        }
 
-        //qtiClass can contain all allowed contents of its parents:
-        var parents = QtiElements.getParentClasses(qtiClass, true);
-        for(var i in parents){
-            ret = _.union(ret, QtiElements.getAllowedContents(parents[i], recursive, checked));
-        }
-
-        return _.uniq(ret, false);
-    };
-
-    QtiElements.isAllowedClass = function(qtiContainerClass, qtiContentClass){
-        var allowedClasses = QtiElements.getAllowedContents(qtiContainerClass);
-        return (_.indexOf(allowedClasses, qtiContentClass) >= 0);
-    };
-
-    QtiElements.getParentClasses = function(qtiClass, recursive){
-        var ret;
-        if(recursive && QtiElements.cache.parents[qtiClass]){
-            ret = QtiElements.cache.parents[qtiClass];
-        }else{
-            ret = [];
-            if(QtiElements.classes[qtiClass]){
-                ret = QtiElements.classes[qtiClass].parents;
-                if(recursive){
-                    for(var i in ret){
-                        ret = _.union(ret, QtiElements.getParentClasses(ret[i], recursive));
-                    }
-                    ret = _.uniq(ret, false);
-                }
+            //qtiClass can contain all allowed contents of its parents:
+            const parents = QtiElements.getParentClasses(qtiClass, true);
+            for (let i in parents) {
+                ret = _.union(ret, QtiElements.getAllowedContents(parents[i], recursive, checked));
             }
-            QtiElements.cache.parents[qtiClass] = ret;
-        }
 
-        return ret;
-    };
+            return _.uniq(ret, false);
+        },
 
-    QtiElements.getChildClasses = function(qtiClass, recursive, type){
-        var ret;
-        var cacheType = type ? type : 'all';
-        if(recursive && QtiElements.cache.children[qtiClass] && QtiElements.cache.children[qtiClass][cacheType]){
-            ret = QtiElements.cache.children[qtiClass][cacheType];
-        }else{
-            ret = [];
-            for(var aClass in QtiElements.classes){
-                var model = QtiElements.classes[aClass];
-                if(_.indexOf(model.parents, qtiClass) >= 0){
-                    if(type){
-                        if(model[type]){
+        isAllowedClass(qtiContainerClass, qtiContentClass) {
+            const allowedClasses = QtiElements.getAllowedContents(qtiContainerClass);
+            return _.indexOf(allowedClasses, qtiContentClass) >= 0;
+        },
+
+        getParentClasses(qtiClass, recursive) {
+            let ret;
+            if (recursive && QtiElements.cache.parents[qtiClass]) {
+                ret = QtiElements.cache.parents[qtiClass];
+            } else {
+                ret = [];
+                if (QtiElements.classes[qtiClass]) {
+                    ret = QtiElements.classes[qtiClass].parents;
+                    if (recursive) {
+                        for (let i in ret) {
+                            ret = _.union(ret, QtiElements.getParentClasses(ret[i], recursive));
+                        }
+                        ret = _.uniq(ret, false);
+                    }
+                }
+                QtiElements.cache.parents[qtiClass] = ret;
+            }
+
+            return ret;
+        },
+
+        getChildClasses(qtiClass, recursive, type) {
+            let ret;
+            const cacheType = type ? type : 'all';
+            if (recursive && QtiElements.cache.children[qtiClass] && QtiElements.cache.children[qtiClass][cacheType]) {
+                ret = QtiElements.cache.children[qtiClass][cacheType];
+            } else {
+                ret = [];
+                for (let aClass in QtiElements.classes) {
+                    const model = QtiElements.classes[aClass];
+                    if (_.indexOf(model.parents, qtiClass) >= 0) {
+                        if (type) {
+                            if (model[type]) {
+                                ret.push(aClass);
+                            }
+                        } else {
                             ret.push(aClass);
                         }
-                    }else{
-                        ret.push(aClass);
-                    }
-                    if(recursive){
-                        ret = _.union(ret, QtiElements.getChildClasses(aClass, recursive, type));
+                        if (recursive) {
+                            ret = _.union(ret, QtiElements.getChildClasses(aClass, recursive, type));
+                        }
                     }
                 }
+                if (!QtiElements.cache.children[qtiClass]) {
+                    QtiElements.cache.children[qtiClass] = {};
+                }
+                QtiElements.cache.children[qtiClass][cacheType] = ret;
             }
-            if(!QtiElements.cache.children[qtiClass]){
-                QtiElements.cache.children[qtiClass] = {};
+
+            return ret;
+        },
+
+        isBlock(qtiClass) {
+            return QtiElements.is(qtiClass, 'block');
+        },
+
+        isInline(qtiClass) {
+            return QtiElements.is(qtiClass, 'inline');
+        },
+
+        is(qtiClass, topClass) {
+            if (qtiClass === topClass) {
+                return true;
+            } else {
+                const parents = QtiElements.getParentClasses(qtiClass, true);
+                return _.indexOf(parents, topClass) >= 0;
             }
-            QtiElements.cache.children[qtiClass][cacheType] = ret;
+        },
+
+        getAvailableAuthoringElements() {
+            const tagTitles = {
+                commonInteractions: __('Common Interactions'),
+                inlineInteractions: __('Inline Interactions'),
+                graphicInteractions: __('Graphic Interactions')
+            };
+
+            return {
+                choiceInteraction: {
+                    label: __('Choice Interaction'),
+                    description: __(
+                        'Select a single (radio buttons) or multiple (check boxes) responses among a set of choices.'
+                    ),
+                    icon: 'icon-choice',
+                    short: __('Choice'),
+                    qtiClass: 'choiceInteraction',
+                    tags: [tagTitles.commonInteractions, 'mcq'],
+                    group: 'common-interactions'
+                },
+                orderInteraction: {
+                    label: __('Order Interaction'),
+                    icon: 'icon-order',
+                    description: __('Arrange a list of choices in the correct order.'),
+                    short: __('Order'),
+                    qtiClass: 'orderInteraction',
+                    tags: [tagTitles.commonInteractions, 'ordering'],
+                    group: 'common-interactions'
+                },
+                associateInteraction: {
+                    label: __('Associate Interaction'),
+                    icon: 'icon-associate',
+                    description: __('Create pair(s) from a series of choices.'),
+                    short: __('Associate'),
+                    qtiClass: 'associateInteraction',
+                    tags: [tagTitles.commonInteractions, 'association'],
+                    group: 'common-interactions'
+                },
+                matchInteraction: {
+                    label: __('Match Interaction'),
+                    icon: 'icon-match',
+                    description: __(
+                        'Create association(s) between two sets of choices displayed in a table (row and column).'
+                    ),
+                    short: __('Match'),
+                    qtiClass: 'matchInteraction',
+                    tags: [tagTitles.commonInteractions, 'association'],
+                    group: 'common-interactions'
+                },
+                hottextInteraction: {
+                    label: __('Hottext Interaction'),
+                    icon: 'icon-hottext',
+                    description: __('Select one or more text parts (hottext) within a text.'),
+                    short: __('Hottext'),
+                    qtiClass: 'hottextInteraction',
+                    tags: [tagTitles.commonInteractions, 'text'],
+                    group: 'common-interactions'
+                },
+                gapMatchInteraction: {
+                    label: __('Gap Match Interaction'),
+                    icon: 'icon-gap-match',
+                    description: __(' Fill in the gaps in a text from a set of choices.'),
+                    short: __('Gap Match'),
+                    qtiClass: 'gapMatchInteraction',
+                    tags: [tagTitles.commonInteractions, 'text', 'association'],
+                    group: 'common-interactions'
+                },
+                sliderInteraction: {
+                    label: __('Slider Interaction'),
+                    icon: 'icon-slider',
+                    description: __('Select a value within a numerical range.'),
+                    short: __('Slider'),
+                    qtiClass: 'sliderInteraction',
+                    tags: [tagTitles.commonInteractions, 'special'],
+                    group: 'common-interactions'
+                },
+                extendedTextInteraction: {
+                    label: __('Extended Text Interaction'),
+                    icon: 'icon-extended-text',
+                    description: __(
+                        'Collect open-ended information in one or more text area(s) (strings or numeric values).'
+                    ),
+                    short: __('Extended Text'),
+                    qtiClass: 'extendedTextInteraction',
+                    tags: [tagTitles.commonInteractions, 'text'],
+                    group: 'common-interactions'
+                },
+                uploadInteraction: {
+                    label: __('File Upload Interaction'),
+                    icon: 'icon-upload',
+                    description: __('Upload a file (e.g. document, picture...) as a response.'),
+                    short: __('File Upload'),
+                    qtiClass: 'uploadInteraction',
+                    tags: [tagTitles.commonInteractions, 'special'],
+                    group: 'common-interactions'
+                },
+                mediaInteraction: {
+                    label: __('Media Interaction'),
+                    icon: 'icon-media',
+                    description: __(
+                        'Control the playing parameters (auto-start, loop) of a video or audio file and report the number of time it has been played.'
+                    ),
+                    short: __('Media'),
+                    qtiClass: 'mediaInteraction',
+                    tags: [tagTitles.commonInteractions, 'media'],
+                    group: 'common-interactions'
+                },
+                _container: {
+                    label: __('Text Block'),
+                    icon: 'icon-font',
+                    description: __(
+                        'Block contains the content (stimulus) of the item such as text or image. It is also required for Inline Interactions.'
+                    ),
+                    short: __('Block'),
+                    qtiClass: '_container',
+                    tags: [tagTitles.inlineInteractions, 'text'],
+                    group: 'inline-interactions'
+                },
+                inlineChoiceInteraction: {
+                    label: __('Inline Choice Interaction'),
+                    icon: 'icon-inline-choice',
+                    description: __('Select a choice from a drop-down list.'),
+                    short: __('Inline Choice'),
+                    qtiClass: 'inlineChoiceInteraction',
+                    tags: [tagTitles.inlineInteractions, 'inline-interactions', 'mcq'],
+                    group: 'inline-interactions'
+                },
+                textEntryInteraction: {
+                    label: __('Text Entry Interaction'),
+                    icon: 'icon-text-entry',
+                    description: __(
+                        'Collect open-ended information in a short text input (strings or numeric values).'
+                    ),
+                    short: __('Text Entry'),
+                    qtiClass: 'textEntryInteraction',
+                    tags: [tagTitles.inlineInteractions, 'inline-interactions', 'text'],
+                    group: 'inline-interactions'
+                },
+                endAttemptInteraction: {
+                    label: __('End Attempt Interaction'),
+                    icon: 'icon-end-attempt',
+                    description: __('Trigger the end of the item attempt.'),
+                    short: __('End Attempt'),
+                    qtiClass: 'endAttemptInteraction',
+                    tags: [tagTitles.inlineInteractions, 'inline-interactions', 'button', 'submit'],
+                    group: 'inline-interactions'
+                },
+                hotspotInteraction: {
+                    label: __('Hotspot Interaction'),
+                    icon: 'icon-hotspot',
+                    description: __('Select one or more areas (hotspots) displayed on an picture.'),
+                    short: __('Hotspot'),
+                    qtiClass: 'hotspotInteraction',
+                    tags: [tagTitles.graphicInteractions, 'mcq'],
+                    group: 'graphic-interactions'
+                },
+                graphicOrderInteraction: {
+                    label: __('Graphic Order Interaction'),
+                    icon: 'icon-graphic-order',
+                    description: __('Order the areas (hotspots) displayed on a picture.'),
+                    short: __('Order'),
+                    qtiClass: 'graphicOrderInteraction',
+                    tags: [tagTitles.graphicInteractions, 'ordering'],
+                    group: 'graphic-interactions'
+                },
+                graphicAssociateInteraction: {
+                    label: __('Graphic Associate Interaction'),
+                    icon: 'icon-graphic-associate',
+                    description: __('Create association(s) between areas (hotspots) displayed on a picture.'),
+                    short: __('Associate'),
+                    qtiClass: 'graphicAssociateInteraction',
+                    tags: [tagTitles.graphicInteractions, 'association'],
+                    group: 'graphic-interactions'
+                },
+                graphicGapMatchInteraction: {
+                    label: __('Graphic Gap Match Interaction'),
+                    icon: 'icon-graphic-gap',
+                    description: __('Fill in the gaps on a picture with a set of image choices.'),
+                    short: __('Gap Match'),
+                    qtiClass: 'graphicGapMatchInteraction',
+                    tags: [tagTitles.graphicInteractions, 'association'],
+                    group: 'graphic-interactions'
+                },
+                selectPointInteraction: {
+                    label: __('Select Point Interaction'),
+                    icon: 'icon-select-point',
+                    description: __('Position one or more points on a picture (response areas are not displayed).'),
+                    short: __('Select Point'),
+                    qtiClass: 'selectPointInteraction',
+                    tags: [tagTitles.graphicInteractions],
+                    group: 'graphic-interactions'
+                }
+            };
         }
-
-        return ret;
-    };
-
-    QtiElements.isBlock = function(qtiClass){
-        return QtiElements.is(qtiClass, 'block');
-    };
-
-    QtiElements.isInline = function(qtiClass){
-        return QtiElements.is(qtiClass, 'inline');
-    };
-
-    QtiElements.is = function(qtiClass, topClass){
-        if(qtiClass === topClass){
-            return true;
-        }else{
-            var parents = QtiElements.getParentClasses(qtiClass, true);
-            return (_.indexOf(parents, topClass) >= 0);
-        }
-    };
-
-    QtiElements.getAvailableAuthoringElements = function(){
-
-        var tagTitles = {
-            commonInteractions: __('Common Interactions'),
-            inlineInteractions: __('Inline Interactions'),
-            graphicInteractions: __('Graphic Interactions')
-        }
-
-        return {
-            choiceInteraction : {
-                label : __('Choice Interaction'),
-                description : __('Select a single (radio buttons) or multiple (check boxes) responses among a set of choices.'),
-                icon : 'icon-choice',
-                short : __('Choice'),
-                qtiClass : 'choiceInteraction',
-                tags:[tagTitles.commonInteractions, 'mcq'],
-                group: 'common-interactions'
-            },
-            orderInteraction : {
-                label : __('Order Interaction'),
-                icon : 'icon-order',
-                description : __('Arrange a list of choices in the correct order.'),
-                short : __('Order'),
-                qtiClass : 'orderInteraction',
-                tags:[tagTitles.commonInteractions, 'ordering'],
-                group: 'common-interactions'
-
-            },
-            associateInteraction : {
-                label : __('Associate Interaction'),
-                icon : 'icon-associate',
-                description : __('Create pair(s) from a series of choices.'),
-                short : __('Associate'),
-                qtiClass : 'associateInteraction',
-                tags:[tagTitles.commonInteractions, 'association'],
-                group: 'common-interactions'
-            },
-            matchInteraction : {
-                label : __('Match Interaction'),
-                icon : 'icon-match',
-                description : __('Create association(s) between two sets of choices displayed in a table (row and column).'),
-                short : __('Match'),
-                qtiClass : 'matchInteraction',
-                tags:[tagTitles.commonInteractions, 'association'],
-                group: 'common-interactions'
-            },
-            hottextInteraction : {
-                label : __('Hottext Interaction'),
-                icon : 'icon-hottext',
-                description : __('Select one or more text parts (hottext) within a text.'),
-                short : __('Hottext'),
-                qtiClass : 'hottextInteraction',
-                tags:[tagTitles.commonInteractions, 'text'],
-                group: 'common-interactions'
-            },
-            gapMatchInteraction : {
-                label : __('Gap Match Interaction'),
-                icon : 'icon-gap-match',
-                description : __(' Fill in the gaps in a text from a set of choices.'),
-                short : __('Gap Match'),
-                qtiClass : 'gapMatchInteraction',
-                tags:[tagTitles.commonInteractions, 'text', 'association'],
-                group: 'common-interactions'
-            },
-            sliderInteraction : {
-                label : __('Slider Interaction'),
-                icon : 'icon-slider',
-                description :__('Select a value within a numerical range.'),
-                short : __('Slider'),
-                qtiClass : 'sliderInteraction',
-                tags:[tagTitles.commonInteractions, 'special'],
-                group: 'common-interactions'
-            },
-            extendedTextInteraction : {
-                label : __('Extended Text Interaction'),
-                icon : 'icon-extended-text',
-                description : __('Collect open-ended information in one or more text area(s) (strings or numeric values).'),
-                short : __('Extended Text'),
-                qtiClass : 'extendedTextInteraction',
-                tags:[tagTitles.commonInteractions, 'text'],
-                group: 'common-interactions'
-            },
-            uploadInteraction : {
-                label : __('File Upload Interaction'),
-                icon : 'icon-upload',
-                description : __('Upload a file (e.g. document, picture...) as a response.'),
-                short : __('File Upload'),
-                qtiClass : 'uploadInteraction',
-                tags:[tagTitles.commonInteractions, 'special'],
-                group: 'common-interactions'
-            },
-            mediaInteraction : {
-                label : __('Media Interaction'),
-                icon : 'icon-media',
-                description : __('Control the playing parameters (auto-start, loop) of a video or audio file and report the number of time it has been played.'),
-                short : __('Media'),
-                qtiClass : 'mediaInteraction',
-                tags:[tagTitles.commonInteractions, 'media'],
-                group: 'common-interactions'
-            },
-            _container : {
-                label : __('Text Block'),
-                icon : 'icon-font',
-                description : __('Block contains the content (stimulus) of the item such as text or image. It is also required for Inline Interactions.'),
-                short : __('Block'),
-                qtiClass : '_container',
-                tags:[tagTitles.inlineInteractions, 'text'],
-                group: 'inline-interactions'
-            },
-            inlineChoiceInteraction : {
-                label : __('Inline Choice Interaction'),
-                icon : 'icon-inline-choice',
-                description : __('Select a choice from a drop-down list.'),
-                short : __('Inline Choice'),
-                qtiClass : 'inlineChoiceInteraction',
-                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'mcq'],
-                group: 'inline-interactions'
-            },
-            textEntryInteraction : {
-                label : __('Text Entry Interaction'),
-                icon : 'icon-text-entry',
-                description : __('Collect open-ended information in a short text input (strings or numeric values).'),
-                short : __('Text Entry'),
-                qtiClass : 'textEntryInteraction',
-                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'text'],
-                group: 'inline-interactions'
-            },
-            endAttemptInteraction : {
-                label : __('End Attempt Interaction'),
-                icon : 'icon-end-attempt',
-                description : __('Trigger the end of the item attempt.'),
-                short : __('End Attempt'),
-                qtiClass : 'endAttemptInteraction',
-                tags:[tagTitles.inlineInteractions, 'inline-interactions', 'button', 'submit'],
-                group: 'inline-interactions'
-            },
-            hotspotInteraction : {
-                label : __('Hotspot Interaction'),
-                icon : 'icon-hotspot',
-                description : __('Select one or more areas (hotspots) displayed on an picture.'),
-                short : __('Hotspot'),
-                qtiClass : 'hotspotInteraction',
-                tags:[tagTitles.graphicInteractions, 'mcq'],
-                group: 'graphic-interactions'
-            },
-            graphicOrderInteraction : {
-                label : __('Graphic Order Interaction'),
-                icon : 'icon-graphic-order',
-                description : __('Order the areas (hotspots) displayed on a picture.'),
-                short : __('Order'),
-                qtiClass : 'graphicOrderInteraction',
-                tags:[tagTitles.graphicInteractions, 'ordering'],
-                group: 'graphic-interactions'
-            },
-            graphicAssociateInteraction : {
-                label : __('Graphic Associate Interaction'),
-                icon : 'icon-graphic-associate',
-                description : __('Create association(s) between areas (hotspots) displayed on a picture.'),
-                short : __('Associate'),
-                qtiClass : 'graphicAssociateInteraction',
-                tags:[tagTitles.graphicInteractions, 'association'],
-                group: 'graphic-interactions'
-            },
-            graphicGapMatchInteraction : {
-                label : __('Graphic Gap Match Interaction'),
-                icon : 'icon-graphic-gap',
-                description : __('Fill in the gaps on a picture with a set of image choices.'),
-                short : __('Gap Match'),
-                qtiClass : 'graphicGapMatchInteraction',
-                tags:[tagTitles.graphicInteractions, 'association'],
-                group: 'graphic-interactions'
-            },
-            selectPointInteraction : {
-                label : __('Select Point Interaction'),
-                icon : 'icon-select-point',
-                description : __('Position one or more points on a picture (response areas are not displayed).'),
-                short : __('Select Point'),
-                qtiClass : 'selectPointInteraction',
-                tags:[tagTitles.graphicInteractions],
-                group: 'graphic-interactions'
-            }
-        };
     };
 
     return QtiElements;
-
 });

--- a/views/js/qtiCreator/helper/qtiElements.js
+++ b/views/js/qtiCreator/helper/qtiElements.js
@@ -18,7 +18,7 @@
 /**
  * Utility to retrieve and manipualte QTI Elements
  */
-define(['jquery', 'lodash', 'i18n'], function ($, _, __) {
+define(['jquery', 'lodash', 'i18n', 'services/features'], function ($, _, __, featuresService) {
     'use strict';
 
     const QtiElements = {
@@ -316,6 +316,26 @@ define(['jquery', 'lodash', 'i18n'], function ($, _, __) {
             }
         },
 
+        /**
+         * Check wether an element is visible, using the feature viibility service
+         * @param {string} qtiClass - see the list of available classes
+         * @returns {boolean} true by default and false only if the element is explicitely registered as hidden
+         */
+        isVisible(qtiClass) {
+            if (this.is(qtiClass, 'customInteraction')) {
+                return featuresService.isVisible(`taoQtiItem/creator/customInteraction/${qtiClass.replace(/Interaction$/, '').replace(/^customInteraction\./, '')}`);
+            }
+            if (this.is(qtiClass, 'interaction')) {
+                return featuresService.isVisible(`taoQtiItem/creator/interaction/${qtiClass.replace(/Interaction$/, '')}`);
+            }
+            return true;
+        },
+
+        /**
+         * Get the list of available elements for the authoring side
+         * The list of those element is statically defined, but we filter out elements that should be visible
+         * @returns {Object} the available elements
+         */
         getAvailableAuthoringElements() {
             const tagTitles = {
                 commonInteractions: __('Common Interactions'),
@@ -323,7 +343,7 @@ define(['jquery', 'lodash', 'i18n'], function ($, _, __) {
                 graphicInteractions: __('Graphic Interactions')
             };
 
-            return {
+            const authoringElements = {
                 choiceInteraction: {
                     label: __('Choice Interaction'),
                     description: __(
@@ -508,6 +528,15 @@ define(['jquery', 'lodash', 'i18n'], function ($, _, __) {
                     group: 'graphic-interactions'
                 }
             };
+
+            //filter out hidden elements
+            const availableElements = {};
+            for (const [elementId, element] of Object.entries(authoringElements)) {
+                if (this.isVisible(elementId)) {
+                    availableElements[elementId] = element;
+                }
+            }
+            return availableElements;
         }
     };
 

--- a/views/js/test/qtiCreator/helper/qtiElements/test.html
+++ b/views/js/test/qtiCreator/helper/qtiElements/test.html
@@ -24,7 +24,7 @@
                         "services/features" : {
                             visibility : {
                                 'taoQtiItem/creator/interaction/endAttempt': 'hide',
-                                'taoQtiItem/creator/interaction/choice': 'show'
+                                'taoQtiItem/creator/interaction/choice': 'show',
                                 'taoQtiItem/creator/customInteraction/likert': 'hide'
                             }
                         }

--- a/views/js/test/qtiCreator/helper/qtiElements/test.html
+++ b/views/js/test/qtiCreator/helper/qtiElements/test.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test - QTI Elements helper</title>
+        <base href="../../../../../../../tao/views/"/>
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" href="css/tao-main-style.css"/>
+        <link rel="stylesheet" href="css/tao-3.css"/>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                requirejs.config({
+                    "config": {
+                        "services/features" : {
+                            visibility : {
+                                'taoQtiItem/creator/interaction/endAttempt': 'hide',
+                                'taoQtiItem/creator/interaction/choice': 'show'
+                                'taoQtiItem/creator/customInteraction/likert': 'hide'
+                            }
+                        }
+                    }
+                });
+
+                //load the test
+                require(['taoQtiItem/test/qtiCreator/helper/qtiElements/test'], function () {
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/qtiCreator/helper/qtiElements/test.js
+++ b/views/js/test/qtiCreator/helper/qtiElements/test.js
@@ -42,6 +42,10 @@ define(['taoQtiItem/qtiCreator/helper/qtiElements'], function (qtiElements) {
         .test('is interaction visible ', (data, assert) => {
             assert.expect(1);
 
-            assert.equal(qtiElements.isVisible(data.title), data.visible, `${data.title} ${data.visible? 'is': 'is not'} visible`);
+            assert.equal(
+                qtiElements.isVisible(data.title),
+                data.visible,
+                `${data.title} ${data.visible ? 'is' : 'is not'} visible`
+            );
         });
 });

--- a/views/js/test/qtiCreator/helper/qtiElements/test.js
+++ b/views/js/test/qtiCreator/helper/qtiElements/test.js
@@ -1,0 +1,47 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define(['taoQtiItem/qtiCreator/helper/qtiElements'], function (qtiElements) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.cases.init([{ title: 'isVisible' }]).test('helper API ', (data, assert) => {
+        assert.expect(1);
+        assert.equal(typeof qtiElements[data.title], 'function', `The instance exposes a "${data.title}" function`);
+    });
+
+    QUnit.module('Behavior');
+
+    QUnit.cases
+        .init([
+            { title: 'endAttemptInteraction', visible: false },
+            { title: 'choiceInteraction', visible: true },
+            { title: 'associateInteraction', visible: true },
+            { title: 'graphicGapMatchInteraction', visible: true },
+            { title: 'notAnInteraction', visible: true }
+        ])
+        .test('is interaction visible ', (data, assert) => {
+            assert.expect(1);
+
+            assert.equal(qtiElements.isVisible(data.title), data.visible, `${data.title} ${data.visible? 'is': 'is not'} visible`);
+        });
+});


### PR DESCRIPTION
Related https://oat-sa.atlassian.net/browse/AUT-1980

 - check if each interaction is visible in the authoring using the key pattern `taoQtiItem/creator/interaction/<interaction>`
 - same for PCI using `taoQtiItem/creator/customInteraction/<typeIdentifier>`
 - A small util has been added to check if a qti element is visible (and cleanup the helper)


### How to test:
 - run the unit test : `cd tao/views/build && npm ci && npx grunt connect:test taoqtiitemtest`
 - configure some interactions to be hidden in `config/tao/client_lib_config_registry.conf.php`, for example
```
                'taoQtiItem/creator/interaction/endAttempt' => 'hide',
                'taoQtiItem/creator/customInteraction/likertScale' => 'hide',
``` 
  and open the authoring to check if the interactions aren't available in the sidebar.