### PR TITLE
fix: PortableCustomInteraction renderer need function to use this

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "github:oat-sa/tao-item-runner-qti-fe#65a9e31f83fb826440b69c653d0bb33994d1c1f8",
-            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2151/pci-renderer"
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.3.tgz",
+            "integrity": "sha512-42PW0vcrrnB1oEpV61/fa5fd9z4MpdY8UUobkv7mYqLToopyf+9XxlxlV+xOrvLuinTR9L6Ahgr3ukdxaHk7Yw=="
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.2.tgz",
-            "integrity": "sha512-C2n/xilUr9X9p4p7sBXEOmaZAKK4KFjm++HmwP+DoMF4l7LdWZERB7EtVMD0GivDQSoWTX73pS0KEe7JDZoDBQ=="
+            "version": "github:oat-sa/tao-item-runner-qti-fe#65a9e31f83fb826440b69c653d0bb33994d1c1f8",
+            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2151/pci-renderer"
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "oat-sa/tao-item-runner-qti-fe#fix/AUT-2151/pci-renderer"
+        "@oat-sa/tao-item-runner-qti": "1.1.3"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "1.1.2"
+        "@oat-sa/tao-item-runner-qti": "oat-sa/tao-item-runner-qti-fe#fix/AUT-2151/pci-renderer"
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2151
**Depends on:** 
- [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/270

**Preconditions:**
Item with Math entry PCI with the picture in prompt added to the test
Test passed by TT or guest

**Steps to reproduce:**

- Go to results tab and select the test
- Click “View“ 
- Click “Review“

**Actual result:** Math entry PCI interaction is not displayed in Test Review mode. error pops-up. Error in console

**Expected result:** Math entry PCI interaction is displayed in Test Review mode without any errors.