### PR TITLE
fix: resize Media interaction

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "github:oat-sa/tao-item-runner-qti-fe#13a51b44d5d67042d2a1eca353e71b121f46d35a",
+            "version": "github:oat-sa/tao-item-runner-qti-fe#89b293159156926982c154422ac79ccb0ae51ee6",
             "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2178/resize-media-interaction"
         }
     }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.3.tgz",
-            "integrity": "sha512-42PW0vcrrnB1oEpV61/fa5fd9z4MpdY8UUobkv7mYqLToopyf+9XxlxlV+xOrvLuinTR9L6Ahgr3ukdxaHk7Yw=="
+            "version": "github:oat-sa/tao-item-runner-qti-fe#13a51b44d5d67042d2a1eca353e71b121f46d35a",
+            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2178/resize-media-interaction"
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "github:oat-sa/tao-item-runner-qti-fe#89b293159156926982c154422ac79ccb0ae51ee6",
-            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2178/resize-media-interaction"
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.4.tgz",
+            "integrity": "sha512-udBFJgyOBh4dO9pX0hWhuJAJ3XEprewLKi9j3hg/AS9JH8Cud8NEfF0EKSUtHt75iy7s+ozC4PQP+malQ4irbQ=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "oat-sa/tao-item-runner-qti-fe#fix/AUT-2178/resize-media-interaction"
+        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2178/resize-media-interaction"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2178/resize-media-interaction"
+        "@oat-sa/tao-item-runner-qti": "1.1.4"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "1.1.3"
+        "@oat-sa/tao-item-runner-qti": "oat-sa/tao-item-runner-qti-fe#fix/AUT-2178/resize-media-interaction"
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2178
Depends on:

- [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/275

Regression after fix:
https://github.com/oat-sa/tao-item-runner-qti-fe/pull/262/files#diff-903b0c826874b1e9917b94ae77a002c935309dcab424c432a854d651e4ba339bR138-R140

**Solution:** move condition (if media interaction in old format == width in `px`, not in `%`) to `resize` function 

## Steps to reproduce: 

- Click the Items tab, create a new Item and click its "Authoring" button
- Drag and Drop a Media Interaction on the canvas
- Add the video file from Resource manager 
- Modify the Size value of Media Player and click outside the interaction area
- Observe the Media Interaction

**Actual result:** Media player adjusts to the size of Media Interaction container, video is displayed in the center on the black background
**Expected result:** Media Player can be resized independently from the size of the media interaction container