### PR TITLE
Fix/aut 2268/prevent drag resize math input

### DIFF
--- a/views/js/qtiCreator/editor/mathInput/mathInput.js
+++ b/views/js/qtiCreator/editor/mathInput/mathInput.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2022 (original work) Open Assessment Technologies SA;
  */
 /**
  * This component present a MathQuill (Latex Wysiwyg) input with a toolbar that allows to add some predefined symbols
@@ -216,11 +216,6 @@ define([
 
                 this._initMathQuill($inputField);
                 createToolbar($toolbar, this.mathField);
-
-                // prevent dragging when the field is rendered in a draggable component
-                $inputField.on('mousedown' + eventNs, function preventDrag(e) {
-                    e.stopPropagation();
-                });
             })
             .on('destroy', function() {
                 var $component = this.getElement(),

--- a/views/js/qtiCreator/editor/mathInput/tpl/mathInput.tpl
+++ b/views/js/qtiCreator/editor/mathInput/tpl/mathInput.tpl
@@ -1,6 +1,6 @@
 <div class="math-input">
     <div class="math-input-toolbar"></div>
-    <div class="math-input-form">
+    <div class="math-input-form no-drag no-resize">
         <span class="math-input-mathquill"></span>
     </div>
 </div>

--- a/views/js/qtiCreator/tpl/forms/static/mathPopup.tpl
+++ b/views/js/qtiCreator/tpl/forms/static/mathPopup.tpl
@@ -1,1 +1,1 @@
-<textarea class="math-popup-input math-popup-input-{{popupMode}}" name="{{popupMode}}-large" placeholder="{{placeholder}}"></textarea>
+<textarea class="math-popup-input math-popup-input-{{popupMode}} no-drag no-resize" name="{{popupMode}}-large" placeholder="{{placeholder}}"></textarea>

--- a/views/js/test/qtiCreator/editor/mathInput/test.js
+++ b/views/js/test/qtiCreator/editor/mathInput/test.js
@@ -19,7 +19,6 @@
  * @author Christophe Noël <christophe@taotesting.com>
  */
 define([
-
     'lodash',
     'jquery',
     'taoQtiItem/qtiCreator/editor/mathInput/mathInput'
@@ -117,33 +116,6 @@ define([
                 .init()
                 .render($container);
         });
-
-    QUnit.test('stop clic propagation', function(assert) {
-        var ready = assert.async();
-        var mathInput = mathInputFactory(),
-            $container = $(fixtureContainer);
-
-        assert.expect(1);
-
-        mathInput
-            .on('render', function() {
-                var $component = this.getElement(),
-                    $inputField = $component.find('.math-input-mathquill');
-
-                assert.equal($inputField.length, 1, 'inputField has been found');
-
-                $component.on('mousedown', function() {
-                    assert.ok(false, 'Event should not propagate to the componen\'s root element');
-                    ready();
-                });
-
-                $inputField.trigger('mousedown');
-
-                ready();
-            })
-            .init()
-            .render($container);
-    });
 
     QUnit.module('Visual test');
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2268

Requires changes from PR: https://github.com/oat-sa/tao-core-ui-fe/pull/470 (via https://github.com/oat-sa/tao-core/pull/3574)

- mathInput.tpl: add classes `no-drag no-resize`
- mathPopup.tpl: add classes `no-drag no-resize`
- remove previous code which tried to fix the same issue in another way (and its test)

https://user-images.githubusercontent.com/43652944/177869282-5af061da-2d15-4cf1-94fe-4fc1ff98b55b.mov

