### PR TITLE
Feature/TR-4575/Allow external dependencies for PCI

### DIFF
--- a/views/build/grunt/portableelement.js
+++ b/views/build/grunt/portableelement.js
@@ -275,6 +275,11 @@ module.exports = function (grunt) {
                         config.paths[extension] = `${root}/${extension}/views/js`;
                         config.paths[model.id] = model.basePath;
 
+                        // Add path to external dependencies
+                        const pathFile = join(model.basePath, 'paths.json');
+                        if (grunt.file.exists(pathFile)) {
+                            config.paths = Object.assign(config.paths, grunt.file.readJSON(pathFile));
+                        }
                         requirejs.optimize(
                             config,
                             function (buildResponse) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4575

Modify the PCI bundler, allowing for the inclusion of external dependencies via path mapping.

How to test:
- add a `path.json` file into a PCI for including an external dependency like an npm package
- require the external dependency from the PCI
- bundle the PCI (`$(cd tao/views/build && npx grunt portableelement -e=taoExtension -i=myPci)` )
- check the bundle task performs without error and that the external dependency is present inside the bundle


Example:
- `path.json`:
```json
{
  "external"   : "../../../taoExtension/views/node_modules/something/dist/external"
}
```

- `taoExtension/views/node_modules/something/dist/external.js`:
```javascript
define(function() {
    return () => alert('It works!');
});
```

- PCI:
```javascript
require([..., 'external'], function(..., external) {
    ...
    external();
    ...
});
```