### PR TITLE
Fix/TR-4212/Decode HTML entities in attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "minimum-stability": "dev",
     "require": {
         "ext-simplexml": "*",
-        "oat-sa/lib-tao-qti": "^7.6.0",
+        "oat-sa/lib-tao-qti": "^7.7.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=14.4.0",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4212

Update QTI-SDK to version `0.28.1`.

Removes the double encoding of attributes (see https://github.com/oat-sa/qti-sdk/pull/325)