### PR TITLE
[Feature] Set LTR value for dir attribute by default

### DIFF
--- a/model/qti/ParserFactory.php
+++ b/model/qti/ParserFactory.php
@@ -382,10 +382,8 @@ class ParserFactory
 
     private function setContainerAttributes(Container $container, DOMElement $data): void
     {
-        $languageAttribute = $data->getAttribute('dir');
-        if (!empty($languageAttribute)) {
-            $container->setAttribute('dir', $languageAttribute);
-        }
+        $languageAttribute = $data->getAttribute('dir') ?: 'ltr';
+        $container->setAttribute('dir', $languageAttribute);
     }
 
     protected function parseContainerItemBody(DOMElement $data, ContainerItemBody $container)


### PR DESCRIPTION
# [AUT-2338](https://oat-sa.atlassian.net/browse/AUT-2338)

## Changes
* If `dir` attribute was not sent - `ltr` value will be set by default

## How to test
1. Create an item;
2. Add any interaction(s);
3. Save;
4. Check `xml` file content.

**Old behavior: _the `itemBody` element does not contain any attrtibutes._**
**New behavior: _`itemBody` contains a `dir` attrtibute with `ltr` value._**