### PR TITLE
Fix/TR-4291/Missing class import

### DIFF
--- a/model/Export/Stylesheet/AssetStylesheetLoader.php
+++ b/model/Export/Stylesheet/AssetStylesheetLoader.php
@@ -26,7 +26,6 @@ use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\filesystem\FileSystemService;
-use oat\taoMediaManager\model\fileManagement\FileManagement;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoMediaManager\model\fileManagement\FlySystemManagement;
 use oat\taoQtiItem\model\Export\AbstractQTIItemExporter;
@@ -100,6 +99,6 @@ class AssetStylesheetLoader extends ConfigurableService
         // FIXME this violates the order of dependencies.
         //  taoQtiItem cannot depend on taoMediaManager as it causes a circular dependency
         //  caused by [#1766](https://github.com/oat-sa/extension-tao-itemqti/pull/1766)
-        return $this->getServiceLocator()->get(FileManagement::SERVICE_ID);
+        return $this->getServiceLocator()->get(FlySystemManagement::SERVICE_ID);
     }
 }

--- a/model/Export/Stylesheet/AssetStylesheetLoader.php
+++ b/model/Export/Stylesheet/AssetStylesheetLoader.php
@@ -26,6 +26,7 @@ use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\filesystem\FileSystemService;
+use oat\taoMediaManager\model\fileManagement\FileManagement;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoMediaManager\model\fileManagement\FlySystemManagement;
 use oat\taoQtiItem\model\Export\AbstractQTIItemExporter;

--- a/model/Export/Stylesheet/AssetStylesheetLoader.php
+++ b/model/Export/Stylesheet/AssetStylesheetLoader.php
@@ -27,6 +27,7 @@ use League\Flysystem\FilesystemInterface;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\oatbox\service\ConfigurableService;
+/** @todo fix the implementation as taoQtiItem MUST NOT depend on taoMediaManager */
 use oat\taoMediaManager\model\fileManagement\FlySystemManagement;
 use oat\taoQtiItem\model\Export\AbstractQTIItemExporter;
 use tao_helpers_Uri as UriHelper;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4192

~~Bring back a removed class import that is still needed.~~
Use the right class for getting the service ID.

Because of this wrong class used, the export and the publication of tests containing styled shared stimulus are failing with the error `Class 'oat\taoQtiItem\model\Export\Stylesheet\FileManagement' not found`.

This was introduced by #2143 

**How to test:**
- create a shared stimulus and add a stylesheet
- create an item and include the shared stimulus
- create a test containing this item
- export the test
- publish the test

**Requirements:**
- You need to install the extension taoMediaManager.
- In order to make possible the inclusion of the stylesheet in a shared stimulus, you will need to add this to `tao/config/tao/client_lib_config_registry.conf.php`:
```
        'services/features' => array(
            'visibility' => array(
                'taoMediaManager/creator/StyleSheetManager' => 'show'
            )
        ),
```
