### PR TITLE
fix: parse removoPlugins properly

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -88,7 +88,7 @@ define([
         });
 
         if (options.removePlugins) {
-            options.removePlugins.split('').forEach(removePluginName => {
+            options.removePlugins.split(',').forEach(removePluginName => {
                 removePlugins.push(removePluginName.trim());
             });
         }


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-2657

### Description 

Rubric block editor has ckeditor buttons which should not be there. Clicking this buttons does nothing and generates console errors

This PR fixes the issue and properly removes the unnecessary buttons from UI

### How to test

1. Go to Tests tab
2. Click ‘New test’ and go to it’s Authoring
3. Click ‘Manage Rubric blocks’ ('A' icon) and then ‘New rubric block’
4. Click on text area and in appeared CK Editor panel click ‘Insert Shared Stimulus'/‘Insert Image’/’Insert Math

https://user-images.githubusercontent.com/10635482/193207470-03b2689a-eecb-463a-a77f-078003213a42.mp4

