### PR TITLE
fix: clean format only on paste

### DIFF
--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -72,9 +72,11 @@ define([
                     _widget.changeState('question');
                 }
             })
-            .on('input.qti-widget', function () {
-                // clean format of paste text
-                $(this).html($(this).text());
+            .on('input.qti-widget', function (e) {
+                if (e.originalEvent.inputType === 'insertFromPaste') {
+                    // clean format of paste text
+                    $(this).html($(this).text());
+                }
             });
     };
 

--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -78,6 +78,7 @@ define([
                     let offset;
                     if (window.getSelection) {
                         const range = window.getSelection().getRangeAt(0);
+                        // new range from div start up to pasted text
                         const preCaretRange = range.cloneRange();
                         preCaretRange.selectNodeContents(this);
                         preCaretRange.setEnd(range.endContainer, range.endOffset);

--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -74,7 +74,7 @@ define([
             })
             .on('input.qti-widget', function (e) {
                 if (e.originalEvent.inputType === 'insertFromPaste') {
-                    // save range and calculate offset for cursor
+                    // calculate offset for cursor
                     let offset;
                     if (window.getSelection) {
                         const range = window.getSelection().getRangeAt(0);

--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -75,10 +75,9 @@ define([
             .on('input.qti-widget', function (e) {
                 if (e.originalEvent.inputType === 'insertFromPaste') {
                     // save range and calculate offset for cursor
-                    let range;
                     let offset;
                     if (window.getSelection) {
-                        range = window.getSelection().getRangeAt(0);
+                        const range = window.getSelection().getRangeAt(0);
                         const preCaretRange = range.cloneRange();
                         preCaretRange.selectNodeContents(this);
                         preCaretRange.setEnd(range.endContainer, range.endOffset);
@@ -87,8 +86,13 @@ define([
                     // clean format of paste text
                     $(this).html($(this).text());
                     // set cursor after inserted text
-                    if (range) {
+                    if (offset) {
+                        const range = document.createRange();
+                        const sel = window.getSelection();
                         range.setStart(this.childNodes[0], offset);
+                        range.collapse(true);
+                        sel.removeAllRanges();
+                        sel.addRange(range);
                     }
                 }
             });

--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -74,8 +74,22 @@ define([
             })
             .on('input.qti-widget', function (e) {
                 if (e.originalEvent.inputType === 'insertFromPaste') {
+                    // save range and calculate offset for cursor
+                    let range;
+                    let offset;
+                    if (window.getSelection) {
+                        range = window.getSelection().getRangeAt(0);
+                        const preCaretRange = range.cloneRange();
+                        preCaretRange.selectNodeContents(this);
+                        preCaretRange.setEnd(range.endContainer, range.endOffset);
+                        offset = preCaretRange.toString().length;
+                    }
                     // clean format of paste text
                     $(this).html($(this).text());
+                    // set cursor after inserted text
+                    if (range) {
+                        range.setStart(this.childNodes[0], offset);
+                    }
                 }
             });
     };


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2161

Regression issue from https://github.com/oat-sa/extension-tao-itemqti/pull/2058 

1. Clear format only for paste event 
2. Set cursor after clean

**How to test:**
as an Author create new Item in LTR language, e.g. English
add A-Block with Inline choice to the item
expand Inline choice dropdown and edit choice options

**Actual**: text typing and pasting goes in RTL direction: 
**Expected:** text typing and pasting goes in LTR direction if LTR language is applied for the item