### PR TITLE
fix: inlineCHoice int. responses not aligned when initially saved LTR

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/Widget.js
@@ -47,7 +47,7 @@ define([
 
     InlineChoiceInteractionWidget.renderChoice = function(choice, shuffleChoice){
 
-        const dir = choice.getRootElement().getBody().getAttributes().dir;
+        const dir = choice.getRootElement().getBody().attributes.dir;
         const tplData = {
             tag : choice.qtiClass,
             serial : choice.serial,

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.0.tgz",
-            "integrity": "sha512-OhZxKifjaqBcUe+zvSzkqAdt6wxyf1ceZwQI0w+jFd3H3mVqpWK+HRfKa98qGHXc5kogUG7U3b/njILI4UV5yQ=="
+            "version": "github:oat-sa/tao-item-runner-qti-fe#4b307413d1c9dd07091c07e9eb9c412282479c4d",
+            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2123/inlinechoice-interaction-responses-not-aligned-when-initially-saved-LTR"
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "github:oat-sa/tao-item-runner-qti-fe#4b307413d1c9dd07091c07e9eb9c412282479c4d",
-            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2123/inlinechoice-interaction-responses-not-aligned-when-initially-saved-LTR"
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.2.tgz",
+            "integrity": "sha512-C2n/xilUr9X9p4p7sBXEOmaZAKK4KFjm++HmwP+DoMF4l7LdWZERB7EtVMD0GivDQSoWTX73pS0KEe7JDZoDBQ=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2123/inlinechoice-interaction-responses-not-aligned-when-initially-saved-LTR"
+        "@oat-sa/tao-item-runner-qti": "1.1.2"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "1.1.0"
+        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2123/inlinechoice-interaction-responses-not-aligned-when-initially-saved-LTR"
     }
 }


### PR DESCRIPTION
Related to Issue: https://oat-sa.atlassian.net/browse/AUT-2123

Fix inline interaction responses box not aligned correctly for RTL when first saved as LTR

**SETPS to test:**
• Checkout to branch: fix/fix/AUT-2123/inlinechoice-interaction-responses-not-aligned-when-initially-saved-LTR
•Create an item
•Add a text block.
•Add an Inline Choice interaction.
•Click save with default language (LTR)
•Re-open and change language to RTL

**ACTUAL RESULT:**
the widget with the choices doesn't show the RTL alignment as the rest of the item.

**EXPECTED RESULT:**
When opening responses box alignment should be RTL in this case

**CHANGES:**
changed the way to get the attr `dir` as where is stored is an object first and passes to be an array after hence it was not retrieved correctly in some cases.
![image](https://user-images.githubusercontent.com/60346520/163803833-ce4aaf28-6774-4f76-aba9-3da9b767b850.png)
