### PR TITLE
fix: update dependency to tao-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=14.4.0",
-        "oat-sa/tao-core": ">=50.18.0",
+        "oat-sa/tao-core": ">=50.18.3",
         "oat-sa/extension-tao-item": ">=11.20.1"
     },
     "autoload": {


### PR DESCRIPTION
Ensure the dependency to tao-core contains the bundler fix https://github.com/oat-sa/tao-core/releases/tag/v50.18.3 