### PR TITLE
fix/AUT-2191/toggle-textcount-element

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/extendedTextInteraction/states/Question.js
@@ -61,53 +61,55 @@ define([
         var _widget = this.widget,
             $form = _widget.$form,
             $original = _widget.$original,
+            $container = _widget.$container,
             $inputs,
             $constraintsBlock,
             $recommendationsBlock,
+            $textCounter,
             interaction = _widget.element,
             isMathEntry = interaction.attr('data-math-entry') === 'true',
             format = interaction.attr('format'),
             patternMask = interaction.attr('patternMask'),
             expectedLength = parseInt(interaction.attr('expectedLength'), 10),
-            expectedLines = parseInt(interaction.attr('expectedLines'),10),
-            maxWords = parseInt(patternMaskHelper.parsePattern(patternMask,'words'),10),
-            maxChars = parseInt(patternMaskHelper.parsePattern(patternMask,'chars'),10),
+            expectedLines = parseInt(interaction.attr('expectedLines'), 10),
+            maxWords = parseInt(patternMaskHelper.parsePattern(patternMask, 'words'), 10),
+            maxChars = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10),
             $counterMaxWords = $('.text-counter-words > .count-max-words', $original),
             $counterMaxLength = $('.text-counter-chars > .count-max-length', $original);
 
         var formats = {
-            plain : {label : __('Plain text'), selected : false},
-            xhtml : {label : __('Rich text'), selected : false}
+            plain: { label: __('Plain text'), selected: false },
+            xhtml: { label: __('Rich text'), selected: false }
         };
 
         if (features.isVisible('taoQtiItem/creator/interaction/extendedText/property/preFormatted')) {
             formats.preformatted = {
-                label : __('Pre-formatted text'),
-                selected : false
+                label: __('Pre-formatted text'),
+                selected: false
             };
         }
 
         if (config.hasMath) {
-            formats.math = {label : __('Rich text + math'), selected : false};
+            formats.math = { label: __('Rich text + math'), selected: false };
         }
 
         var constraints = {
-            none : {label : __("None"), selected : true},
-            maxLength : {label : __("Max Length"), selected : false},
-            maxWords : {label : __("Max Words"), selected : false},
-            pattern : {label : __("Pattern"), selected : false}
+            none: { label: __('None'), selected: true },
+            maxLength: { label: __('Max Length'), selected: false },
+            maxWords: { label: __('Max Words'), selected: false },
+            pattern: { label: __('Pattern'), selected: false }
         };
 
         /**
          * Set the selected on the right items before sending it to the view for constraints
          */
-        if ( !isNaN(maxWords) && maxWords > 0) {
+        if (!isNaN(maxWords) && maxWords > 0) {
             constraints.none.selected = false;
             constraints.maxWords.selected = true;
-        }else if (!isNaN(maxChars) && maxChars > 0) {
+        } else if (!isNaN(maxChars) && maxChars > 0) {
             constraints.none.selected = false;
             constraints.maxLength.selected = true;
-        }else if( patternMask !== null && patternMask !== undefined && patternMask !== ""){
+        } else if (patternMask !== null && patternMask !== undefined && patternMask !== '') {
             constraints.none.selected = false;
             constraints.pattern.selected = true;
         }
@@ -119,19 +121,21 @@ define([
         /**
          * Set the selected on the right items before sending it to the view for formats
          */
-        if(formats[format]){
+        if (formats[format]) {
             formats[format].selected = true;
         }
 
-        $form.html(formTpl({
-            formats : formats,
-            patternMask : patternMask,
-            maxWords : maxWords,
-            maxLength : maxChars,
-            expectedLength : expectedLength,
-            expectedLines : expectedLines,
-            constraints : constraints
-        }));
+        $form.html(
+            formTpl({
+                formats: formats,
+                patternMask: patternMask,
+                maxWords: maxWords,
+                maxLength: maxChars,
+                expectedLength: expectedLength,
+                expectedLines: expectedLines,
+                constraints: constraints
+            })
+        );
 
         if (!maxWords && !maxChars) {
             $('.text-counter', $original).hide();
@@ -140,12 +144,13 @@ define([
         formElement.initWidget($form);
 
         $inputs = {
-            maxLength : $form.find('[name="maxLength"]'),
-            maxWords : $form.find('[name="maxWords"]'),
-            patternMask : $form.find('[name="patternMask"]')
+            maxLength: $form.find('[name="maxLength"]'),
+            maxWords: $form.find('[name="maxWords"]'),
+            patternMask: $form.find('[name="patternMask"]')
         };
         $constraintsBlock = $form.find('#constraints');
         $recommendationsBlock = $form.find('#recommendations');
+        $textCounter = $container.find('.text-counter');
 
         if (format === 'xhtml') {
             if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints')) {
@@ -160,7 +165,7 @@ define([
         var callbacks = {};
 
         // -- format Callback
-        callbacks.format = function(interaction, attrValue){
+        callbacks.format = function (interaction, attrValue) {
             var response = interaction.getResponseDeclaration();
             var correctResponse = _.values(response.getCorrect());
             var previousFormat = interaction.attr('format');
@@ -178,13 +183,16 @@ define([
             if (format === 'xhtml') {
                 if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints')) {
                     $constraintsBlock.hide();
+                    $textCounter.hide();
                 }
                 if (!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations')) {
                     $recommendationsBlock.hide();
+                    $textCounter.hide();
                 }
             } else {
                 $constraintsBlock.show();
                 $recommendationsBlock.show();
+                $textCounter.show();
             }
 
             if (format !== 'xhtml' && previousFormat === 'xhtml') {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.0.tgz",
-            "integrity": "sha512-OhZxKifjaqBcUe+zvSzkqAdt6wxyf1ceZwQI0w+jFd3H3mVqpWK+HRfKa98qGHXc5kogUG7U3b/njILI4UV5yQ=="
+            "version": "github:oat-sa/tao-item-runner-qti-fe#4cab92f09018cb6f0f08c33cbb0010a36c074c94",
+            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2191/extendedtext-toggle-text-counter"
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "github:oat-sa/tao-item-runner-qti-fe#4cab92f09018cb6f0f08c33cbb0010a36c074c94",
-            "from": "github:oat-sa/tao-item-runner-qti-fe#fix/AUT-2191/extendedtext-toggle-text-counter"
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.1.9.tgz",
+            "integrity": "sha512-K1UejLXKVpw6/7jTyAHEtYIhTvWjf+Se5RltAPg5E2r2X/PFGEsaZ+ZAiIpYeUml7UDX+W34Ai2eUeZQPh/iuA=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "oat-sa/tao-item-runner-qti-fe#fix/AUT-2191/extendedtext-toggle-text-counter"
+        "@oat-sa/tao-item-runner-qti": "1.1.9"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "1.1.0"
+        "@oat-sa/tao-item-runner-qti": "oat-sa/tao-item-runner-qti-fe#fix/AUT-2191/extendedtext-toggle-text-counter"
     }
 }


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-2191

### Description

When switching format in extendedText interaction the textCount panel related to constraints/recommendations should be toggled if related feature is hidden from UI by configuration

### How to test

- Kitchen : https://test-hidefeatures.playground.kitchen.it.taocloud.org/
- Locally : should be tested along with https://github.com/oat-sa/tao-item-runner-qti-fe/pull/285
Disable xhtml constraints & recommendations in UI, use `config/tao/client_lib_config_registry.conf.php`
set 
```
                'taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints' => 'hide',
                'taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations' => 'hide',
```
in services/features section
Edit extendedText intearction, switch between PlainText and RichText modes, see the textCounter is toggled accordingly