### PR TITLE
Fix/TR-4575/Parsing error with self closing tags in a PCI markup

### DIFF
--- a/model/qti/interaction/PortableCustomInteraction.php
+++ b/model/qti/interaction/PortableCustomInteraction.php
@@ -52,27 +52,27 @@ class PortableCustomInteraction extends CustomInteraction
     protected $typeIdentifier = '';
     protected $entryPoint = '';
     protected $version = '0.0.0';
-    
+
     public function setTypeIdentifier($typeIdentifier)
     {
         $this->typeIdentifier = $typeIdentifier;
     }
-    
+
     public function setEntryPoint($entryPoint)
     {
         $this->entryPoint = $entryPoint;
     }
-    
+
     public function getTypeIdentifier()
     {
         return $this->typeIdentifier;
     }
-    
+
     public function getEntryPoint()
     {
         return $this->entryPoint;
     }
-    
+
     public function getProperties()
     {
         return $this->properties;
@@ -91,22 +91,22 @@ class PortableCustomInteraction extends CustomInteraction
     {
         return $this->stylesheets;
     }
-    
+
     public function setStylesheets($stylesheets)
     {
         $this->stylesheets = $stylesheets;
     }
-    
+
     public function getMediaFiles()
     {
         return $this->mediaFiles;
     }
-    
+
     public function setMediaFiles($mediaFiles)
     {
         $this->mediaFiles = $mediaFiles;
     }
-    
+
     public function getVersion()
     {
         return $this->version;
@@ -133,7 +133,7 @@ class PortableCustomInteraction extends CustomInteraction
 
     public function toArray($filterVariableContent = false, &$filtered = [])
     {
-        
+
         $returnValue = parent::toArray($filterVariableContent, $filtered);
 
         $returnValue['typeIdentifier'] = $this->typeIdentifier;
@@ -152,7 +152,7 @@ class PortableCustomInteraction extends CustomInteraction
     {
         return static::getTemplatePath() . 'interactions/qti.portableCustomInteraction.tpl.php';
     }
-    
+
     protected function getTemplateQtiVariables()
     {
 
@@ -166,7 +166,7 @@ class PortableCustomInteraction extends CustomInteraction
         $this->getRelatedItem()->addNamespace($this->markupNs, $this->markupNs);
         return $variables;
     }
-    
+
     /**
      * Feed the pci instance with data provided in the pci dom node
      *
@@ -232,7 +232,7 @@ class PortableCustomInteraction extends CustomInteraction
 
         $markupNodes = $parser->queryXPathChildren(['portableCustomInteraction', 'markup'], $data, $xmlnsName);
         if ($markupNodes->length) {
-            $markup = $parser->getBodyData($markupNodes->item(0), true, true);
+            $markup = $parser->getBodyData($markupNodes->item(0), true);
             $this->setMarkup($markup);
         }
     }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-4575

### Summary

When trying to save an existing item with a PCI having line breaks in the markup, the server returns with the error `Item XML is not valid`.

This is due to an option allowing the XML parser to auto close self closing tags.

### Details

The option `LIBXML_NOEMPTYTAG` was activated for PCI and PIC. As per the [PHP documentation](https://www.php.net/manual/en/libxml.constants.php), this option expands empty tags. As an example `<br />` becomes `<br></br>` and the browser transforms it to `<br /></br>`. When this is sent to the server, the XML validator returns with the error message `Item XML is not valid: Opening and ending tag mismatch`.

The activation of this option was introduced by the PR #317. Unfortunately, this PR does not explain the intent, and I did not find any reference to this in our records.

### How to test

- have an item with a PCI
- edit the prompt of the PCI, adding line breaks
- save the item and exit the authoring
- edit again the item
- save it...
