### PR TITLE
fix: Choice Interaction - update cardinality when type is changed

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -108,6 +108,7 @@ define([
         const widget = this.widget;
         const $form = widget.$form;
         const interaction = widget.element;
+        const response = interaction.getResponseDeclaration();
         const currListStyle = getListStyle(interaction);
         const $choiceArea = widget.$container.find('.choice-area');
         let minMaxComponent = null;
@@ -279,6 +280,7 @@ define([
             $form.find('[name="constraints"][value="none"]').prop('checked', true);
             $form.find('[name="constraints"][value="other"]').prop('disabled', true);
             deleteMinMax();
+            response.attr('cardinality', 'single');
         };
 
         const setSelectedCase = () => {
@@ -294,7 +296,6 @@ define([
         callbacks.type = function (interactionParam, value) {
             type = value;
             setSelectedCase();
-            const response = interaction.getResponseDeclaration();
             if (type === 'single') {
                 $form.find('[name="constraints"][value="other"]').prop('disabled', true);
                 deleteMinMax();

--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -103,7 +103,7 @@ define([
         return !_.isNull(listStyle) ? listStyle.pop().replace(listStylePrefix, '') : null;
     }
 
-    ChoiceInteractionStateQuestion.prototype.initForm = function initForm(updateCardinality) {
+    ChoiceInteractionStateQuestion.prototype.initForm = function initForm() {
         let callbacks;
         const widget = this.widget;
         const $form = widget.$form;
@@ -246,7 +246,7 @@ define([
 
         //data change callbacks with the usual min/maxChoices
         callbacks = formElement.getMinMaxAttributeCallbacks('minChoices', 'maxChoices', {
-            updateCardinality: updateCardinality,
+            updateCardinality: false,
             allowNull: true
         });
 
@@ -294,11 +294,14 @@ define([
         callbacks.type = function (interactionParam, value) {
             type = value;
             setSelectedCase();
+            const response = interaction.getResponseDeclaration();
             if (type === 'single') {
                 $form.find('[name="constraints"][value="other"]').prop('disabled', true);
                 deleteMinMax();
+                response.attr('cardinality', 'single');
             } else {
                 $form.find('[name="constraints"][value="other"]').prop('disabled', false);
+                response.attr('cardinality', 'multiple');
             }
         };
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2480

Issue: 
GIVEN: Item with Choice Interaction contained Single choice option selected with Constrains “None“/”Answer required” created
WHEN user exports Item
THEN qti.xml file contains cardinality="multiple" for responseDeclaration instead of cardinality="single"

Solution:
update `cardinality` when `type: single, multiple` is changed