### PR TITLE
Feature/aut 2337/marshall lang dir attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "minimum-stability": "dev",
     "require": {
         "ext-simplexml": "*",
-        "oat-sa/lib-tao-qti": " 7.5.0",
+        "oat-sa/lib-tao-qti": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 7.6.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=14.4.0",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "minimum-stability": "dev",
     "require": {
         "ext-simplexml": "*",
-        "oat-sa/lib-tao-qti": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 7.6.0",
+        "oat-sa/lib-tao-qti": "7.6.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=14.4.0",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2337

## Problem to solve

Import/export shared stimulus and keep the "lang" and "dir" attributes is not working.

Example where the problem happens: https://github.com/oat-sa/extension-tao-mediamanager/blob/master/model/sharedStimulus/encoder/SharedStimulusMediaEncoder.php#L51 When we call XmlDocument::load() it does not keep the attributes we need. 

## Solutions

- Add possibilities for custom attributes in the BodyElement

## PRs

- https://github.com/oat-sa/qti-sdk/pull/318
- https://github.com/oat-sa/lib-tao-qti/pull/121