### PR TITLE
feat: make hasMath false by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis" : ">=14.4.0",
-        "oat-sa/tao-core" : ">=49.3.0",
+        "oat-sa/tao-core" : ">=50.13.0 ",
         "oat-sa/extension-tao-item" : ">=11.20.1"
     },
     "autoload": {

--- a/controller/QtiCreator.php
+++ b/controller/QtiCreator.php
@@ -28,6 +28,7 @@ use core_kernel_classes_Resource;
 use oat\generis\model\data\event\ResourceUpdated;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\event\EventManager;
+use oat\tao\model\featureFlag\FeatureFlagConfigSwitcher;
 use oat\tao\model\http\HttpJsonResponseTrait;
 use oat\tao\model\media\MediaService;
 use oat\tao\model\TaoOntology;
@@ -270,8 +271,7 @@ class QtiCreator extends tao_actions_CommonModule
 
         $config = new CreatorConfig();
 
-        $ext = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiItem');
-        $creatorConfig = $ext->getConfig('qtiCreator');
+        $creatorConfig = $this->getFeatureFlagConfigSwitcher()->getSwitchedExtensionConfig('taoQtiItem', 'qtiCreator');
 
         if (is_array($creatorConfig)) {
             foreach ($creatorConfig as $prop => $value) {
@@ -338,6 +338,11 @@ class QtiCreator extends tao_actions_CommonModule
     private function getItemIdentifierValidator(): ItemIdentifierValidator
     {
         return $this->getServiceLocator()->getContainer()->get(ItemIdentifierValidator::class);
+    }
+
+    private function getFeatureFlagConfigSwitcher(): FeatureFlagConfigSwitcher
+    {
+        return $this->getServiceLocator()->getContainer()->get(FeatureFlagConfigSwitcher::class);
     }
 
     /**

--- a/install/scripts/ExtendConfigurationRegistry.php
+++ b/install/scripts/ExtendConfigurationRegistry.php
@@ -35,16 +35,18 @@ class ExtendConfigurationRegistry extends InstallAction
 
         $setValues = $registry->get(ExtendedTextInteractionConfigurationRegistry::ID);
 
-        return $setValues
-            ? Report::createSuccess(
+        if ($setValues) {
+            return Report::createSuccess(
                 sprintf(
                     "Applied the following configuration to `%s`\n%s",
                     ExtendedTextInteractionConfigurationRegistry::class,
                     json_encode($setValues)
                 )
-            )
-            : Report::createError(
-                sprintf('No values set to `%s`', ExtendedTextInteractionConfigurationRegistry::class)
             );
+        }
+
+        return Report::createError(
+            sprintf('No values set to `%s`', ExtendedTextInteractionConfigurationRegistry::class)
+        );
     }
 }

--- a/install/scripts/ExtendConfigurationRegistry.php
+++ b/install/scripts/ExtendConfigurationRegistry.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
+ */
+
+namespace oat\taoQtiItem\install\scripts;
+
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\reporting\Report;
+use oat\taoQtiItem\model\QtiCreator\ExtendedTextInteractionConfigurationRegistry;
+
+class ExtendConfigurationRegistry extends InstallAction
+{
+    public function __invoke($params): Report
+    {
+        $registry = $this->propagate(new ExtendedTextInteractionConfigurationRegistry());
+        $registry->setHasMath(false);
+
+        $setValues = $registry->get(ExtendedTextInteractionConfigurationRegistry::ID);
+
+        return $setValues
+            ? Report::createSuccess(
+                sprintf(
+                    "Applied the following configuration to `%s`\n%s",
+                    ExtendedTextInteractionConfigurationRegistry::class,
+                    json_encode($setValues)
+                )
+            )
+            : Report::createError(
+                sprintf('No values set to `%s`', ExtendedTextInteractionConfigurationRegistry::class)
+            );
+    }
+}

--- a/install/scripts/SetupExtendedTextInteractionConfigurationRegistry.php
+++ b/install/scripts/SetupExtendedTextInteractionConfigurationRegistry.php
@@ -34,6 +34,8 @@ use oat\taoQtiItem\model\QtiCreator\ExtendedTextInteractionConfigurationRegistry
  *
  * Run the following to disable Math Entry format option
  * php index.php 'oat\taoQtiItem\install\scripts\SetupExtendedTextInteractionConfigurationRegistry' -m 0
+ *
+ * @deprecated This configuration will only be handled by featureFlag by default is always false
  */
 class SetupExtendedTextInteractionConfigurationRegistry extends ScriptAction
 {

--- a/manifest.php
+++ b/manifest.php
@@ -24,6 +24,7 @@ use oat\taoQtiItem\controller\QtiCreator;
 use oat\taoQtiItem\controller\QtiCssAuthoring;
 use oat\taoQtiItem\controller\QtiPreview;
 use oat\taoQtiItem\install\scripts\addValidationSettings;
+use oat\taoQtiItem\install\scripts\ExtendConfigurationRegistry;
 use oat\taoQtiItem\install\scripts\SetDragAndDropConfig;
 use oat\taoQtiItem\install\scripts\setXMLParserConfig;
 use oat\taoQtiItem\model\qti\CustomInteractionAsset\ServiceProvider\CustomInteractionAssetExtractorAllocatorServiceProvider;
@@ -74,6 +75,7 @@ return [
             SetUpQueueTasks::class,
             RegisterItemCompilerBlacklist::class,
             RegisterNpmPaths::class,
+            ExtendConfigurationRegistry::class,
         ]
     ],
     'local' => [

--- a/migrations/Version202205181148531101_taoQtiItem.php
+++ b/migrations/Version202205181148531101_taoQtiItem.php
@@ -43,16 +43,22 @@ final class Version202205181148531101_taoQtiItem extends AbstractMigration
 
         $setValues = $registry->get(ExtendedTextInteractionConfigurationRegistry::ID);
 
-        $this->addReport(
-            $setValues
-                ? Report::createSuccess(
-                sprintf(
-                    "Applied the following configuration to `%s`\n%s",
-                    ExtendedTextInteractionConfigurationRegistry::class,
-                    json_encode($setValues)
+        if ($setValues) {
+            $this->addReport(
+                Report::createSuccess(
+                    sprintf(
+                        "Applied the following configuration to `%s`\n%s",
+                        ExtendedTextInteractionConfigurationRegistry::class,
+                        json_encode($setValues)
+                    )
                 )
-            )
-                : Report::createError(
+            );
+
+            return;
+        }
+
+        $this->addReport(
+            Report::createError(
                 sprintf('No values set to `%s`', ExtendedTextInteractionConfigurationRegistry::class)
             )
         );

--- a/migrations/Version202205181148531101_taoQtiItem.php
+++ b/migrations/Version202205181148531101_taoQtiItem.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022  (original work) Open Assessment Technologies SA;
+ *
+ * @author Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiItem\model\QtiCreator\ExtendedTextInteractionConfigurationRegistry;
+
+final class Version202205181148531101_taoQtiItem extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Removes base64 data pattern from item compilation asset blacklist.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $registry = $this->propagate(new ExtendedTextInteractionConfigurationRegistry());
+        $registry->setHasMath(false);
+
+        $setValues = $registry->get(ExtendedTextInteractionConfigurationRegistry::ID);
+
+        $this->addReport(
+            $setValues
+                ? Report::createSuccess(
+                sprintf(
+                    "Applied the following configuration to `%s`\n%s",
+                    ExtendedTextInteractionConfigurationRegistry::class,
+                    json_encode($setValues)
+                )
+            )
+                : Report::createError(
+                sprintf('No values set to `%s`', ExtendedTextInteractionConfigurationRegistry::class)
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2082

### Solution

hasMath is false by default now and only changed on the scope of taoDeliverConnect installation

Documentation: https://github.com/oat-sa/tao-core/blob/feat/AUT-2082/feature-flag-visibility-tao-advance/models/classes/featureFlag/README.md

### TODO 

- [x] Add documentation
- [x] Validate solution with FE
- [x] Validate that installation works

## Related PRs

- https://github.com/oat-sa/extension-tao-deliver-connect/pull/116
- https://github.com/oat-sa/tao-core/pull/3530