### PR TITLE
Feature/TR-4575/Disable a minify option of Babel that is breaking PCI

### DIFF
--- a/views/build/grunt/portableelement.js
+++ b/views/build/grunt/portableelement.js
@@ -180,7 +180,8 @@ module.exports = function (grunt) {
                     [
                         'minify',
                         {
-                            mangle: false
+                            mangle: false,
+                            builtIns: false
                         }
                     ]
                 ],


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-4575

### Summary
Literally, as the title already expresses: disable a minify option of Babel that is breaking PCI.

### Details
When trying to bundle an external library, the bundled package didn't load because the code was broken with a surprising undefined prototype error. This is due to the fact the library is internally borrowing the same name as a built-in object for a variable, and Babel is trying to apply a local optimization to it. The optimized output is unfortunately not in sync anymore with the original intent, and the code breaks.

### How to test
Bundle PCI and check it loads well both in the authoring and in the runtime.

As a reminder, to bundle PCI (example with the MathEntry):
```sh
cd tao/views/build
npx grunt portableelement -e=qtiItemPci -i=mathEntryInteraction
```

**Note:** This is needed to properly bundle the next version of the MathEntry PCI.

**Note 2:** More info on the disabled option: https://babeljs.io/docs/en/babel-plugin-minify-builtins
