### PR TITLE
fix: removed manual refactoring to max width which breaks grid

### DIFF
--- a/views/js/qtiCreator/editor/gridEditor/resizable.js
+++ b/views/js/qtiCreator/editor/gridEditor/resizable.js
@@ -74,15 +74,15 @@ define([
 
             $activeZone.draggable({
                 containment : $nextCol.length ? [
-                    offset.left + min * unitWidth - marginWidth * 2 + 10,
-                    offset.top,
-                    offset.left + $col.outerWidth() + marginWidth + $nextCol.outerWidth() - nextMin * unitWidth - activeWidth / 2 - 10,
-                    offset.top + $col.height()
+                    $col.offset.left + min * unitWidth - marginWidth * 2 + 10,
+                    $col.offset.top,
+                    $col.offset.left + $col.outerWidth() + marginWidth + $nextCol.outerWidth() - nextMin * unitWidth - activeWidth / 2 - 10,
+                    $col.offset.top + $col.height()
                 ] : [
-                    offset.left + min * unitWidth - marginWidth - activeWidth / 2 - 10,
-                    offset.top,
+                    $col.offset.left + min * unitWidth - marginWidth - activeWidth / 2 - 10,
+                    $col.offset.top,
                     $row.offset().left + $row.outerWidth() - marginWidth - activeWidth / 2 - 12,
-                    offset.top + $col.height()
+                    $col.offset.top + $col.height()
                 ],
                 axis : 'x',
                 cursor : 'col-resize',
@@ -91,7 +91,7 @@ define([
                     $col.trigger('resizestart.gridEdit');
 
                     let $overlay = $('<div>', {'class' : 'grid-edit-resizable-outline'});
-                    if($nextCol.length){
+                    if($col.next().length){
                         $overlay.width(parseFloat($col.outerWidth()) + marginWidth + parseFloat($nextCol.outerWidth()));
                     }else{
                         $overlay.css({'width' : '100%', 'border-right-width' : 0});

--- a/views/js/qtiCreator/editor/gridEditor/resizable.js
+++ b/views/js/qtiCreator/editor/gridEditor/resizable.js
@@ -25,21 +25,21 @@ define([
     'taoQtiItem/lib/jqueryui_dragdrop'
 ], function(_, $, config, helper, qtiElements){
     "use strict";
-    var _syncHandleHeight = function($row){
-        var h = $row.height() - parseFloat($row.children('[class^="col-"], [class*=" col-"]').css('margin-bottom'));
+    let _syncHandleHeight = function($row){
+        let h = $row.height() - parseFloat($row.children('[class^="col-"], [class*=" col-"]').css('margin-bottom'));
         $row.find('.grid-edit-resizable-zone').height(h);
     };
 
-    var _createResizables = function createResizables($el){
+    const _createResizables = function createResizables($el){
 
-        var marginWidth = parseFloat($el.find('[class^="col-"]:last, [class*=" col-"]:last').css('margin-left')),
-            activeWidth = 20;
+           let marginWidth = parseFloat($el.find('[class^="col-"]:last, [class*=" col-"]:last').css('margin-left'));
+           let activeWidth = 20;
 
 
 
         $el.find('[class^="col-"], [class*=" col-"]').each(function(){
 
-            var $col = $(this);
+            let $col = $(this);
 
             //@todo this should be more generic
             //see draggable etc for more references
@@ -52,22 +52,22 @@ define([
                 return true;
             }
 
-            var $nextCol = $col.next(),
-                $row = $col.parent('.grid-row'),
-                offset = $col.offset(),
-                max = 12,
-                min = qtiElements.is($col.data('qti-class'), 'interaction') ? config.min.interaction : config.min.text,
-                nextMin = qtiElements.is($nextCol.data('qti-class'), 'interaction') ? config.min.interaction : config.min.text,
-                unitWidth = $row.width() / max;
+            let $nextCol = $col.next();
+            let $row = $col.parent('.grid-row');
+            let offset = $col.offset();
+            let max = 12;
+            let min = qtiElements.is($col.data('qti-class'), 'interaction') ? config.min.interaction : config.min.text;
+            let nextMin = qtiElements.is($nextCol.data('qti-class'), 'interaction') ? config.min.interaction : config.min.text;
+            let unitWidth = $row.width() / max;
 
-            var activeHeight = $row.height() - parseFloat($col.css('margin-bottom'));
-            var $activeZone = $('<div>', {'class' : 'grid-edit-resizable-zone grid-edit-resizable-zone-active'}).css({top : 0, right : -(marginWidth + (activeWidth - marginWidth) / 2), width : activeWidth, height : activeHeight});
-            var $handle = $('<span>', {'class' : 'grid-edit-resizable-handle'});
+            let activeHeight = $row.height() - parseFloat($col.css('margin-bottom'));
+            let $activeZone = $('<div>', {'class' : 'grid-edit-resizable-zone grid-edit-resizable-zone-active'}).css({top : 0, right : -(marginWidth + (activeWidth - marginWidth) / 2), width : activeWidth, height : activeHeight});
+            let $handle = $('<span>', {'class' : 'grid-edit-resizable-handle'});
             $activeZone.append($handle);
             $col.append($activeZone);
 
-            var _syncOutlineHeight = function(){
-                var h = $row.height() - parseFloat($col.css('margin-bottom'));
+            let _syncOutlineHeight = function(){
+                let h = $row.height() - parseFloat($col.css('margin-bottom'));
                 $col.find('.grid-edit-resizable-outline').height(h);
                 $activeZone.height(h);
             };
@@ -90,7 +90,7 @@ define([
 
                     $col.trigger('resizestart.gridEdit');
 
-                    var $overlay = $('<div>', {'class' : 'grid-edit-resizable-outline'});
+                    let $overlay = $('<div>', {'class' : 'grid-edit-resizable-outline'});
                     if($nextCol.length){
                         $overlay.width(parseFloat($col.outerWidth()) + marginWidth + parseFloat($nextCol.outerWidth()));
                     }else{
@@ -106,9 +106,9 @@ define([
                 },
                 drag : _.throttle(function(){
 
-                    var width = ($(this).offset().left + activeWidth / 2) - $col.offset().left,
-                        units = helper.getColUnits($col),
-                        nextUnits = $nextCol.length ? helper.getColUnits($nextCol) : 0;
+                    let width = ($(this).offset().left + activeWidth / 2) - $col.offset().left;
+                    let units = helper.getColUnits($col);
+                    let nextUnits = $nextCol.length ? helper.getColUnits($nextCol) : 0;
 
                     if(!$nextCol.length){
                         //need to resize the outline element:
@@ -174,18 +174,18 @@ define([
 
     };
 
-    var _deleteResizables = function _deleteResizables($el){
+    const _deleteResizables = function _deleteResizables($el){
 
         $el.find('.grid-edit-resizable-zone').remove();
     };
 
-    var _setColUnits = function _setColUnits($elt, newUnits){
+    let _setColUnits = function _setColUnits($elt, newUnits){
 
         if($elt.attr('class').match(/col-([\d]+)/)){
 
-            var oldUnits = $elt.attr('data-units');
-            var $parentRow = $elt.parent('.grid-row');
-            var totalUnits = $parentRow.attr('data-units');
+            let oldUnits = $elt.attr('data-units');
+            let $parentRow = $elt.parent('.grid-row');
+            let totalUnits = $parentRow.attr('data-units');
             $parentRow.attr('data-units', totalUnits - oldUnits + newUnits);//update parent
             $elt.attr('data-units', newUnits);//update element
             $elt.removeClass('col-' + oldUnits).addClass('col-' + newUnits);

--- a/views/js/qtiCreator/editor/gridEditor/resizable.js
+++ b/views/js/qtiCreator/editor/gridEditor/resizable.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA ;
  *
  */
 define([
@@ -106,13 +106,13 @@ define([
                 },
                 drag : _.throttle(function(){
 
-                    var width = ($(this).offset().left + activeWidth / 2) - offset.left,
+                    var width = ($(this).offset().left + activeWidth / 2) - $col.offset().left,
                         units = helper.getColUnits($col),
                         nextUnits = $nextCol.length ? helper.getColUnits($nextCol) : 0;
 
                     if(!$nextCol.length){
                         //need to resize the outline element:
-                        $col.find('.grid-edit-resizable-outline').width($handle.offset().left - offset.left);
+                        $col.find('.grid-edit-resizable-outline').width($handle.offset().left - $col.offset().left);
                     }
 
                     if(width + marginWidth * 0 < (units - 1) * unitWidth){//need to compensate for the width of the active zone

--- a/views/js/qtiCreator/helper/gridUnits.js
+++ b/views/js/qtiCreator/helper/gridUnits.js
@@ -151,31 +151,6 @@ define(['lodash'], function(_){
         positive = _.sortBy(positive, 'refactoredUnits');
         negative = _.sortBy(negative, 'refactoredUnits');
 
-        if(totalRefactoredUnits > max){
-            //too much !
-
-            //@todo : start with the hightest refactored
-            _.eachRight(positive, function(col){
-                col.refactoredUnits --;
-                totalRefactoredUnits--;
-                if(totalRefactoredUnits === max){
-                    return false;
-                }
-            });
-
-        }else if(totalRefactoredUnits < max){
-
-            //@todo : start with the lowest refactored
-            _.each(negative, function(col){
-                col.refactoredUnits ++;
-                totalRefactoredUnits++;
-                if(totalRefactoredUnits === max){
-                    return false;
-                }
-            });
-
-        }
-
         _.each(negative, function(col){
             ret.push(col);
         });

--- a/views/js/qtiCreator/helper/gridUnits.js
+++ b/views/js/qtiCreator/helper/gridUnits.js
@@ -151,6 +151,30 @@ define(['lodash'], function(_){
         positive = _.sortBy(positive, 'refactoredUnits');
         negative = _.sortBy(negative, 'refactoredUnits');
 
+        if(totalRefactoredUnits > max){
+            //too much !
+
+            //@todo : start with the hightest refactored
+            _.eachRight(positive, function(col){
+                col.refactoredUnits --;
+                totalRefactoredUnits--;
+                if(totalRefactoredUnits === max){
+                    return false;
+                }
+            });
+
+        }else if(totalRefactoredUnits < max){
+
+            //@todo : start with the lowest refactored
+            _.each(negative, function(col){
+                col.refactoredUnits ++;
+                totalRefactoredUnits++;
+                if(totalRefactoredUnits === max){
+                    return false;
+                }
+            });
+
+        }
         _.each(negative, function(col){
             ret.push(col);
         });

--- a/views/js/qtiCreator/helper/gridUnits.js
+++ b/views/js/qtiCreator/helper/gridUnits.js
@@ -175,6 +175,7 @@ define(['lodash'], function(_){
             });
 
         }
+
         _.each(negative, function(col){
             ret.push(col);
         });

--- a/views/js/qtiCreator/widgets/states/Deleting.js
+++ b/views/js/qtiCreator/widgets/states/Deleting.js
@@ -145,7 +145,8 @@ define([
         cols = gridUnits.redistribute(cols);
 
         _.each(cols, function (col) {
-            col.elt.removeClass(`col-${col.units}`).addClass(`col-${col.refactoredUnits}`);
+            let oldClass = col.elt.context.classList.value
+            col.elt.removeClass(oldClass.match(/col-([\d]+)/).input).addClass(`col-${col.refactoredUnits}`);
             gridHelper.setUnitsFromClass(col.elt);
         });
 


### PR DESCRIPTION
**Related to:**
 https://oat-sa.atlassian.net/browse/AUT-151


**SETPS to test:**
• Checkout to branch: /AUT-151/asset-no-resizing-after-removing-A-blocks
• Create passage or item and add 6 A bocks in the same row
• Delete them one by one until there is only 1 left
• Try to resize block left

**ACTUAL RESULT:**
It is impossible to resize the A block

**EXPECTED RESULT:**
The A block can be resized
![AUT-151-VIDEO](https://user-images.githubusercontent.com/60346520/171618019-69771b48-be55-4142-a699-effd73797dcd.gif)


**PROBLEM:**
The `refactored units` are used to create boostrap grid columns hence when refactoring them manually to take the whole width, we force the number of units to change breaking the process that updates the grid classes.
The logic to remove boostrap class ony worked for columns the same size.

**SOLUTION:**
Removed part of the function that manually forces a change in refactored units as this is handled by boostrap grid clasess (col-[numbr]) and is that part that breaks the process.

Small modification in remove old class for the boostrap class column so that it worked for columns with different sizes as well