### PR TITLE
fix: add conditional to append button so it doesn't add twice when fi…

### DIFF
--- a/views/js/qtiCreator/editor/blockAdder/blockAdder.js
+++ b/views/js/qtiCreator/editor/blockAdder/blockAdder.js
@@ -171,7 +171,7 @@ define([
          */
         function _appendButton($widget) {
             //only append button to no-tmp widget and only add it once:
-            if (!$widget.children('.add-block-element').length && !$widget.parent('.colrow.tmp').length) {
+            if (!$widget.children('.add-block-element').length && !$widget.parent('.colrow.tmp').length && !$widget.children('figure').length) {
                 const $adder = $(adderTpl());
                 $widget.append($adder);
                 $adder.on('click', function (e) {


### PR DESCRIPTION
**RELATED TO:** https://oat-sa.atlassian.net/browse/AUT-2450
STEPS TO TEST:
1º Create an item with an A block that has an image with fig-caption
2º Save item.
3º Go back to the items tab and go inside authoring again.

**ACTUAL RESULT:**
Block adder plus sign shows twice in A block

**EXPECTED RESULT:**
Block adder shows only once 

![adder](https://user-images.githubusercontent.com/60346520/189161648-b9316541-9c5f-47fd-a4a1-2fb7dec268a6.gif)



**NOTE:**
In order to see the blockAdder + symbol in items you'll need to have  the multi-column enabled. to do so, go to
` config/taoQtiItem/qtiCreator.conf.php`
and set
`‘multi-column’ => true`