### PR TITLE
Toggle feature in item authoring property panels

### DIFF
--- a/views/js/qtiCreator/tpl/forms/interactions/associate.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/associate.tpl
@@ -1,4 +1,4 @@
-{{#if enabledFeatures.shuffle}}
+{{#if enabledFeatures.shuffleChoices}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>

--- a/views/js/qtiCreator/tpl/forms/interactions/associate.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/associate.tpl
@@ -1,3 +1,4 @@
+{{#if enabledFeatures.shuffle}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>
@@ -9,6 +10,7 @@
 {{__ "If the shuffle attribute is true then the delivery engine will randomize the order in which the choices are initially presented. However each choice may be “shuffled” of “fixed” individually."}}
     </span>
 </div>
+{{/if}}
 
 <div class="panel min-max-panel">
     <h3>{{__ "Number of associations"}}</h3>

--- a/views/js/qtiCreator/tpl/forms/interactions/choice.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/choice.tpl
@@ -50,6 +50,7 @@
         {{__ 'If this box is checked the student will be able to eliminate choices.'}}
     </span>
 </div>
+{{#if enabledFeatures.shuffle}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>
@@ -61,7 +62,9 @@
         {{__ 'If the shuffle attribute is true then the delivery engine will randomize the order in which the choices are initially presented. However each choice may be "shuffled" of "fixed" individually.'}}
     </span>
 </div>
+{{/if}}
 <hr/>
+{{#if enabledFeatures.listStyle}}
 <div class="panel">
     <h3>{{__ "List Style"}}</h3>
     <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -71,9 +74,8 @@
 
     <select data-list-style/>
 </div>
-
-
 <hr/>
+{{/if}}
 <div class="panel">
     <h3>{{__ 'Orientation'}}</h3>
     <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/qtiCreator/tpl/forms/interactions/choice.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/choice.tpl
@@ -50,7 +50,7 @@
         {{__ 'If this box is checked the student will be able to eliminate choices.'}}
     </span>
 </div>
-{{#if enabledFeatures.shuffle}}
+{{#if enabledFeatures.shuffleChoices}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>

--- a/views/js/qtiCreator/tpl/forms/interactions/extendedText.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/extendedText.tpl
@@ -8,57 +8,61 @@
     	{{/each}}
     </select>
 </div>
-<hr>
-<div class="panel">
-    <h3 class="full-width">{{__ "Constraints"}}</h3>
-    <select name="constraint" class="select2" data-has-search="false">
-        {{#each constraints}}
-            <option value="{{@key}}" {{#if selected}}selected="selected"{{/if}}>{{label}}</option>
-        {{/each}}
-    </select>
+<div id="constraints">
+    <hr>
+    <div class="panel">
+        <h3 class="full-width">{{__ "Constraints"}}</h3>
+        <select name="constraint" class="select2" data-has-search="false">
+            {{#each constraints}}
+                <option value="{{@key}}" {{#if selected}}selected="selected"{{/if}}>{{label}}</option>
+            {{/each}}
+        </select>
+    </div>
+    <div class="panel extendedText">
+        {{!-- Let the user enter his own pattern --}}
+        <div class="constraint constraint-pattern" {{#unless constraints.pattern.selected}}style="display:none"{{/unless}}>
+            <label>
+                {{__ "Pattern"}}
+            </label>
+            <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <span class="tooltip-content">{{__ "If given, the pattern mask specifies a regular expression that the candidate's response must match in order to be considered valid"}}</span>
+            <input type="text" name="patternMask" value="{{#if patternMask}}{{patternMask}}{{/if}}"/>
+        </div>
+        {{!-- Use the patternMask w/ a regex controlled by thoses UI components --}}
+        <div class="constraint constraint-maxLength" {{#unless constraints.maxLength.selected}}style="display:none"{{/unless}}>
+            <label class="spinner">
+                {{__ "Max length"}}
+            </label>
+            <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <span class="tooltip-content">{{__ "We will use the patternMask to do this, to be compliant with the IMS standard"}}</span>
+            <input type="text" data-min="0" data-increment="1" class="incrementer" name="maxLength" {{#if maxLength}}value="{{maxLength}}"{{/if}} />
+        </div>
+        {{!-- Use the patternMask w/ a regex controlled by thoses UI components --}}
+        <div class="constraint constraint-maxWords" {{#unless constraints.maxWords.selected}}style="display:none"{{/unless}}>
+            <label class="spinner">
+                {{__ "Max words"}}
+            </label>
+            <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <span class="tooltip-content">{{__ "We will use the patternMask to do this, to be compliant with the IMS standard"}}</span>
+            <input type="text" data-min="0" data-increment="1" class="incrementer" name="maxWords" {{#if maxWords}}value="{{maxWords}}"{{/if}}/>
+        </div>
+    </div>
 </div>
-<div class="panel extendedText">
-    {{!-- Let the user enter his own pattern --}}
-    <div class="constraint constraint-pattern" {{#unless constraints.pattern.selected}}style="display:none"{{/unless}}>
-        <label>
-            {{__ "Pattern"}}
-        </label>
-        <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-        <span class="tooltip-content">{{__ "If given, the pattern mask specifies a regular expression that the candidate's response must match in order to be considered valid"}}</span>
-        <input type="text" name="patternMask" value="{{#if patternMask}}{{patternMask}}{{/if}}"/>
-    </div>
-    {{!-- Use the patternMask w/ a regex controlled by thoses UI components --}}
-    <div class="constraint constraint-maxLength" {{#unless constraints.maxLength.selected}}style="display:none"{{/unless}}>
+<div id="recommendations">
+    <hr>
+    <div class="panel extendedText">
+        <h3 class="full-width">{{__ "Recommendations"}}</h3>
         <label class="spinner">
-            {{__ "Max length"}}
+            {{__ "Length"}}
         </label>
         <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-        <span class="tooltip-content">{{__ "We will use the patternMask to do this, to be compliant with the IMS standard"}}</span>
-        <input type="text" data-min="0" data-increment="1" class="incrementer" name="maxLength" {{#if maxLength}}value="{{maxLength}}"{{/if}} />
-    </div>
-    {{!-- Use the patternMask w/ a regex controlled by thoses UI components --}}
-    <div class="constraint constraint-maxWords" {{#unless constraints.maxWords.selected}}style="display:none"{{/unless}}>
-        <label class="spinner">
-            {{__ "Max words"}}
+        <span class="tooltip-content">{{__ "Provides a hint to the candidate as to the expected overall length of the desired response measured in number of characters."}}</span>
+        <input type="text" data-min="0" data-increment="1" class="incrementer" name="expectedLength" value="{{#if expectedLength}}{{expectedLength}}{{/if}}"/>
+        <label for="" class="spinner">
+            {{__ "Lines"}}
         </label>
         <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-        <span class="tooltip-content">{{__ "We will use the patternMask to do this, to be compliant with the IMS standard"}}</span>
-        <input type="text" data-min="0" data-increment="1" class="incrementer" name="maxWords" {{#if maxWords}}value="{{maxWords}}"{{/if}}/>
+        <span class="tooltip-content">{{__ "Provides a hint to the candidate as to the expected number of lines of input required. A line is expected to have about 72 characters."}}</span>
+        <input type="text" class="incrementer" data-min="0" data-increment="1" name="expectedLines" value="{{#if expectedLines}}{{expectedLines}}{{/if}}">
     </div>
-</div>
-<hr>
-<div class="panel extendedText">
-    <h3 class="full-width">{{__ "Recommendations"}}</h3>
-    <label class="spinner">
-        {{__ "Length"}}
-    </label>
-    <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-    <span class="tooltip-content">{{__ "Provides a hint to the candidate as to the expected overall length of the desired response measured in number of characters."}}</span>
-    <input type="text" data-min="0" data-increment="1" class="incrementer" name="expectedLength" value="{{#if expectedLength}}{{expectedLength}}{{/if}}"/>
-    <label for="" class="spinner">
-        {{__ "Lines"}}
-    </label>
-    <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-    <span class="tooltip-content">{{__ "Provides a hint to the candidate as to the expected number of lines of input required. A line is expected to have about 72 characters."}}</span>
-    <input type="text" class="incrementer" data-min="0" data-increment="1" name="expectedLines" value="{{#if expectedLines}}{{expectedLines}}{{/if}}">
 </div>

--- a/views/js/qtiCreator/tpl/forms/interactions/gapMatch.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/gapMatch.tpl
@@ -1,4 +1,4 @@
-{{#if enabledFeatures.shuffle}}
+{{#if enabledFeatures.shuffleChoices}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>

--- a/views/js/qtiCreator/tpl/forms/interactions/gapMatch.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/gapMatch.tpl
@@ -1,3 +1,4 @@
+{{#if enabledFeatures.shuffle}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>
@@ -9,3 +10,4 @@
         {{__ 'If the shuffle attribute is true then the delivery engine will randomize the order in which the choices are initially presented. However each choice may be "shuffled" of "fixed" individually.'}}
     </span>
 </div>
+{{/if}}

--- a/views/js/qtiCreator/tpl/forms/interactions/inlineChoice.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/inlineChoice.tpl
@@ -1,4 +1,4 @@
-{{#if enabledFeatures.shuffle}}
+{{#if enabledFeatures.shuffleChoices}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>

--- a/views/js/qtiCreator/tpl/forms/interactions/inlineChoice.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/inlineChoice.tpl
@@ -1,3 +1,4 @@
+{{#if enabledFeatures.shuffle}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>
@@ -9,6 +10,7 @@
 {{__ "If the shuffle attribute is true then the delivery engine will randomize the order in which the choices are initially presented. However each choice may be “shuffled” of “fixed” individually."}}
     </span>
 </div>
+{{/if}}
 <div class="panel">
     <label>
         <input name="required" type="checkbox" {{#if required}}checked="checked"{{/if}}/>

--- a/views/js/qtiCreator/tpl/forms/interactions/order.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/order.tpl
@@ -1,4 +1,4 @@
-{{#if enabledFeatures.shuffle}}
+{{#if enabledFeatures.shuffleChoices}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>

--- a/views/js/qtiCreator/tpl/forms/interactions/order.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/order.tpl
@@ -1,3 +1,4 @@
+{{#if enabledFeatures.shuffle}}
 <div class="panel">
     <label>
         <input name="shuffle" type="checkbox" {{#if shuffle}}checked="checked"{{/if}}/>
@@ -9,13 +10,13 @@
         {{__ 'If the shuffle attribute is true then the delivery engine will randomize the order in which the choices are initially presented. However each choice may be "shuffled" of "fixed" individually.'}}
     </span>
 </div>
-
+{{/if}}
 <hr/>
 <div class="panel min-max-panel">
     <h3>{{__ "Allowed choices"}}</h3>
 </div>
+{{#if enabledFeatures.orientation}}
 <hr/>
-
 <div class="panel">
     <h3>{{__ 'Orientation'}}</h3>
     <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -36,3 +37,4 @@
         </label>
     </div>
 </div>
+{{/if}}

--- a/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
@@ -48,7 +48,7 @@ define([
         $form.html(formTpl({
             shuffle : !!interaction.attr('shuffle'),
             enabledFeatures: {
-                shuffleChoices: features('taoQtiItem/qtiCreator/widgets/interactions/associateInteraction/shuffleChoices')
+                shuffleChoices: features('taoQtiItem/creator/interaction/associate/property/shuffle')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
@@ -48,7 +48,7 @@ define([
         $form.html(formTpl({
             shuffle : !!interaction.attr('shuffle'),
             enabledFeatures: {
-                shuffle: false
+                shuffleChoices: features('taoQtiItem/qtiCreator/widgets/interactions/associateInteraction/shuffleChoices')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
@@ -23,8 +23,18 @@ define([
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'taoQtiItem/qtiCreator/widgets/component/minMax/minMax',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/associate',
-    'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter'
-], function(_, stateFactory, Question, formElement, minMaxComponentFactory, formTpl, sizeAdapter){
+    'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter',
+    'services/features'
+], function (
+    _, 
+    stateFactory, 
+    Question, 
+    formElement, 
+    minMaxComponentFactory, 
+    formTpl, 
+    sizeAdapter, 
+    features
+) {
     'use strict';
 
     var AssociateInteractionStateQuestion = stateFactory.extend(Question);
@@ -36,7 +46,10 @@ define([
        var interaction = this.widget.element;
 
         $form.html(formTpl({
-            shuffle : !!interaction.attr('shuffle')
+            shuffle : !!interaction.attr('shuffle'),
+            enabledFeatures: {
+                shuffle: false
+            }
         }));
 
         minMaxComponentFactory($form.find('.min-max-panel'), {

--- a/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/associateInteraction/states/Question.js
@@ -48,7 +48,7 @@ define([
         $form.html(formTpl({
             shuffle : !!interaction.attr('shuffle'),
             enabledFeatures: {
-                shuffleChoices: features('taoQtiItem/creator/interaction/associate/property/shuffle')
+                shuffleChoices: features.isVisible('taoQtiItem/creator/interaction/associate/property/shuffle')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -193,8 +193,8 @@ define([
                 horizontal: interaction.attr('orientation') === 'horizontal',
                 eliminable: /\beliminable\b/.test(interaction.attr('class')),
                 enabledFeatures: {
-                    shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/choiceInteraction/shuffleChoices'),
-                    listStyle: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/choiceInteraction/listStyle')
+                    shuffleChoices: features.isVisible('taoQtiItem/creator/interaction/choice/property/shuffle'),
+                    listStyle: features.isVisible('taoQtiItem/creator/interaction/choice/property/listStyle')
                 }
             })
         );

--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -192,10 +192,9 @@ define([
                 shuffle: !!interaction.attr('shuffle'),
                 horizontal: interaction.attr('orientation') === 'horizontal',
                 eliminable: /\beliminable\b/.test(interaction.attr('class')),
-                // TODO: use features service to retreive feature state
                 enabledFeatures: {
-                    shuffle: false,
-                    listStyle: false
+                    shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/choiceInteraction/shuffleChoices'),
+                    listStyle: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/choiceInteraction/listStyle')
                 }
             })
         );

--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -26,8 +26,19 @@ define([
     'taoQtiItem/qtiCreator/widgets/component/minMax/minMax',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/choice',
     'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter',
+    'services/features',
     'ui/liststyler'
-], function (_, __, stateFactory, Question, formElement, minMaxComponentFactory, formTpl, sizeAdapter) {
+], function (
+    _,
+    __,
+    stateFactory,
+    Question,
+    formElement,
+    minMaxComponentFactory,
+    formTpl,
+    sizeAdapter,
+    features
+) {
     'use strict';
 
     const exitState = function exitState() {
@@ -180,7 +191,12 @@ define([
                 constraints,
                 shuffle: !!interaction.attr('shuffle'),
                 horizontal: interaction.attr('orientation') === 'horizontal',
-                eliminable: /\beliminable\b/.test(interaction.attr('class'))
+                eliminable: /\beliminable\b/.test(interaction.attr('class')),
+                // TODO: use features service to retreive feature state
+                enabledFeatures: {
+                    shuffle: false,
+                    listStyle: false
+                }
             })
         );
 

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -80,7 +80,7 @@ define([
             xhtml : {label : __('Rich text'), selected : false}
         };
 
-        if (features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/extendedTextInteraction/formats/preFormatted')) {
+        if (features.isVisible('taoQtiItem/creator/interaction/extendedText/property/preFormatted')) {
             formats.preformatted = {
                 label : __('Pre-formatted text'),
                 selected : false
@@ -167,10 +167,10 @@ define([
             renderer.render(interaction);
 
             if (format === 'xhtml') {
-                if (!features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/extendedTextInteraction/constraints/xhtml')) {
+                if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints')) {
                     $constraintsBlock.hide();
                 }
-                if (!features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/extendedTextInteraction/recommendations/xhtml')) {
+                if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations')) {
                     $recommendationsBlock.hide();
                 }
             } else if (previousFormat === 'xhtml') {

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -147,6 +147,15 @@ define([
         $constraintsBlock = $form.find('#constraints');
         $recommendationsBlock = $form.find('#recommendations');
 
+        if (format === 'xhtml') {
+            if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints')) {
+                $constraintsBlock.hide();
+            }
+            if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations')) {
+                $recommendationsBlock.hide();
+            }
+        }
+
         //  init data change callbacks
         var callbacks = {};
 

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -173,7 +173,7 @@ define([
                 if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations')) {
                     $recommendationsBlock.hide();
                 }
-            } else if (previousFormat === 'xhtml') {
+            } else {
                 $constraintsBlock.show();
                 $recommendationsBlock.show();
             }

--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -25,8 +25,21 @@ define([
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
     'taoQtiItem/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction',
     'taoQtiItem/qtiCommonRenderer/helpers/patternMask',
-    'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/extendedText'
-], function($, _, __, module, stateFactory, Question, formElement, renderer, patternMaskHelper, formTpl){
+    'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/extendedText',
+    'services/features'
+], function(
+    $,
+    _,
+    __,
+    module,
+    stateFactory,
+    Question,
+    formElement,
+    renderer,
+    patternMaskHelper,
+    formTpl,
+    features
+) {
     'use strict';
 
     var config = module.config();
@@ -49,6 +62,8 @@ define([
             $form = _widget.$form,
             $original = _widget.$original,
             $inputs,
+            $constraintsBlock,
+            $recommendationsBlock,
             interaction = _widget.element,
             isMathEntry = interaction.attr('data-math-entry') === 'true',
             format = interaction.attr('format'),
@@ -62,9 +77,15 @@ define([
 
         var formats = {
             plain : {label : __('Plain text'), selected : false},
-            preformatted : {label : __('Pre-formatted text'), selected : false},
             xhtml : {label : __('Rich text'), selected : false}
         };
+
+        if (features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/extendedTextInteraction/formats/preFormatted')) {
+            formats.preformatted = {
+                label : __('Pre-formatted text'),
+                selected : false
+            };
+        }
 
         if (config.hasMath) {
             formats.math = {label : __('Rich text + math'), selected : false};
@@ -123,6 +144,8 @@ define([
             maxWords : $form.find('[name="maxWords"]'),
             patternMask : $form.find('[name="patternMask"]')
         };
+        $constraintsBlock = $form.find('#constraints');
+        $recommendationsBlock = $form.find('#recommendations');
 
         //  init data change callbacks
         var callbacks = {};
@@ -142,6 +165,18 @@ define([
             interaction.attr('format', format);
             interaction.attr('data-math-entry', isMath ? 'true' : 'false');
             renderer.render(interaction);
+
+            if (format === 'xhtml') {
+                if (!features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/extendedTextInteraction/constraints/xhtml')) {
+                    $constraintsBlock.hide();
+                }
+                if (!features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/extendedTextInteraction/recommendations/xhtml')) {
+                    $recommendationsBlock.hide();
+                }
+            } else if (previousFormat === 'xhtml') {
+                $constraintsBlock.show();
+                $recommendationsBlock.show();
+            }
 
             if (format !== 'xhtml' && previousFormat === 'xhtml') {
                 if (typeof correctResponse[0] !== 'undefined') {

--- a/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
@@ -278,7 +278,7 @@ define([
         $form.html(formTpl({
             shuffle : !!interaction.attr('shuffle'),
             enabledFeatures: {
-                shuffle: false
+                shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/gapMatchInteraction/shuffleChoices')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
@@ -30,7 +30,8 @@ define([
     'taoQtiItem/qtiCreator/model/choices/GapText',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/gapMatch',
     'tpl!taoQtiItem/qtiCreator/tpl/toolbars/gap-create',
-    'tpl!taoQtiItem/qtiCreator/tpl/toolbars/htmlEditorTrigger'
+    'tpl!taoQtiItem/qtiCreator/tpl/toolbars/htmlEditorTrigger',
+    'services/features'
 ], function(
     $,
     _,
@@ -46,7 +47,8 @@ define([
     Choice,
     formTpl,
     newGapTpl,
-    toolbarTpl
+    toolbarTpl,
+    features
 ){
     'use strict';
 
@@ -274,7 +276,10 @@ define([
             interaction = _widget.element;
 
         $form.html(formTpl({
-            shuffle : !!interaction.attr('shuffle')
+            shuffle : !!interaction.attr('shuffle'),
+            enabledFeatures: {
+                shuffle: false
+            }
         }));
 
         formElement.initWidget($form);

--- a/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
@@ -278,7 +278,7 @@ define([
         $form.html(formTpl({
             shuffle : !!interaction.attr('shuffle'),
             enabledFeatures: {
-                shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/gapMatchInteraction/shuffleChoices')
+                shuffleChoices: features.isVisible('taoQtiItem/creator/interaction/gapMatch/property/shuffle')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/states/Question.js
@@ -63,7 +63,7 @@ define([
             shuffle : !!interaction.attr('shuffle'),
             required : !!interaction.attr('required'),
             enabledFeatures: {
-                shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/inlineChoiceInteraction/shuffleChoices')
+                shuffleChoices: features.isVisible('taoQtiItem/creator/interaction/inlineChoice/property/shuffle')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/states/Question.js
@@ -3,8 +3,9 @@ define([
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/interactions/states/Question',
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
-    'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/inlineChoice'
-], function($, stateFactory, Question, formElement, formTpl){
+    'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/inlineChoice',
+    'services/features'
+], function($, stateFactory, Question, formElement, formTpl, features){
 
     var InlineChoiceInteractionStateQuestion = stateFactory.extend(Question, function(){
 
@@ -60,7 +61,10 @@ define([
 
         $form.html(formTpl({
             shuffle : !!interaction.attr('shuffle'),
-            required : !!interaction.attr('required')
+            required : !!interaction.attr('required'),
+            enabledFeatures: {
+                shuffle: false
+            }
         }));
 
         formElement.initWidget($form);

--- a/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/inlineChoiceInteraction/states/Question.js
@@ -63,7 +63,7 @@ define([
             shuffle : !!interaction.attr('shuffle'),
             required : !!interaction.attr('required'),
             enabledFeatures: {
-                shuffle: false
+                shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/inlineChoiceInteraction/shuffleChoices')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
@@ -57,8 +57,8 @@ define([
             shuffle : !!interaction.attr('shuffle'),
             horizontal : interaction.attr('orientation') === 'horizontal',
             enabledFeatures: {
-                shuffle: false,
-                orientation: false
+                shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/orderInteraction/shuffleChoices'),
+                orientation: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/orderInteraction/orientation')
             }
         }));
 

--- a/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
@@ -25,8 +25,18 @@ define([
     'taoQtiItem/qtiCreator/widgets/component/minMax/minMax',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/order',
     'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter',
+    'services/features',
     'ui/liststyler'
-], function(_, stateFactory, Question, formElement, minMaxComponentFactory, formTpl, sizeAdapter){
+], function (
+    _, 
+    stateFactory, 
+    Question, 
+    formElement, 
+    minMaxComponentFactory, 
+    formTpl,
+    sizeAdapter,
+    features
+) {
     'use strict';
 
     var OrderInteractionStateQuestion = stateFactory.extend(Question);
@@ -45,7 +55,11 @@ define([
 
         $form.html(formTpl({
             shuffle : !!interaction.attr('shuffle'),
-            horizontal : interaction.attr('orientation') === 'horizontal'
+            horizontal : interaction.attr('orientation') === 'horizontal',
+            enabledFeatures: {
+                shuffle: false,
+                orientation: false
+            }
         }));
 
         //usual min/maxChoices control

--- a/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/orderInteraction/states/Question.js
@@ -57,8 +57,8 @@ define([
             shuffle : !!interaction.attr('shuffle'),
             horizontal : interaction.attr('orientation') === 'horizontal',
             enabledFeatures: {
-                shuffleChoices: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/orderInteraction/shuffleChoices'),
-                orientation: features.isVisible('taoQtiItem/qtiCreator/widgets/interactions/orderInteraction/orientation')
+                shuffleChoices: features.isVisible('taoQtiItem/creator/interaction/order/property/shuffle'),
+                orientation: features.isVisible('taoQtiItem/creator/interaction/order/property/orientation')
             }
         }));
 


### PR DESCRIPTION
# Description

Some features not supported by Solar need to be hidden from item authoring

## How to test

On your installation of currentGen add the following lines to the config file `config/tao/client_lib_config_registry.conf.php`:
```php
'services/features' => array(
    'visibility' => array(
        'taoQtiItem/creator/interaction/choice/property/shuffle' => 'hide',
        'taoQtiItem/creator/interaction/choice/property/listStyle' => 'hide',
        'taoQtiItem/creator/interaction/order/property/shuffle' => 'hide',
        'taoQtiItem/creator/interaction/order/property/orientation' => 'hide',
        'taoQtiItem/creator/interaction/associate/property/shuffle' => 'hide',
        'taoQtiItem/creator/interaction/gapMatch/property/shuffle' => 'hide',
        'taoQtiItem/creator/interaction/inlineChoice/property/shuffle' => 'hide',
        'taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints' => 'hide',
        'taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations' => 'hide',
        'taoQtiItem/creator/interaction/extendedText/property/preFormatted' => 'hide'
    )
),
```

Then enter item authoring and try to create following interactions and check if these features are hidden