### PR TITLE
Use babel in PCI bundling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=14.4.0",
-        "oat-sa/tao-core": ">=50.16.3",
+        "oat-sa/tao-core": ">=50.18.0",
         "oat-sa/extension-tao-item": ">=11.20.1"
     },
     "autoload": {

--- a/views/build/grunt/portableelement.js
+++ b/views/build/grunt/portableelement.js
@@ -10,42 +10,39 @@
  * @example compile only the likertScaleInteraction in the extension qtiItemPci using short param
  * grunt portableelement -e=qtiItemPci -i=likertScaleInteraction
  */
+
+const { join } = require('path');
+
 module.exports = function (grunt) {
     'use strict';
 
-    var root = grunt.option('root');
-    var requirejs = grunt.option('requirejsModule');
-    var ext = require(root + '/tao/views/build/tasks/helpers/extensions')(grunt, root);
-    var amdConfig = require(root + '/tao/views/build/config/requirejs.build.json');
+    const root = grunt.option('root');
+    const requirejs = grunt.option('requirejsModule');
+    const babel = grunt.option('babelModule');
+    const ext = require(join(root, '/tao/views/build/tasks/helpers/extensions.js'))(grunt, root);
+    const amdConfig = require(join(root, '/tao/views/build/config/requirejs.build.json'));
 
-    var portableModels = [
+    const portableModels = [
         {
-            type : 'PCI',
-            file : 'pciCreator.json',
-            searchPattern : '/views/js/pciCreator/**/pciCreator.json'
+            type: 'PCI', //deprecated
+            file: 'pciCreator.json',
+            searchPattern: '/views/js/pciCreator/**/pciCreator.json'
         },
         {
-            type : 'IMSPCI',
-            file : 'imsPciCreator.json',
-            searchPattern : '/views/js/pciCreator/**/imsPciCreator.json'
+            type: 'IMSPCI',
+            file: 'imsPciCreator.json',
+            searchPattern: '/views/js/pciCreator/**/imsPciCreator.json'
         },
         {
-            type : 'PIC',
-            file : 'picCreator.json',
-            searchPattern : '/views/js/picCreator/**/picCreator.json'
+            type: 'PIC', //deprecated
+            file: 'picCreator.json',
+            searchPattern: '/views/js/picCreator/**/picCreator.json'
         }
     ];
 
     grunt.config.merge({
         portableelement: {
             options: {
-                optimize: 'uglify2',
-                uglify2: {
-                    mangle: false,
-                    output: {
-                        'max_line_len': 666
-                    }
-                },
                 preserveLicenseComments: false,
                 optimizeAllPluginResources: true,
                 findNestedDependencies: true,
@@ -57,19 +54,29 @@ module.exports = function (grunt) {
                 generateSourceMaps: true,
                 removeCombined: true,
                 baseUrl: amdConfig.baseUrl,
-                shim : amdConfig.shim,
+                shim: amdConfig.shim,
                 excludeShallow: ['mathJax'],
                 exclude: ['qtiCustomInteractionContext', 'qtiInfoControlContext']
-                    .concat(ext.getExtensionSources('taoQtiItem', ['views/js/qtiItem/**/*.js', 'views/js/qtiCreator/**/*.js'], true))
+                    .concat(
+                        ext.getExtensionSources(
+                            'taoQtiItem',
+                            ['views/js/qtiItem/**/*.js', 'views/js/qtiCreator/**/*.js'],
+                            true
+                        )
+                    )
                     .concat(ext.getExtensionSources('taoItems', ['views/js/**/*.js'], true)),
-                paths: Object.assign({
-                    'taoItems': root + '/taoItems/views/js',
-                    'taoItemsCss': root + '/taoItems/views/css',
-                    'taoQtiItem': root + '/taoQtiItem/views/js',
-                    'taoQtiItemCss': root + '/taoQtiItem/views/css',
-                    'qtiCustomInteractionContext': root + '/taoQtiItem/views/js/runtime/qtiCustomInteractionContext',
-                    'qtiInfoControlContext': root + '/taoQtiItem/views/js/runtime/qtiInfoControlContext'
-                }, amdConfig.paths, require('./paths.json'))
+                paths: Object.assign(
+                    {
+                        taoItems: `${root}/taoItems/views/js`,
+                        taoItemsCss: `${root}/taoItems/views/css`,
+                        taoQtiItem: `${root}/taoQtiItem/views/js`,
+                        taoQtiItemCss: `${root}/taoQtiItem/views/css`,
+                        qtiCustomInteractionContext: `${root}/taoQtiItem/views/js/runtime/qtiCustomInteractionContext`,
+                        qtiInfoControlContext: `${root}/taoQtiItem/views/js/runtime/qtiInfoControlContext`
+                    },
+                    amdConfig.paths,
+                    require('./paths.json')
+                )
             }
         }
     });
@@ -83,9 +90,7 @@ module.exports = function (grunt) {
     function getHookFileName(pciRuntimeData, prefix) {
         if (Array.isArray(pciRuntimeData.src) && pciRuntimeData.src.length > 0) {
             //by convention the first module is the hook file
-            return pciRuntimeData.src[0]
-                .replace(/\.js$/i, '')
-                .replace(/^\.\//, prefix + '/');
+            return pciRuntimeData.src[0].replace(/\.js$/i, '').replace(/^\.\//, `${prefix}/`);
         }
     }
 
@@ -95,14 +100,14 @@ module.exports = function (grunt) {
      * @returns {String}
      */
     function getMinHookFile(pciRuntimeData) {
-        var minHookFile;
+        let minHookFile;
         if (pciRuntimeData.hook) {
             minHookFile = pciRuntimeData.hook;
         } else if (Array.isArray(pciRuntimeData.libraries) && pciRuntimeData.libraries.length > 0) {
             //by convention the first module is the min file
             minHookFile = pciRuntimeData.libraries[0];
         }
-        if(minHookFile){
+        if (minHookFile) {
             return minHookFile.replace(/^\.\//, '');
         }
     }
@@ -112,39 +117,39 @@ module.exports = function (grunt) {
      * @param {Array|Function} report
      */
     function printReport(report) {
-        if(Array.isArray(report)){
+        if (Array.isArray(report)) {
             report.forEach(function (r) {
                 printReport(r);
             });
-        }else if(typeof report === 'function'){
+        } else if (typeof report === 'function') {
             report.call();
         }
     }
 
     /**
      * Get the portable element model from its manifest file
-     * @param file
+     * @param {string} file
      * @returns {*}
      */
-    function getPortableModelFromFile(file){
-        var model;
-        portableModels.forEach(function(portableModel){
-            if(file.match(new RegExp('\/' + portableModel.file + '$'))){
+    function getPortableModelFromFile(file) {
+        let model;
+        portableModels.forEach(function (portableModel) {
+            if (file.match(new RegExp(`/${portableModel.file}$`))) {
                 model = {};
                 model.type = portableModel.type;
                 model.manifest = grunt.file.readJSON(file);
-                model.basePath = file.replace('/' + portableModel.file, '');
+                model.basePath = file.replace(`/${portableModel.file}`, '');
                 model.id = model.manifest.typeIdentifier;
                 model.map = [
                     {
-                        name : 'RUNTIME',
-                        src : getHookFileName(model.manifest.runtime, model.id),
-                        min : getMinHookFile(model.manifest.runtime)
+                        name: 'RUNTIME',
+                        src: getHookFileName(model.manifest.runtime, model.id),
+                        min: getMinHookFile(model.manifest.runtime)
                     },
                     {
-                        name : 'CREATOR',
-                        src : getHookFileName(model.manifest.creator, model.id),
-                        min : getMinHookFile(model.manifest.creator)
+                        name: 'CREATOR',
+                        src: getHookFileName(model.manifest.creator, model.id),
+                        min: getMinHookFile(model.manifest.creator)
                     }
                 ];
                 return false;
@@ -153,99 +158,172 @@ module.exports = function (grunt) {
         return model;
     }
 
+    function transpile(sourceFilePath, sourceMapFilePath) {
+        if (!grunt.file.exists(sourceFilePath)) {
+            return Promise.reject(new Error(`Unable to find or read "${sourceFilePath}"`));
+        }
+        const code = grunt.file.read(sourceFilePath);
+
+        const hasSourceMap = grunt.file.exists(sourceMapFilePath);
+        const sourceMap = hasSourceMap ? grunt.file.read(sourceMapFilePath) : null;
+
+        return babel
+            .transformAsync(code, {
+                presets: [
+                    [
+                        '@babel/env',
+                        {
+                            targets: 'extends @oat-sa/browserslist-config-tao',
+                            useBuiltIns: false
+                        }
+                    ],
+                    [
+                        'minify',
+                        {
+                            mangle: false
+                        }
+                    ]
+                ],
+                sourceMap: hasSourceMap,
+                inputSourceMap: hasSourceMap ? JSON.parse(sourceMap) : void 0,
+                comments: false,
+                sourceType: 'script'
+            })
+            .then(transformResult => {
+                if (transformResult && transformResult.code) {
+                    grunt.file.write(sourceFilePath, transformResult.code);
+                }
+                if (hasSourceMap && transformResult.map) {
+                    grunt.file.write(sourceMapFilePath, JSON.stringify(transformResult.map));
+                }
+            });
+    }
+
     grunt.registerTask('portableelement', 'Compile Portable Elements', function () {
+        const done = this.async();
+        const extension = grunt.option('extension') || grunt.option('e');
+        const selectedId = grunt.option('identifier') || grunt.option('i');
+        let manifests, compileTasks;
 
-        var done = this.async();//async mode because requirejs optimization is an async process
-        var extension = grunt.option('extension') || grunt.option('e');
-        var selectedId = grunt.option('identifier') || grunt.option('i');
-        var manifests, compileTasks;
-        var self = this;
-
-        if(!extension){
+        if (!extension) {
             grunt.log.error('Missing the extension in param, e.g. "grunt portableelement -e=qtiItemPci"');
             return done();
         }
 
-        grunt.log.writeln('Started optimizing portable elements in extension "' + extension + '"');
+        grunt.log.writeln(`Started optimizing portable elements in extension "${extension}"`);
 
-        if(selectedId){
-            grunt.log.writeln('Only searching portable element "' + selectedId + '"');
+        if (selectedId) {
+            grunt.log.writeln(`Only searching portable element "${selectedId}"`);
         }
 
-        manifests = portableModels.reduce(function(acc, model) {
-            return grunt.file.expand(root + '/' + extension + model.searchPattern).concat(acc);
-        }, []);
+        manifests = portableModels.reduce(
+            (acc, model) => grunt.file.expand(join(root, extension, model.searchPattern)).concat(acc),
+            []
+        );
 
-        compileTasks = manifests.map(function(file){
+        compileTasks = manifests.map(file => {
+            let config;
+            const model = getPortableModelFromFile(file);
+            const subcompilationPromises = [];
 
-            var config;
-            var model = getPortableModelFromFile(file);
-            var subcompilationPromises = [];
-
-            if(!model){
+            if (!model) {
                 //not the targeted one
-                return Promise.resolve([grunt.log.error.bind(null, 'invalid portable manifest file ' + file)]);
+                return Promise.resolve([grunt.log.error.bind(null, `invalid portable manifest file ${file}`)]);
             }
 
-            if(selectedId && selectedId !== model.id){
+            if (selectedId && selectedId !== model.id) {
                 //not the targeted one
                 return Promise.resolve([]);
             }
 
-            subcompilationPromises.push([grunt.log.subhead.bind(null, model.type + ' "' + model.id + '" found in manifest "' + file + '" ...')]);
+            subcompilationPromises.push([
+                grunt.log.subhead.bind(null, `${model.type} "${model.id}" found in manifest "${file}" ...`)
+            ]);
 
-            model.map.forEach(function(compilMap){
-                subcompilationPromises.push(new Promise(function(resolve, reject){
-                    var report = [];
+            model.map.forEach(compilMap => {
+                subcompilationPromises.push(
+                    new Promise((resolve, reject) => {
+                        const report = [];
 
-                    if (!compilMap.src) {
-                        //when no source file has been found, skip the compilation
-                        report.push(grunt.log.ok.bind(null, 'No source file defined for ' + model.type +' "' + model.id + '" - '+compilMap.name));
-                        return resolve(report);
-                    }
-
-                    //extends the default configuration with portable element specific build config
-                    config = self.options({
-                        name: compilMap.src,
-                        out: model.basePath + '/' + compilMap.min,
-
-                        //this wrapping is required to allow self loading portable element module.
-                        wrap: {
-                            start: '',
-                            end: "define(['" + compilMap.src + "'],function(" + model.type + '){return ' + model.type + '});'
+                        if (!compilMap.src) {
+                            //when no source file has been found, skip the compilation
+                            report.push(
+                                grunt.log.ok.bind(
+                                    null,
+                                    `No source file defined for ${model.type} "${model.id}" - ${compilMap.name}`
+                                )
+                            );
+                            return resolve(report);
                         }
-                        //(note: the option "insertRequire" does not work because it is resolved asynchronously)
-                    });
 
-                    // Add the path to the given extension for portableLib resolution
-                    config.paths[extension] = root + '/' + extension + '/views/js';
-                    config.paths[model.id] = model.basePath;
+                        const outputFile = join(model.basePath, compilMap.min);
 
-                    requirejs.optimize(config, function (buildResponse) {
-                        report.push(grunt.log.ok.bind(null, 'Compiled ' + model.type + ' "' + model.id + '" - ' + compilMap.name));
-                        report.push(grunt.log.writeln.bind(null, buildResponse));
-                        resolve(report);
-                    }, function (err) {
-                        report.push(grunt.log.error.bind(null, model.type + ' "' + model.id + '" ' + compilMap.name + ' cannot be compiled'));
-                        report.push(grunt.log.error.bind(null, err));
-                        reject(report);
-                    });
-                }));
+                        //extends the default configuration with portable element specific build config
+                        config = this.options({
+                            name: compilMap.src,
+                            out: outputFile,
+
+                            //this wrapping is required to allow self loading portable element module.
+                            wrap: {
+                                start: '',
+                                end: `define(['${compilMap.src}'],function(${model.type}){return ${model.type}});`
+                            }
+                            //(note: the option "insertRequire" does not work because it is resolved asynchronously)
+                        });
+
+                        // Add the path to the given extension for portableLib resolution
+                        config.paths[extension] = `${root}/${extension}/views/js`;
+                        config.paths[model.id] = model.basePath;
+
+                        requirejs.optimize(
+                            config,
+                            function (buildResponse) {
+                                report.push(
+                                    grunt.log.ok.bind(null, `Compiled ${model.type} "${model.id}" - ${compilMap.name}`)
+                                );
+                                report.push(grunt.log.writeln.bind(null, buildResponse));
+
+                                report.push(grunt.log.writeln.bind(null, `Transpile ${outputFile}`));
+                                transpile(outputFile, `${outputFile}.map`)
+                                    .then(() => {
+                                        report.push(grunt.log.ok.bind(null, `${outputFile} updated.`));
+                                        resolve(report);
+                                    })
+                                    .catch(err => {
+                                        report.push(grunt.log.error.bind(null, err));
+                                        reject(report);
+                                    });
+                            },
+                            function (err) {
+                                report.push(
+                                    grunt.log.error.bind(
+                                        null,
+                                        `${model.type} "${model.id}" ${compilMap.name} cannot be compiled`
+                                    )
+                                );
+                                report.push(grunt.log.error.bind(null, err));
+                                reject(report);
+                            }
+                        );
+                    })
+                );
             });
 
             return Promise.all(subcompilationPromises);
         });
 
         if (compileTasks.length) {
-            Promise.all(compileTasks).then(function (report) {
-                printReport(report);
-                done();
-            }).catch(function (report) {
-                printReport(report);
-                done();
-            });
+            Promise.all(compileTasks)
+                .then(function (report) {
+                    printReport(report);
+                    done();
+                })
+                .catch(function (report) {
+                    printReport(report);
+                    done();
+                });
         } else {
-            grunt.log.writeln('no portable element to be compiled in extension "'+extension+'"');
+            grunt.log.writeln(`no portable element to be compiled in extension "${extension}"`);
             done();
         }
     });


### PR DESCRIPTION
## Changes 
- Reformat the `portableelement` task declaration
 - Add babel in the PCI bundling task to transpile bundles using the OAT preset

## Requires
 - https://github.com/oat-sa/tao-core/pull/3559

## Todo 
 - [x] Merge and release https://github.com/oat-sa/tao-core/pull/3559 first
 - [x] Update the dependency to tao-core based on the release version of https://github.com/oat-sa/tao-core/pull/3559 in the `composer.json` to guarantee the dependency

## How to test
 - take a PCI and introduce some ES2015 features like `const`, arrow functions, etc.
 - bundle the PCI
 - register and test the PCI 