### PR TITLE
feat: remove taotooltip ckeditor plugin is configured so

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -21,12 +21,25 @@ define([
     'jquery',
     'ckeditor',
     'core/promise',
+    'services/features',
     'taoQtiItem/qtiCreator/helper/ckConfigurator',
     'taoQtiItem/qtiItem/core/Element',
     'taoQtiItem/qtiCreator/widgets/helpers/content',
     'taoQtiItem/qtiCreator/widgets/helpers/deletingState',
     'taoQtiItem/qtiCreator/editor/ckEditor/featureFlag'
-], function (_, __, $, CKEditor, Promise, ckConfigurator, Element, contentHelper, deletingHelper, featureFlag) {
+], function (
+    _,
+    __,
+    $,
+    CKEditor,
+    Promise,
+    features,
+    ckConfigurator,
+    Element,
+    contentHelper,
+    deletingHelper,
+    featureFlag
+) {
     'use strict';
 
     const _defaults = {
@@ -61,6 +74,22 @@ define([
 
         options = _.defaults(options, _defaults);
 
+        const isHiddenPlugin = pluginName => !features.isVisible(`taoQtiItem/creator/content/plugin/${pluginName}`);
+
+        const registeredPluginNames = CKEditor.plugins.registered && Object.keys(CKEditor.plugins.registered);
+        const removePlugins = [];
+        registeredPluginNames.forEach(pluginName => {
+            if (isHiddenPlugin(pluginName)) {
+                removePlugins.push(pluginName);
+            }
+        });
+
+        if (options.removePlugins) {
+            options.removePlugins.split('').forEach(removePluginName => {
+                removePlugins.push(removePluginName.trim());
+            });
+        }
+
         if (!($editable instanceof $) || !$editable.length) {
             throw new Error('invalid jquery element for $editable');
         }
@@ -79,7 +108,7 @@ define([
         const ckConfig = {
             dtdMode: 'qti',
             autoParagraph: false,
-            removePlugins: options.removePlugins || '',
+            removePlugins: removePlugins.join(','),
             enterMode: options.enterMode || CKEditor.ENTER_P,
             floatSpaceDockedOffsetY: 10,
             sharedSpaces: {
@@ -528,6 +557,7 @@ define([
          * @param {Boolean} [editorOptions.shieldInnerContent] - define if the inner widget content should be protected or not
          * @param {Boolean} [editorOptions.passthroughInnerContent] - define if the inner widget content should be accessible directly or not
          * @param {Boolean} [editorOptions.enterMode] - what is the behavior of the "Enter" key (see ENTER_MODE_xxx in ckEditor configuration)
+         * @param {String} [editorOptions.removePlugins] - comma-separated list of plugins to disable
          * @returns {undefined}
          */
         buildEditor: function ($container, editorOptions) {

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -11,10 +11,9 @@ define([
     'use strict';
 
     const wrapperCls = 'custom-text-box';
-  
-    const isHiddenPlugin = (pluginName) => {
-        return !features.isVisible(`taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins/${pluginName}`);
-    }
+
+    const isHiddenPlugin = pluginName =>
+        !features.isVisible(`taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins/${pluginName}`);
     const TextActive = stateFactory.extend(
         Active,
         function () {
@@ -49,20 +48,20 @@ define([
                 widget: widget,
                 container: container
             }
-        }
+        };
 
-        const getEditorOptions = function() {
+        const getEditorOptions = function () {
             const editorOptions = {};
             const removePlugins = [];
-    
-            if(isHiddenPlugin('taotooltip')) {
-                removePlugins.push('taotooltip'); 
+
+            if (isHiddenPlugin('taotooltip')) {
+                removePlugins.push('taotooltip');
             }
 
             editorOptions.removePlugins = removePlugins.join(',');
             return Object.assign({}, defaultEditorOptions, editorOptions);
-        }
-        
+        };
+
         if (!htmlEditor.hasEditor($editableContainer)) {
             htmlEditor.buildEditor($editableContainer, getEditorOptions());
         }
@@ -72,6 +71,30 @@ define([
         htmlEditor.destroyEditor(this.widget.$container);
     };
 
+    const changeCallbacks = function (widget) {
+        return {
+            textBlockCssClass: function (element, value) {
+                let $wrap = widget.$container.find(`.${wrapperCls}`);
+
+                value = value.trim();
+                if (value === wrapperCls) {
+                    value = '';
+                }
+
+                if (!$wrap.length) {
+                    $wrap = widget.$container.find('[data-html-editable="true"]').wrapInner('<div />').children();
+                }
+
+                $wrap.attr('class', `${wrapperCls} ${value}`);
+            },
+            scrolling: function (element, value) {
+                itemScrollingMethods.wrapContent(widget, value, 'inner');
+            },
+            scrollingHeight: function (element, value) {
+                itemScrollingMethods.setScrollingHeight(widget.$container.find(`.${wrapperCls}`), value);
+            }
+        };
+    };
     TextActive.prototype.initForm = function () {
         const widget = this.widget,
             $form = widget.$form,
@@ -93,31 +116,6 @@ define([
         formElement.setChangeCallbacks($form, widget.element, changeCallbacks(widget));
 
         itemScrollingMethods.initSelect($form, isScrolling, selectedHeight);
-    };
-
-    const changeCallbacks = function (widget) {
-        return {
-            textBlockCssClass: function (element, value) {
-                let $wrap = widget.$container.find(`.${wrapperCls}`);
-
-                value = value.trim();
-                if (value === wrapperCls) {
-                    value = '';
-                }
-
-                if (!$wrap.length) {
-                    $wrap = widget.$container.find('[data-html-editable="true"]').wrapInner('<div />').children();
-                }
-
-                $wrap.attr('class', wrapperCls + ' ' + value);
-            },
-            scrolling: function (element, value) {
-                itemScrollingMethods.wrapContent(widget, value, 'inner');
-            },
-            scrollingHeight: function (element, value) {
-                itemScrollingMethods.setScrollingHeight(widget.$container.find(`.${wrapperCls}`), value);
-            }
-        };
     };
 
     return TextActive;

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -54,7 +54,7 @@ define([
             const editorOptions = {};
             const removePlugins = [];
     
-            if(features.isVisible(taoTooltipOption)) {
+            if(!features.isVisible(taoTooltipOption)) {
                 removePlugins.push('taotooltip'); 
             }
             editorOptions.removePlugins = removePlugins.join(',');

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -23,8 +23,7 @@ define([
 
     const wrapperCls = 'custom-text-box';
 
-    const isHiddenPlugin = pluginName =>
-        !features.isVisible(`taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins/${pluginName}`);
+    const isHiddenPlugin = pluginName => !features.isVisible(`taoQtiItem/creator/content/plugin/${pluginName}`);
 
     const registeredPluginNames = ckeditor.plugins.registered && Object.keys(ckeditor.plugins.registered);
     const TextActive = stateFactory.extend(

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -12,8 +12,11 @@ define([
 
     const wrapperCls = 'custom-text-box';
 
-    const taoTooltipOption = 'TaoTooltip';
-
+    const pluginConfigurationKey = 'taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins';
+  
+    const isHiddenPlugin = (pluginName) => {
+        return !features.isVisible(`taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins/${pluginName}`);
+    }
     const TextActive = stateFactory.extend(
         Active,
         function () {
@@ -54,9 +57,10 @@ define([
             const editorOptions = {};
             const removePlugins = [];
     
-            if(!features.isVisible(taoTooltipOption)) {
+            if(isHiddenPlugin('taotooltip')) {
                 removePlugins.push('taotooltip'); 
             }
+
             editorOptions.removePlugins = removePlugins.join(',');
             return Object.assign({}, defaultEditorOptions, editorOptions);
         }

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -1,4 +1,5 @@
 define([
+    'services/features',
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/static/states/Active',
     'taoQtiItem/qtiCreator/editor/ckEditor/htmlEditor',
@@ -6,10 +7,12 @@ define([
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/static/text',
     'taoQtiItem/qtiCreator/widgets/static/helpers/itemScrollingMethods'
-], function (stateFactory, Active, htmlEditor, content, formElement, formTpl, itemScrollingMethods) {
+], function (features, stateFactory, Active, htmlEditor, content, formElement, formTpl, itemScrollingMethods) {
     'use strict';
 
     const wrapperCls = 'custom-text-box';
+
+    const taoTooltipOption = 'TaoTooltip';
 
     const TextActive = stateFactory.extend(
         Active,
@@ -31,22 +34,35 @@ define([
 
         $editableContainer.attr('data-html-editable-container', true);
 
-        if (!htmlEditor.hasEditor($editableContainer)) {
-            htmlEditor.buildEditor($editableContainer, {
-                change: function (data) {
-                    changeCallback.call(this, data);
-                    if (!data) {
-                        widget.$form.find('[name="textBlockCssClass"]').val('');
-                    }
-                },
-                blur: function () {
-                    widget.changeState('sleep');
-                },
-                data: {
-                    widget: widget,
-                    container: container
+        const defaultEditorOptions = {
+            change: function (data) {
+                changeCallback.call(this, data);
+                if (!data) {
+                    widget.$form.find('[name="textBlockCssClass"]').val('');
                 }
-            });
+            },
+            blur: function () {
+                widget.changeState('sleep');
+            },
+            data: {
+                widget: widget,
+                container: container
+            }
+        }
+
+        const getEditorOptions = function() {
+            const editorOptions = {};
+            const removePlugins = [];
+    
+            if(features.isVisible(taoTooltipOption)) {
+                removePlugins.push('taotooltip'); 
+            }
+            editorOptions.removePlugins = removePlugins.join(',');
+            return Object.assign({}, defaultEditorOptions, editorOptions);
+        }
+        
+        if (!htmlEditor.hasEditor($editableContainer)) {
+            htmlEditor.buildEditor($editableContainer, getEditorOptions());
         }
     };
 

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -1,4 +1,5 @@
 define([
+    'ckeditor',
     'services/features',
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/static/states/Active',
@@ -7,13 +8,25 @@ define([
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/static/text',
     'taoQtiItem/qtiCreator/widgets/static/helpers/itemScrollingMethods'
-], function (features, stateFactory, Active, htmlEditor, content, formElement, formTpl, itemScrollingMethods) {
+], function (
+    ckeditor,
+    features,
+    stateFactory,
+    Active,
+    htmlEditor,
+    content,
+    formElement,
+    formTpl,
+    itemScrollingMethods
+) {
     'use strict';
 
     const wrapperCls = 'custom-text-box';
 
     const isHiddenPlugin = pluginName =>
         !features.isVisible(`taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins/${pluginName}`);
+
+    const registeredPluginNames = ckeditor.plugins.registered && Object.keys(ckeditor.plugins.registered);
     const TextActive = stateFactory.extend(
         Active,
         function () {
@@ -54,9 +67,11 @@ define([
             const editorOptions = {};
             const removePlugins = [];
 
-            if (isHiddenPlugin('taotooltip')) {
-                removePlugins.push('taotooltip');
-            }
+            registeredPluginNames.forEach(pluginName => {
+                if (isHiddenPlugin(pluginName)) {
+                    removePlugins.push('taotooltip');
+                }
+            });
 
             editorOptions.removePlugins = removePlugins.join(',');
             return Object.assign({}, defaultEditorOptions, editorOptions);

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -11,8 +11,6 @@ define([
     'use strict';
 
     const wrapperCls = 'custom-text-box';
-
-    const pluginConfigurationKey = 'taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins';
   
     const isHiddenPlugin = (pluginName) => {
         return !features.isVisible(`taoQtiItem/qtiCreator/widgets/static/text/ckeditor/plugins/${pluginName}`);

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -41,7 +41,7 @@ define([
                     widget.$form.find('[name="textBlockCssClass"]').val('');
                 }
             },
-            blur: function () {
+            blur() {
                 widget.changeState('sleep');
             },
             data: {

--- a/views/js/qtiCreator/widgets/static/text/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Active.js
@@ -35,7 +35,7 @@ define([
         $editableContainer.attr('data-html-editable-container', true);
 
         const defaultEditorOptions = {
-            change: function (data) {
+            change(data) {
                 changeCallback.call(this, data);
                 if (!data) {
                     widget.$form.find('[name="textBlockCssClass"]').val('');


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-2114

### Description

Tooltip option needs to be removed based on config provided by backend

### How to test

[Composer file](https://github.com/oat-sa/kitchen-playground/blob/tao/community-202205/files/delivery/composer.json) been used for local installation of currentGen: 

On your installation of currentGen add the following lines to the config file `config/tao/client_lib_config_registry.conf.php` : 

```
        'services/features' => array(
            'visibility' => array(
                'taoQtiItem/creator/content/plugin/taotooltip' => 'hide'
            )
        )
```



<img width="336" alt="Screenshot 2022-04-14 at 19 28 12" src="https://user-images.githubusercontent.com/10635482/163432961-b767d8d2-f2aa-4616-a926-778b7c8ee497.png">

 - Enter authoring, try to edit some text i.e. interaction prompt. Check tooltip icon is not in the list of tools
 - Try to update the config file like `'taoQtiItem/creator/content/plugin/taotooltip' => 'show'` check the Tooltip otion is back
 - Try to remove the line  `'taoQtiItem/creator/content/plugin/taotooltip' => 'show'`  from config file check the Tooltip option is present
