### PR TITLE
fix/AUT-1965: fix selector for editable entries

### DIFF
--- a/views/js/qtiCreator/editor/gridEditor/droppable.js
+++ b/views/js/qtiCreator/editor/gridEditor/droppable.js
@@ -38,7 +38,7 @@ define([
             data = options.data || {};
 
         var $placeholder = $('<div>', {'id' : 'qti-block-element-placeholder', 'class' : 'qti-droppable-block-hover'}),
-        marginWidth = parseFloat($el.find('[class^="col-"], [class*=" col-"]').last().css('margin-left')),
+            marginWidth = parseFloat($el.find('[class^="col-"], [class*=" col-"]').last().css('margin-left')),
             isEmpty = ($el.children('.grid-row').length === 0);
 
         //add dropping class (used to fix col-*:first margin issue);
@@ -50,8 +50,7 @@ define([
             $el.append(_getNewRow().append(_getNewCol().addClass('col-12')));
 
         }else{
-
-            $el.find('.grid-row').each(function(){
+            $el.children('.grid-row').each(function(){
 
                 var $row = $(this), cols = [];
 


### PR DESCRIPTION
Related to [AUT-1965](https://oat-sa.atlassian.net/browse/AUT-1965)
fixes as well [AUT-822](https://oat-sa.atlassian.net/browse/AUT-822)

Description:
Droppable rows area used generic sectors that cause scope conflict with the content of complex components (like Stimulus) inside of interactions.

Changes:
* Decrease the scope of the row to its children's only
How to check:
* Follow instructions from the ticket [AUT-1965](https://oat-sa.atlassian.net/browse/AUT-1965)
* Create one Passage from the Assets section
* Create an item
* Add choice interaction
* Add Passage to interaction content
* From now drag and drop one more choice interaction below
* First observe fix of [AUT-822](https://oat-sa.atlassian.net/browse/AUT-822)
* Then click on the preview button
* Observe column view a fix of [AUT-1965](https://oat-sa.atlassian.net/browse/AUT-1965)

Requires:
* Client's composer is optional but nice to have.