### PR TITLE
Fix/aut 2268/static math popup disable top resize

### DIFF
--- a/views/js/qtiCreator/helper/windowPopup.js
+++ b/views/js/qtiCreator/helper/windowPopup.js
@@ -30,8 +30,9 @@ define([
     'use strict';
 
     var defaultConfig = {
-        draggable : true,
-        resizable : true
+        draggable: true,
+        resizable: true,
+        resizableEdges: { top: true, right: true, bottom: true, left: true }
     };
 
     /**
@@ -39,6 +40,7 @@ define([
      * @param {Object} config
      * @param {Boolean} config.draggable - if the window should be draggable
      * @param {Boolean} config.resizable - if the window should be resizable
+     * @param {Object} config.resizableEdges - which edges should be resizable (interactjs)
      */
     return function windowPopupFactory(specs, config) {
         var windowPopup;
@@ -51,7 +53,7 @@ define([
             makeDraggable(windowPopup);
         }
         if (config.resizable) {
-            makeResizable(windowPopup);
+            makeResizable(windowPopup, { edges: config.resizableEdges });
         }
         makeStackable(windowPopup, { stackingScope: 'qti-creator' });
         makeWindowed(windowPopup);

--- a/views/js/qtiCreator/widgets/static/math/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/math/states/Active.js
@@ -234,7 +234,8 @@ define([
                 minWidth: 460,
                 maxWidth: 960,
                 minHeight: 220,
-                maxHeight: 640
+                maxHeight: 640,
+                resizableEdges: { top: false, right: true, bottom: true, left: true }
             };
 
         return windowPopupFactory({}, popupOptions)
@@ -273,7 +274,8 @@ define([
                 minWidth: 240,
                 maxWidth: 960,
                 minHeight: 160,
-                maxHeight: 640
+                maxHeight: 640,
+                resizableEdges: { top: false, right: true, bottom: true, left: true }
             },
             smallField = self.fields['$' + popupMode]; // the corresponding "small" field in the widget form
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2268?focusedCommentId=193137

Following a comment from UX, the usability of the 2 static math editor popups should be improved by **removing the top resize handle**. This is easy enough - just pass config through to interactjs.

So the popups will end up with:
- resize handles: bottom, left & right edges
- draggable handle: everything apart from the top edge and the textarea.

Kitchen env is provided in ticket.
Unit tests were not affected (these components not covered).

https://user-images.githubusercontent.com/43652944/179525207-1066b7e2-1943-4d45-b14a-73873826651f.mov


