### PR TITLE
Fix/AUT-2589/edit table caption issues

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -133,7 +133,8 @@ define([
                         const $newImgPlaceholder = $editable.find('[data-new="true"][data-qti-class="img"]');
                         if (
                             $newImgPlaceholder.length &&
-                            !$editable.closest('.qti-choice, .qti-flow-container').length
+                            !$editable.closest('.qti-choice, .qti-flow-container').length &&
+                            !$newImgPlaceholder.closest('.qti-table caption').length
                         ) {
                             // instead img will add figure element
                             $newImgPlaceholder.attr('data-qti-class', 'figure');

--- a/views/js/qtiCreator/widgets/static/table/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/table/states/Active.js
@@ -66,9 +66,10 @@ define([
             this.buildEditor();
         },
         function exit() {
-            // fix caption on close
-            // on Enter ckeditor creates additional caption
-            // move all content in first one caption
+            // fix a caption on exit
+            // on Enter ckeditor creates an additional caption
+            // move all contents from second caption and others to the first caption
+            // second caption and others will be removed
             const $editableContainer = this.widget.$container;
             const $caption = $('caption', $editableContainer);
             if ($caption.length > 1) {
@@ -85,9 +86,9 @@ define([
                 });
                 $first.focus();
             }
-            // on alignment ckeditor adds paragraph
-            // move content from paragraph to caption
-            // set alignment class to caption
+            // on alignment ckeditor adds a paragraph
+            // move content from the paragraph to the caption, the paragraph will be removed
+            // set alignment's class to the caption
             const $paragraphsInCaption = $('caption > p', $editableContainer);
             if ($paragraphsInCaption.length > 0) {
                 $paragraphsInCaption.each(function () {

--- a/views/js/qtiCreator/widgets/static/table/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/table/states/Active.js
@@ -196,7 +196,7 @@ define([
         if (!htmlEditor.hasEditor($editableContainer)) {
             htmlEditor.buildEditor($editableContainer, {
                 placeholder: '',
-                change: getChangeCallback(container, $editableContainer),
+                change: getChangeCallback(container),
                 removePlugins: 'magicline',
                 data: {
                     container: container,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2589

**How to reproduce:**

- Creating an item
- Adding A-block
- Adding a table with caption
- Aligning the caption to the right
- Saving --> could not be saved

**Issue:** in QTI we can't use tag `<p>`inside `caption`.
**Solution:** move alignment class to `caption`

**Other fixed issue:** 
1. QTI doesn't allow `figure` in `caption`, will be `img`
2. on `Enter` inserted new line that is new `caption`. Copied content of new `caption` to first `caption`