### PR TITLE
Feature/tr 4477/custom theme in editor Previewer

### DIFF
--- a/views/js/qtiCreator/plugins/menu/preview.js
+++ b/views/js/qtiCreator/plugins/menu/preview.js
@@ -98,7 +98,8 @@ define([
                 if (!this.isEmpty()) {
                     previewerFactory(type, uri, {}, {
                         readOnly: false,
-                        fullPage: true
+                        fullPage: true,
+                        pluginsOptions: config.pluginsOptions
                     });
                 }
             });


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4477

Custom theme should be applied in Item Preview, which can be opened from 2 places:
- Authoring -> Items-> Preview : done in [#425](https://github.com/oat-sa/extension-tao-test/pull/425)
- Authoring -> Items-> Edit Item-> Preview: done here

See ticket description for more detailed steps to reproduce.

Migration from customer extension PR will add to `\config\tao\client_lib_config_registry.conf.php`:
```
...
return new oat\oatbox\config\ConfigurationService(array(
    'config' => array(
        ....
       'taoQtiItem/qtiCreator/plugins/menu/preview' => array(
            'pluginsOptions' =>  array(
                'itemThemeSwitcher' => array(
                    'activeNamespace' => '...'
                )
            )
        ),
        ....        
    )
));

```
