### PR TITLE
Feature/adf 1040/fix pci manager export

### DIFF
--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -532,7 +532,12 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
 
         $filesystem = $this->getFileSystem();
         foreach ($files as $file) {
-            $zip->addFromString($file, $filesystem->getFileContentFromModelStorage($object, $file));
+            try {
+                $zip->addFromString($file, $filesystem->getFileContentFromModelStorage($object, $file));
+            } catch (PortableElementFileStorageException $e) {
+                // do not include missing/sharedClientLib files
+                continue;
+            }
         }
 
         $zip->close();

--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -514,11 +514,9 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
     /**
      * Export a portable element to a zip package
      *
-     * @param PortableElementObject $object
-     * @return string
      * @throws \common_Exception
      */
-    public function export(PortableElementObject $object)
+    public function export(PortableElementObject $object): string
     {
         $zip = new \ZipArchive();
         $path = $this->getZipLocation($object);

--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -524,7 +524,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
         $path = $this->getZipLocation($object);
 
         if ($zip->open($path, \ZipArchive::CREATE) !== true) {
-            throw new \common_Exception('Unable to create zipfile ' . $path);
+            throw new \common_Exception('Unable to create zip file ' . $path);
         }
 
         $manifest = $this->getManifest($object);
@@ -534,13 +534,11 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
 
         $filesystem = $this->getFileSystem();
         foreach ($files as $file) {
-            if (strpos($file, './') === 0) {
-                //only export the files that are in the portable element package (exclude the shared libraries)
-                $zip->addFromString($file, $filesystem->getFileContentFromModelStorage($object, $file));
-            }
+            $zip->addFromString($file, $filesystem->getFileContentFromModelStorage($object, $file));
         }
 
         $zip->close();
+
         return $path;
     }
 


### PR DESCRIPTION
Related bug ticket: https://oat-sa.atlassian.net/browse/ADF-1040
The issue is that if a PCI developer forgot (or did not know that it may affect anything) to add ./  before local library name in manifest it was considered as shared client library and not included to exported zip,
that way when importing such zip, the file will be missing and the PCI will fail to be added,
as we do not know how much PCIs may be affected with such issue so the best solution seems to just remove such ./ check for export and still try to include a file into package even if it's name starts without ./ if it is not a part of PCI assets just skip it
Related PR: https://github.com/oat-sa/extension-tao-itemqti-pci/pull/315