### PR TITLE
fix: scale choices coords on image resize

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/Widget.js
@@ -13,75 +13,91 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
-
 
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'jquery', 'lodash', 'i18n',
+    'jquery',
+    'lodash',
+    'i18n',
     'taoQtiItem/qtiCreator/widgets/interactions/Widget',
     'taoQtiItem/qtiCreator/widgets/interactions/graphicInteraction/Widget',
-    'taoQtiItem/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/states'
-], function($, _, __, Widget, GraphicWidget, states){
-
+    'taoQtiItem/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/states',
+    'taoQtiItem/qtiCommonRenderer/helpers/Graphic'
+], function ($, _, __, Widget, GraphicWidget, states, GraphicHelper) {
     'use strict';
 
     /**
      * The Widget that provides components used by the QTI Creator for the GraphicAssociate Interaction.
-     * 
+     *
      * @extends taoQtiItem/qtiCreator/widgets/interactions/Widget
      * @extends taoQtiItem/qtiCreator/widgets/interactions/GraphicInteraction/Widget
      *
      * @exports taoQtiItem/qtiCreator/widgets/interactions/graphicAssociateInteraction/Widget
-     */      
-    var GraphicAssociateInteractionWidget = _.extend(Widget.clone(), GraphicWidget, {
-
+     */
+    const GraphicAssociateInteractionWidget = _.extend(Widget.clone(), GraphicWidget, {
         /**
          * Set up the widget
          * @see {taoQtiItem/qtiCreator/widgets/interactions/Widget#initCreator}
-         * @param {Object} options - extra options 
+         * @param {Object} options - extra options
          * @param {String} options.baseUrl - the resource base url
          * @param {jQueryElement} options.choiceForm = a reference to the form of the choices
          */
-        initCreator : function(options){
-            var paper;
+        initCreator: function (options) {
             this.baseUrl = options.baseUrl;
             this.choiceForm = options.choiceForm;
-            
+
             this.registerStates(states);
-            
+
             //call parent initCreator
             Widget.initCreator.call(this);
-           
-            paper = this.createPaper(); 
-            if(paper){
+
+            const paper = this.createPaper(_.bind(this.scaleChoices, this));
+            if (paper) {
                 this.element.paper = paper;
-                this.createChoices();    
+                this.createChoices();
             }
         },
-
+        /**
+         * Called back on paper resize to scale the choices coords
+         */
+        scaleChoices: function () {
+            if (this.element.paper) {
+                const interaction = this.element;
+                const choices = interaction.getChoices();
+                _.forEach(choices, choice => {
+                    choice.attr(
+                        'coords',
+                        GraphicHelper.qtiCoords(
+                            interaction.paper.getById(choice.serial),
+                            interaction.paper,
+                            interaction.object.attr('width')
+                        )
+                    );
+                });
+            }
+        },
         /**
          * Gracefull destroy the widget
          * @see {taoQtiItem/qtiCreator/widgets/Widget#destroy}
          */
-        destroy : function(){
-
-            var $container = this.$original;
-            var $item      = $container.parents('.qti-item');
+        destroy: function () {
+            const $container = this.$original;
+            const $item = $container.parents('.qti-item');
 
             //stop listening the resize
-            $item.off('resize.gridEdit.' + this.element.serial);
-            $(window).off('resize.qti-widget.' + this.element.serial);
-            $container.off('resize.qti-widget.' + this.element.serial);
+            $item.off(`resize.gridEdit.${this.element.serial}`);
+            $(window).off(`resize.qti-widget.${this.element.serial}`);
+            $container.off(`resize.qti-widget.${this.element.serial}`);
 
             //call parent destroy
             Widget.destroy.call(this);
         }
-   });
+    });
 
     return GraphicAssociateInteractionWidget;
 });

--- a/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/Widget.js
@@ -56,7 +56,7 @@ define([
             //call parent initCreator
             Widget.initCreator.call(this);
 
-            const paper = this.createPaper(_.bind(this.scaleChoices, this));
+            const paper = this.createPaper(() => this.scaleChoices());
             if (paper) {
                 this.element.paper = paper;
                 this.createChoices();

--- a/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/Question.js
@@ -58,7 +58,7 @@ define([
     /**
      * Question State initialization: set up side bar, editors and shae factory
      */
-    const initQuestionState = function initQuestionState() {
+    function initQuestionState() {
         const widget = this.widget;
         const interaction = widget.element;
         const paper = interaction.paper;
@@ -195,7 +195,7 @@ define([
     /**
      * Exit the question state, leave the room cleaned up
      */
-    const exitQuestionState = function exitQuestionState() {
+    function exitQuestionState() {
         const widget = this.widget;
         const interaction = widget.element;
         const paper = interaction.paper;

--- a/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/Question.js
@@ -13,10 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
-
 
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
@@ -37,7 +36,7 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/forms/choices/associableHotspot',
     'taoQtiItem/qtiCreator/helper/panel',
     'taoQtiItem/qtiCreator/widgets/interactions/helpers/bgImage'
-], function(
+], function (
     $,
     _,
     __,
@@ -53,56 +52,54 @@ define([
     choiceFormTpl,
     panel,
     bgImage
-){
+) {
     'use strict';
 
     /**
      * Question State initialization: set up side bar, editors and shae factory
      */
-    var initQuestionState = function initQuestionState(){
+    const initQuestionState = function initQuestionState() {
+        const widget = this.widget;
+        const interaction = widget.element;
+        const paper = interaction.paper;
 
-        var widget      = this.widget;
-        var interaction = widget.element;
-        var paper       = interaction.paper;
+        const $choiceForm = widget.choiceForm;
+        const $formInteractionPanel = $('#item-editor-interaction-property-bar');
+        const $formChoicePanel = $('#item-editor-choice-property-bar');
 
-        var $choiceForm  = widget.choiceForm;
-        var $formInteractionPanel = $('#item-editor-interaction-property-bar');
-        var $formChoicePanel = $('#item-editor-choice-property-bar');
+        let $left, $top, $width, $height;
 
-        var $left, $top, $width, $height;
-
-        if(!paper){
+        if (!paper) {
             return;
         }
 
         //instantiate the shape editor, attach it to the widget to retrieve it during the exit phase
         widget._editor = shapeEditor(widget, {
-            shapeCreated : function(shape, type){
-                var newChoice = interaction.createChoice({
-                    shape  : type === 'path' ? 'poly' : type,
-                    coords : GraphicHelper.qtiCoords(shape)
+            shapeCreated: function (shape, type) {
+                const newChoice = interaction.createChoice({
+                    shape: type === 'path' ? 'poly' : type,
+                    coords: GraphicHelper.qtiCoords(shape)
                 });
 
                 //link the shape to the choice
                 shape.id = newChoice.serial;
             },
-            shapeRemoved : function(id){
+            shapeRemoved: function (id) {
                 interaction.removeChoice(id);
             },
-            enterHandling : function(shape){
+            enterHandling: function (shape) {
                 enterChoiceForm(shape.id);
             },
-            quitHandling : function(){
+            quitHandling: function () {
                 leaveChoiceForm();
             },
-            shapeChange : function(shape){
-                var bbox;
-                var choice = interaction.getChoice(shape.id);
-                if(choice){
-                    choice.attr('coords', GraphicHelper.qtiCoords(shape));
+            shapeChange: function (shape) {
+                const choice = interaction.getChoice(shape.id);
+                if (choice) {
+                    choice.attr('coords', GraphicHelper.qtiCoords(shape, paper, interaction.object.attr('width')));
 
-                    if($left && $left.length){
-                        bbox = shape.getBBox();
+                    if ($left && $left.length) {
+                        const bbox = shape.getBBox();
                         $left.val(parseInt(bbox.x, 10));
                         $top.val(parseInt(bbox.y, 10));
                         $width.val(parseInt(bbox.width, 10));
@@ -120,46 +117,43 @@ define([
          * @private
          * @param {String} serial - the choice serial
          */
-        function enterChoiceForm(serial){
-            var choice = interaction.getChoice(serial);
-            var element, bbox;
+        function enterChoiceForm(serial) {
+            const choice = interaction.getChoice(serial);
 
-            if(choice){
-
+            if (choice) {
                 //get shape bounding box
-                element = interaction.paper.getById(serial);
-                bbox = element.getBBox();
+                const element = interaction.paper.getById(serial);
+                const bbox = element.getBBox();
 
                 $choiceForm.empty().html(
                     choiceFormTpl({
-                        identifier  : choice.id(),
-                        fixed       : choice.attr('fixed'),
-                        serial      : serial,
-                        x           : parseInt(bbox.x, 10),
-                        y           : parseInt(bbox.y, 10),
-                        width       : parseInt(bbox.width, 10),
-                        height      : parseInt(bbox.height, 10)
+                        identifier: choice.id(),
+                        fixed: choice.attr('fixed'),
+                        serial: serial,
+                        x: parseInt(bbox.x, 10),
+                        y: parseInt(bbox.y, 10),
+                        width: parseInt(bbox.width, 10),
+                        height: parseInt(bbox.height, 10)
                     })
                 );
 
                 //controls matchMin and matchMax attributes
                 minMaxComponentFactory($choiceForm.find('.min-max-panel'), {
-                    min : {
-                        fieldName:   'matchMin',
-                        value:       _.parseInt(choice.attr('matchMin')) || 0,
+                    min: {
+                        fieldName: 'matchMin',
+                        value: _.parseInt(choice.attr('matchMin')) || 0,
                         helpMessage: __('The minimum number of choices this choice must be associated with to form a valid response.')
                     },
-                    max : {
-                        fieldName:   'matchMax',
-                        value:       _.parseInt(choice.attr('matchMax')) || 0,
+                    max: {
+                        fieldName: 'matchMax',
+                        value: _.parseInt(choice.attr('matchMax')) || 0,
                         helpMessage: __('The maximum number of choices this choice may be associated with.')
                     },
-                    upperThreshold :  _.size(interaction.getChoices()),
-                }).on('render', function(){
-                    var self = this;
-                    widget.on('choiceCreated choiceDeleted', function(data){
-                        if(data.interaction.serial === interaction.serial){
-                            self.updateThresholds(1, _.size(interaction.getChoices()));
+                    upperThreshold: _.size(interaction.getChoices())
+                }).on('render', function () {
+                    widget.on('choiceCreated choiceDeleted', data => {
+                        if (data.interaction.serial === interaction.serial) {
+                            this.updateThresholds(1, _.size(interaction.getChoices()));
                         }
                     });
                 });
@@ -167,7 +161,7 @@ define([
                 formElement.initWidget($choiceForm);
 
                 //init data validation and binding
-                var callbacks = formElement.getMinMaxAttributeCallbacks('matchMin', 'matchMax');
+                const callbacks = formElement.getMinMaxAttributeCallbacks('matchMin', 'matchMax');
                 callbacks.identifier = identifierHelper.updateChoiceIdentifier;
                 callbacks.fixed = formElement.getAttributeChangeCallback();
 
@@ -178,9 +172,9 @@ define([
                 panel.closeSections($formInteractionPanel.children('section'));
 
                 //change the nodes bound to the position fields
-                $left   = $('input[name=x]', $choiceForm);
-                $top    = $('input[name=y]', $choiceForm);
-                $width  = $('input[name=width]', $choiceForm);
+                $left = $('input[name=x]', $choiceForm);
+                $top = $('input[name=y]', $choiceForm);
+                $width = $('input[name=width]', $choiceForm);
                 $height = $('input[name=height]', $choiceForm);
             }
         }
@@ -189,8 +183,8 @@ define([
          * Leave the choice form
          * @private
          */
-        function leaveChoiceForm(){
-            if($formChoicePanel.css('display') !== 'none'){
+        function leaveChoiceForm() {
+            if ($formChoicePanel.css('display') !== 'none') {
                 panel.openSections($formInteractionPanel.children('section'));
                 $formChoicePanel.hide();
                 $choiceForm.empty();
@@ -201,21 +195,21 @@ define([
     /**
      * Exit the question state, leave the room cleaned up
      */
-    var exitQuestionState = function exitQuestionState(){
-        var widget      = this.widget;
-        var interaction = widget.element;
-        var paper       = interaction.paper;
-        var valid       = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
+    const exitQuestionState = function exitQuestionState() {
+        const widget = this.widget;
+        const interaction = widget.element;
+        const paper = interaction.paper;
+        const valid = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
 
         widget.isValid('graphicAssociateInteraction', valid);
 
-        if(!paper){
+        if (!paper) {
             return;
         }
 
         $(window).off('resize.changestate');
 
-        if(widget._editor){
+        if (widget._editor) {
             widget._editor.destroy();
         }
         $('.image-editor.solid, .block-listing.source', this.widget.$container).css('min-width', 0);
@@ -226,60 +220,58 @@ define([
      * @extends taoQtiItem/qtiCreator/widgets/interactions/blockInteraction/states/Question
      * @exports taoQtiItem/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/Question
      */
-    var GraphicAssociateInteractionStateQuestion = stateFactory.extend(Question, initQuestionState, exitQuestionState);
+    const GraphicAssociateInteractionStateQuestion = stateFactory.extend(Question, initQuestionState, exitQuestionState);
 
     /**
      * Initialize the form linked to the interaction
      */
-    GraphicAssociateInteractionStateQuestion.prototype.initForm = function initForm(){
-
-        var widget = this.widget;
-        var options = widget.options;
-        var interaction = widget.element;
-        var $form = widget.$form;
+    GraphicAssociateInteractionStateQuestion.prototype.initForm = function initForm() {
+        const widget = this.widget;
+        const options = widget.options;
+        const interaction = widget.element;
+        const $form = widget.$form;
 
         /**
          * Get the maximum number of pairs regarding the number of choices: f(n) = n(n-1)/2
          * @param {Number} choices - the number of choices
          * @returns {Number} the number of possible pairs
          */
-        var getMaxPairs = function getMaxPairs(choices){
-            var pairs = 0;
-            if(choices > 0){
+        const getMaxPairs = function getMaxPairs(choices) {
+            const pairs = 0;
+            if (choices > 0) {
                 return Math.round((choices * (choices - 1)) / 2);
             }
             return pairs;
         };
 
-        $form.html(formTpl({
-            baseUrl         : options.baseUrl,
-            data            : interaction.object.attr('data'),
-            width           : interaction.object.attr('width'),
-            height          : interaction.object.attr('height'),
-            type            : interaction.object.attr('type')
-        }));
-
+        $form.html(
+            formTpl({
+                baseUrl: options.baseUrl,
+                data: interaction.object.attr('data'),
+                width: interaction.object.attr('width'),
+                height: interaction.object.attr('height'),
+                type: interaction.object.attr('type')
+            })
+        );
 
         //controls min and max association
         minMaxComponentFactory($form.find('.min-max-panel'), {
-            min : {
-                fieldName:   'minAssociations',
-                value:       _.parseInt(interaction.attr('minAssociations')) || 0,
+            min: {
+                fieldName: 'minAssociations',
+                value: _.parseInt(interaction.attr('minAssociations')) || 0,
                 helpMessage: __('The minimum number of associations that the candidate is required to make to form a valid response.')
             },
-            max : {
-                fieldName:   'maxAssociations',
-                value:       _.parseInt(interaction.attr('maxAssociations')) || 0,
+            max: {
+                fieldName: 'maxAssociations',
+                value: _.parseInt(interaction.attr('maxAssociations')) || 0,
                 helpMessage: __('The maximum number of associations that the candidate is allowed to make.')
             },
-            upperThreshold : getMaxPairs(_.size(interaction.getChoices()))
-        }).on('render', function(){
-            var self = this;
-
+            upperThreshold: getMaxPairs(_.size(interaction.getChoices()))
+        }).on('render', function () {
             //the range is based on the number of possible associations
-            widget.on('choiceCreated choiceDeleted', function(data){
-                if(data.interaction.serial === interaction.serial){
-                    self.updateThresholds(1, getMaxPairs(_.size(interaction.getChoices())));
+            widget.on('choiceCreated choiceDeleted', data => {
+                if (data.interaction.serial === interaction.serial) {
+                    this.updateThresholds(1, getMaxPairs(_.size(interaction.getChoices())));
                 }
             });
         });

--- a/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicAssociateInteraction/states/Question.js
@@ -190,7 +190,7 @@ define([
                 $choiceForm.empty();
             }
         }
-    };
+    }
 
     /**
      * Exit the question state, leave the room cleaned up
@@ -213,7 +213,7 @@ define([
             widget._editor.destroy();
         }
         $('.image-editor.solid, .block-listing.source', this.widget.$container).css('min-width', 0);
-    };
+    }
 
     /**
      * The question state for the graphicAssociate interaction

--- a/views/js/qtiCreator/widgets/interactions/graphicGapMatchInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicGapMatchInteraction/Widget.js
@@ -57,7 +57,7 @@ define([
             //call parent initCreator
             Widget.initCreator.call(this);
 
-            const paper = this.createPaper(_.bind(this.scaleGapList, this));
+            const paper = this.createPaper(() => this.scaleGapList());
             if (paper) {
                 this.element.paper = paper;
                 this.createChoices();

--- a/views/js/qtiCreator/widgets/interactions/graphicGapMatchInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicGapMatchInteraction/Widget.js
@@ -13,22 +13,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015-2019 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
-
 
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'jquery', 'lodash', 'i18n',
+    'jquery',
+    'lodash',
+    'i18n',
     'ui/hider',
     'taoQtiItem/qtiCreator/widgets/interactions/Widget',
     'taoQtiItem/qtiCreator/widgets/interactions/graphicInteraction/Widget',
-    'taoQtiItem/qtiCreator/widgets/interactions/graphicGapMatchInteraction/states/states'
-], function($, _, __, hider, Widget, GraphicWidget, states){
-
+    'taoQtiItem/qtiCreator/widgets/interactions/graphicGapMatchInteraction/states/states',
+    'taoQtiItem/qtiCommonRenderer/helpers/Graphic'
+], function ($, _, __, hider, Widget, GraphicWidget, states, GraphicHelper) {
     'use strict';
 
     /**
@@ -39,8 +40,7 @@ define([
      *
      * @exports taoQtiItem/qtiCreator/widgets/interactions/graphicGapMatchInteraction/Widget
      */
-    var GraphicGapMatchInteractionWidget = _.extend(Widget.clone(), GraphicWidget, {
-
+    const GraphicGapMatchInteractionWidget = _.extend(Widget.clone(), GraphicWidget, {
         /**
          * Initialize the widget
          * @see {taoQtiItem/qtiCreator/widgets/interactions/Widget#initCreator}
@@ -48,8 +48,7 @@ define([
          * @param {String} options.baseUrl - the resource base url
          * @param {jQueryElement} options.choiceForm = a reference to the form of the choices
          */
-        initCreator : function(options){
-            var paper;
+        initCreator: function (options) {
             this.baseUrl = options.baseUrl;
             this.choiceForm = options.choiceForm;
 
@@ -58,8 +57,8 @@ define([
             //call parent initCreator
             Widget.initCreator.call(this);
 
-            paper = this.createPaper(_.bind(this.scaleGapList, this));
-            if(paper){
+            const paper = this.createPaper(_.bind(this.scaleGapList, this));
+            if (paper) {
                 this.element.paper = paper;
                 this.createChoices();
                 this.createGapImgs();
@@ -70,15 +69,14 @@ define([
          * Gracefully destroy the widget
          * @see {taoQtiItem/qtiCreator/widgets/Widget#destroy}
          */
-        destroy : function(){
-
-            var $container = this.$original;
-            var $item      = $container.parents('.qti-item');
+        destroy: function () {
+            const $container = this.$original;
+            const $item = $container.parents('.qti-item');
 
             //stop listening the resize
-            $item.off('resize.gridEdit.' + this.element.serial);
-            $(window).off('resize.qti-widget.' + this.element.serial);
-            $container.off('resize.qti-widget.' + this.element.serial);
+            $item.off(`resize.gridEdit.${this.element.serial}`);
+            $(window).off(`resize.qti-widget.${this.element.serial}`);
+            $container.off(`resize.qti-widget.${this.element.serial}`);
 
             //call parent destroy
             Widget.destroy.call(this);
@@ -89,31 +87,44 @@ define([
          * @param {Number} newSize - the interaction size
          * @param {Number} [factor=1] - scaling factor
          */
-        scaleGapList : function(newSize, factor){
-
-            var $container = this.$original;
-            var $gapList   = $('ul.source', $container);
-            $gapList.css('max-width', newSize + 'px');
-            if(factor && factor !== 1){
-                $gapList.find('img').each(function(){
-                    var $img = $(this);
-                    $img.width( $img.attr('width') * factor );
-                    $img.height( $img.attr('height') * factor );
+        scaleGapList: function (newSize, factor) {
+            const $container = this.$original;
+            const $gapList = $('ul.source', $container);
+            $gapList.css('max-width', `${newSize}px`);
+            if (factor && factor !== 1) {
+                $gapList.find('img').each(function () {
+                    const $img = $(this);
+                    $img.width($img.attr('width') * factor);
+                    $img.height($img.attr('height') * factor);
                 });
                 $container.data('factor', factor);
+            }
+            if (this.element.paper) {
+                const interaction = this.element;
+                const choices = interaction.getChoices();
+                _.forEach(choices, choice => {
+                    choice.attr(
+                        'coords',
+                        GraphicHelper.qtiCoords(
+                            interaction.paper.getById(choice.serial),
+                            interaction.paper,
+                            interaction.object.attr('width')
+                        )
+                    );
+                });
             }
         },
 
         /**
          * Create the gap images
          */
-        createGapImgs : function(){
-            var interaction = this.element;
-            var $container  = this.$original;
-            var $gapList    = $('ul.source', $container);
+        createGapImgs: function () {
+            const interaction = this.element;
+            const $container = this.$original;
+            const $gapList = $('ul.source', $container);
 
             $gapList.empty();
-            _.forEach(interaction.gapImgs, function(gapImg){
+            _.forEach(interaction.gapImgs, function (gapImg) {
                 $gapList.append(gapImg.render());
             });
         },
@@ -123,7 +134,7 @@ define([
          * @param {String} template
          * @param {Object} choice
          */
-        infinityMatchMax (template, choice) {
+        infinityMatchMax(template, choice) {
             const interaction = this.element;
             const response = interaction.getResponseDeclaration();
 
@@ -149,10 +160,10 @@ define([
          * @param {Array} choiceCollection
          * @returns {Array}
          */
-        getMatchMaxOrderedChoices (choiceCollection) {
+        getMatchMaxOrderedChoices(choiceCollection) {
             return _(choiceCollection)
                 .map(function (choice) {
-                    var matchMax = parseInt(choice.attr('matchMax'), 10);
+                    let matchMax = parseInt(choice.attr('matchMax'), 10);
                     if (_.isNaN(matchMax)) {
                         matchMax = 0;
                     }
@@ -166,24 +177,24 @@ define([
                 .valueOf();
         },
 
-        pairExists (collection, pair) {
+        pairExists(collection, pair) {
             if (pair.length !== 2) {
                 return false;
             }
-            return collection[pair[0] + ' ' + pair[1]] || collection[pair[1] + ' ' + pair[0]];
+            return collection[`${pair[0]} ${pair[1]}`] || collection[`${pair[1]} ${pair[0]}`];
         },
 
-        calculatePossiblePairs (interaction) {
-            var pairs = [];
-            var matchSet1 = this.getMatchMaxOrderedChoices(interaction.getGapImgs());
-            var matchSet2 = this.getMatchMaxOrderedChoices(interaction.getChoices());
+        calculatePossiblePairs(interaction) {
+            const pairs = [];
+            const matchSet1 = this.getMatchMaxOrderedChoices(interaction.getGapImgs());
+            const matchSet2 = this.getMatchMaxOrderedChoices(interaction.getChoices());
 
             _.forEach(matchSet1, choice1 => _.forEach(matchSet2, choice2 => pairs.push([choice1.id, choice2.id])));
 
             return pairs;
         },
 
-        isChoiceInfinitePair (identifier, interaction, response) {
+        isChoiceInfinitePair(identifier, interaction, response) {
             const mapEntries = response.mapEntries;
             const mapDefault = parseFloat(response.mappingAttributes.defaultValue) || 0;
 
@@ -193,7 +204,7 @@ define([
                 const possiblePairs = this.calculatePossiblePairs(interaction);
                 _.forEachRight(possiblePairs, pair => {
                     if (!this.pairExists(allPossibleMapEntries, pair)) {
-                        allPossibleMapEntries[pair[0] + ' ' + pair[1]] = mapDefault;
+                        allPossibleMapEntries[`${pair[0]} ${pair[1]}`] = mapDefault;
                     }
                 });
             }
@@ -206,7 +217,7 @@ define([
                         isInfinitePair = true;
                     }
                 }
-            })
+            });
             return isInfinitePair;
         }
     });

--- a/views/js/qtiCreator/widgets/interactions/graphicGapMatchInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicGapMatchInteraction/states/Question.js
@@ -13,10 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA ;
  *
  */
-
 
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
@@ -63,7 +62,7 @@ define([
     resourceManager,
     bgImage
 ) {
-    "use strict";
+    'use strict';
 
     var GraphicGapMatchInteractionStateQuestion;
 
@@ -99,8 +98,6 @@ define([
             .attr('width', width)
             .attr('height', height);
     }
-
-
 
     /**
      * Question State initialization: set up side bar, editors and shape factory
@@ -178,8 +175,6 @@ define([
             widget.changeState('sleep');
         });
 
-
-
         /**
          * Create the 'add option' button
          */
@@ -196,12 +191,10 @@ define([
 
                 // on successful upload
                 $addOption.on('selected.upload', function (e, args) {
-
                     $addOption.off('selected.upload');
 
                     const size = args.size;
-                    let height,
-                        width;
+                    let height, width;
 
                     if (size) {
                         height = args.size.height;
@@ -215,19 +208,16 @@ define([
                     setUpGapImg(gapImgObj);
                 });
                 resourceManager($addOption, gapImgSelectorOptions);
-
             });
             $addOption.appendTo($gapList);
         }
 
-
         /**
          * Insert and setup the gap image
          *
-         * @param gapImgObj
+         * @param {Object} gapImgObj
          */
         function setUpGapImg(gapImgObj) {
-
             const $gapList = $('ul.source', widget.$original),
                 $addOption = $('.empty', $gapList),
                 $deleteBtn = $(mediaTlbTpl());
@@ -273,7 +263,6 @@ define([
             var element, bbox, callbacks;
 
             if (choice) {
-
                 //get shape bounding box
                 element = interaction.paper.getById(serial);
                 bbox = element.getBBox();
@@ -292,32 +281,34 @@ define([
 
                 //controls match min/max for the choices (the shapes)
                 minMaxComponentFactory($choiceForm.find('.min-max-panel'), {
-                    min : {
-                        fieldName:   'matchMin',
-                        value:       _.parseInt(choice.attr('matchMin')) || 0,
+                    min: {
+                        fieldName: 'matchMin',
+                        value: _.parseInt(choice.attr('matchMin')) || 0,
                         helpMessage: __('The minimum number of choices this choice must be associated with to form a valid response.')
                     },
-                    max : {
-                        fieldName:   'matchMax',
-                        value:       _.parseInt(choice.attr('matchMax')) || 0,
+                    max: {
+                        fieldName: 'matchMax',
+                        value: _.parseInt(choice.attr('matchMax')) || 0,
                         helpMessage: __('The maximum number of choices this choice may be associated with.')
                     },
-                    upperThreshold :  _.size(interaction.getChoices()),
-                }).on('render', function(){
-                    var self = this;
+                    upperThreshold: _.size(interaction.getChoices())
+                })
+                    .on('render', function () {
+                        var self = this;
 
-                    //the range matches the number of choices
-                    widget.on('choiceCreated choiceDeleted', function(data){
-                        if(data.interaction.serial === interaction.serial){
-                            self.updateThresholds(1, _.size(interaction.getChoices()));
-                        }
+                        //the range matches the number of choices
+                        widget.on('choiceCreated choiceDeleted', function (data) {
+                            if (data.interaction.serial === interaction.serial) {
+                                self.updateThresholds(1, _.size(interaction.getChoices()));
+                            }
+                        });
+                        // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
+                        widget.infinityMatchMax('hotspot', choice);
+                    })
+                    .on('change', function () {
+                        // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
+                        widget.infinityMatchMax('hotspot', choice);
                     });
-                    // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
-                    widget.infinityMatchMax('hotspot', choice);
-                }).on('change', function () {
-                    // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
-                    widget.infinityMatchMax('hotspot', choice);
-                });
 
                 formElement.initWidget($choiceForm);
 
@@ -358,7 +349,6 @@ define([
          * @param {String} serial - the gapImg serial
          */
         function enterGapImgForm(serial) {
-
             let callbacks,
                 gapImg = interaction.getGapImg(serial),
                 initMediasizer,
@@ -367,62 +357,69 @@ define([
                 $mediaSizer;
 
             if (gapImg) {
-
-                $choiceForm.empty().html(gapImgFormTpl({
-                    identifier: gapImg.id(),
-                    fixed: gapImg.attr('fixed'),
-                    serial: serial,
-                    baseUrl: options.baseUrl,
-                    data: gapImg.object.attr('data'),
-                    width: gapImg.object.attr('width'),
-                    height: gapImg.object.attr('height'),
-                    type: gapImg.object.attr('type')
-                }));
+                $choiceForm.empty().html(
+                    gapImgFormTpl({
+                        identifier: gapImg.id(),
+                        fixed: gapImg.attr('fixed'),
+                        serial: serial,
+                        baseUrl: options.baseUrl,
+                        data: gapImg.object.attr('data'),
+                        width: gapImg.object.attr('width'),
+                        height: gapImg.object.attr('height'),
+                        type: gapImg.object.attr('type')
+                    })
+                );
 
                 //controls the match min/max for the gap images
                 minMaxComponentFactory($choiceForm.find('.min-max-panel'), {
-                    min : {
-                        fieldName:   'matchMin',
-                        value:       _.parseInt(gapImg.attr('matchMin')) || 0,
+                    min: {
+                        fieldName: 'matchMin',
+                        value: _.parseInt(gapImg.attr('matchMin')) || 0,
                         helpMessage: __('The minimum number of choices this choice must be associated with to form a valid response.')
                     },
-                    max : {
-                        fieldName:   'matchMax',
-                        value:       _.parseInt(gapImg.attr('matchMax')) || 0,
+                    max: {
+                        fieldName: 'matchMax',
+                        value: _.parseInt(gapImg.attr('matchMax')) || 0,
                         helpMessage: __('The maximum number of choices this choice may be associated with.')
                     },
-                    upperThreshold :  _.size(interaction.getChoices()),
-                }).on('render', function(){
-                    var self = this;
+                    upperThreshold: _.size(interaction.getChoices())
+                })
+                    .on('render', function () {
+                        var self = this;
 
-                    //the range is matching the number of choices (not the number of gap img)
-                    widget.on('choiceCreated choiceDeleted', function(data){
-                        if(data.interaction.serial === interaction.serial){
-                            self.updateThresholds(1, _.size(interaction.getChoices()));
-                        }
+                        //the range is matching the number of choices (not the number of gap img)
+                        widget.on('choiceCreated choiceDeleted', function (data) {
+                            if (data.interaction.serial === interaction.serial) {
+                                self.updateThresholds(1, _.size(interaction.getChoices()));
+                            }
+                        });
+                        // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
+                        widget.infinityMatchMax('gapImg', gapImg);
+                    })
+                    .on('change', function () {
+                        // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
+                        widget.infinityMatchMax('gapImg', gapImg);
                     });
-                    // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
-                    widget.infinityMatchMax('gapImg', gapImg);
-                }).on('change', function () {
-                    // display warning message in case matchMax is set to 0 (infinite) and pair is higher that 0
-                    widget.infinityMatchMax('gapImg', gapImg);
-                });
 
                 // <li/> that will contain the image
-                $gapImgBox = $(`li[data-serial="${  gapImg.serial  }"]`);
+                $gapImgBox = $(`li[data-serial="${gapImg.serial}"]`);
 
                 $gapImgElem = $gapImgBox.find('img');
 
                 //init media sizer
-                $mediaSizer = $choiceForm.find('.media-sizer-panel')
-                    .on('create.mediasizer', function(e, params) {
-                        // On creation, mediasizer uses style properties to set
-                        // width and height, but our image needs to use the
-                        // it's attributes to set and resize properly.
-                        params.width = $gapImgElem.attr('width');
-                        params.height = $gapImgElem.attr('height');
-                        applyMediasizerValues(params, widget.$original.data('factor'), $gapImgElem.get(0).naturalHeight, $gapImgElem.get(0).naturalWidth);
-                    });
+                $mediaSizer = $choiceForm.find('.media-sizer-panel').on('create.mediasizer', function (e, params) {
+                    // On creation, mediasizer uses style properties to set
+                    // width and height, but our image needs to use the
+                    // it's attributes to set and resize properly.
+                    params.width = $gapImgElem.attr('width');
+                    params.height = $gapImgElem.attr('height');
+                    applyMediasizerValues(
+                        params,
+                        widget.$original.data('factor'),
+                        $gapImgElem.get(0).naturalHeight,
+                        $gapImgElem.get(0).naturalWidth
+                    );
+                });
 
                 initMediasizer = function () {
                     // Hack to manually set mediasizer to use gapImg's height
@@ -464,8 +461,13 @@ define([
                 };
 
                 // callbacks
-                $mediaSizer.on('sizechange.mediasizer', function(e, params) {
-                    applyMediasizerValues(params, widget.$original.data('factor'), $gapImgElem.get(0).naturalHeight, $gapImgElem.get(0).naturalWidth);
+                $mediaSizer.on('sizechange.mediasizer', function (e, params) {
+                    applyMediasizerValues(
+                        params,
+                        widget.$original.data('factor'),
+                        $gapImgElem.get(0).naturalHeight,
+                        $gapImgElem.get(0).naturalWidth
+                    );
 
                     gapImg.object.attr('width', params.width);
                     gapImg.object.attr('height', params.height);
@@ -506,7 +508,6 @@ define([
             return;
         }
 
-
         $(window).off('resize.changestate');
 
         if (widget._editor) {
@@ -517,8 +518,7 @@ define([
         $('ul.source .empty', widget.$original).remove();
 
         //restore gapImg appearance
-        widget.$container.find('.qti-gapImg').removeClass('active')
-            .find('.mini-tlb').remove();
+        widget.$container.find('.qti-gapImg').removeClass('active').find('.mini-tlb').remove();
         $('.image-editor.solid, .block-listing.source', widget.$container).css('min-width', 0);
     }
 
@@ -533,19 +533,20 @@ define([
      * Initialize the form linked to the interaction
      */
     GraphicGapMatchInteractionStateQuestion.prototype.initForm = function () {
-
         var widget = this.widget;
         var options = widget.options;
         var interaction = widget.element;
         var $form = widget.$form;
 
-        $form.html(formTpl({
-            baseUrl: options.baseUrl,
-            data: interaction.object.attr('data'),
-            width: interaction.object.attr('width'),
-            height: interaction.object.attr('height'),
-            type: interaction.object.attr('type')
-        }));
+        $form.html(
+            formTpl({
+                baseUrl: options.baseUrl,
+                data: interaction.object.attr('data'),
+                width: interaction.object.attr('width'),
+                height: interaction.object.attr('height'),
+                type: interaction.object.attr('type')
+            })
+        );
 
         imageSelector($form, options);
 
@@ -553,10 +554,7 @@ define([
 
         bgImage.setupImage(widget);
 
-        bgImage.setChangeCallbacks(
-            widget,
-            formElement
-        );
+        bgImage.setChangeCallbacks(widget, formElement);
     };
 
     return GraphicGapMatchInteractionStateQuestion;

--- a/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/states/Question.js
@@ -13,10 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
-
 
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
@@ -35,57 +34,70 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/forms/interactions/graphicOrder',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/choices/hotspot',
     'taoQtiItem/qtiCreator/helper/panel',
-    'taoQtiItem/qtiCreator/widgets/interactions/helpers/bgImage',
-], function($, _, GraphicHelper, stateFactory, Question, shapeEditor, imageSelector, formElement, minMaxComponentFactory, identifierHelper, formTpl, choiceFormTpl, panel, bgImage){
-
+    'taoQtiItem/qtiCreator/widgets/interactions/helpers/bgImage'
+], function (
+    $,
+    _,
+    GraphicHelper,
+    stateFactory,
+    Question,
+    shapeEditor,
+    imageSelector,
+    formElement,
+    minMaxComponentFactory,
+    identifierHelper,
+    formTpl,
+    choiceFormTpl,
+    panel,
+    bgImage
+) {
     'use strict';
 
     /**
      * Question State initialization: set up side bar, editors and shae factory
      */
-    var initQuestionState = function initQuestionState(){
-
-        var widget      = this.widget;
+    var initQuestionState = function initQuestionState() {
+        var widget = this.widget;
         var interaction = widget.element;
-        var paper       = interaction.paper;
+        var paper = interaction.paper;
 
-        var $choiceForm  = widget.choiceForm;
+        var $choiceForm = widget.choiceForm;
         var $formInteractionPanel = $('#item-editor-interaction-property-bar');
         var $formChoicePanel = $('#item-editor-choice-property-bar');
 
         var $left, $top, $width, $height;
 
-        if(!paper){
+        if (!paper) {
             return;
         }
 
         //instantiate the shape editor, attach it to the widget to retrieve it during the exit phase
         widget._editor = shapeEditor(widget, {
-            shapeCreated : function(shape, type){
+            shapeCreated: function (shape, type) {
                 var newChoice = interaction.createChoice({
-                    shape  : type === 'path' ? 'poly' : type,
-                    coords : GraphicHelper.qtiCoords(shape)
+                    shape: type === 'path' ? 'poly' : type,
+                    coords: GraphicHelper.qtiCoords(shape)
                 });
 
                 //link the shape to the choice
                 shape.id = newChoice.serial;
             },
-            shapeRemoved : function(id){
+            shapeRemoved: function (id) {
                 interaction.removeChoice(id);
             },
-            enterHandling : function(shape){
+            enterHandling: function (shape) {
                 enterChoiceForm(shape.id);
             },
-            quitHandling : function(){
+            quitHandling: function () {
                 leaveChoiceForm();
             },
-            shapeChange : function(shape){
+            shapeChange: function (shape) {
                 var bbox;
                 var choice = interaction.getChoice(shape.id);
-                if(choice){
-                    choice.attr('coords', GraphicHelper.qtiCoords(shape));
+                if (choice) {
+                    choice.attr('coords', GraphicHelper.qtiCoords(shape, paper, interaction.object.attr('width')));
 
-                    if($left && $left.length){
+                    if ($left && $left.length) {
                         bbox = shape.getBBox();
                         $left.val(parseInt(bbox.x, 10));
                         $top.val(parseInt(bbox.y, 10));
@@ -101,13 +113,12 @@ define([
 
         //we need to stop the question mode on resize, to keep the coordinate system coherent,
         //even in responsive (the side bar introduce a biais)
-        $(window).on('resize.changestate', function(){
+        $(window).on('resize.changestate', function () {
             widget.changeState('sleep');
         });
 
-
-        widget.on('attributeChange', function(data){
-            if(data.key === 'maxChoices'){
+        widget.on('attributeChange', function (data) {
+            if (data.key === 'maxChoices') {
                 widget.renderOrderList();
             }
         });
@@ -116,24 +127,23 @@ define([
          * @private
          * @param {String} serial - the choice serial
          */
-        function enterChoiceForm(serial){
+        function enterChoiceForm(serial) {
             var choice = interaction.getChoice(serial);
             var element, bbox;
-            if(choice){
-
+            if (choice) {
                 //get shape bounding box
                 element = interaction.paper.getById(serial);
                 bbox = element.getBBox();
 
                 $choiceForm.empty().html(
                     choiceFormTpl({
-                        identifier  : choice.id(),
-                        fixed       : choice.attr('fixed'),
-                        serial      : serial,
-                        x           : parseInt(bbox.x, 10),
-                        y           : parseInt(bbox.y, 10),
-                        width       : parseInt(bbox.width, 10),
-                        height      : parseInt(bbox.height, 10)
+                        identifier: choice.id(),
+                        fixed: choice.attr('fixed'),
+                        serial: serial,
+                        x: parseInt(bbox.x, 10),
+                        y: parseInt(bbox.y, 10),
+                        width: parseInt(bbox.width, 10),
+                        height: parseInt(bbox.height, 10)
                     })
                 );
 
@@ -141,8 +151,8 @@ define([
 
                 //init data validation and binding
                 formElement.setChangeCallbacks($choiceForm, choice, {
-                    identifier  : identifierHelper.updateChoiceIdentifier,
-                    fixed       : formElement.getAttributeChangeCallback()
+                    identifier: identifierHelper.updateChoiceIdentifier,
+                    fixed: formElement.getAttributeChangeCallback()
                 });
 
                 $formChoicePanel.show();
@@ -150,9 +160,9 @@ define([
                 panel.closeSections($formInteractionPanel.children('section'));
 
                 //change the nodes bound to the position fields
-                $left   = $('input[name=x]', $choiceForm);
-                $top    = $('input[name=y]', $choiceForm);
-                $width  = $('input[name=width]', $choiceForm);
+                $left = $('input[name=x]', $choiceForm);
+                $top = $('input[name=y]', $choiceForm);
+                $width = $('input[name=width]', $choiceForm);
                 $height = $('input[name=height]', $choiceForm);
             }
         }
@@ -161,8 +171,8 @@ define([
          * Leave the choice form
          * @private
          */
-        function leaveChoiceForm(){
-            if($formChoicePanel.css('display') !== 'none'){
+        function leaveChoiceForm() {
+            if ($formChoicePanel.css('display') !== 'none') {
                 panel.openSections($formInteractionPanel.children('section'));
                 $formChoicePanel.hide();
                 $choiceForm.empty();
@@ -173,21 +183,21 @@ define([
     /**
      * Exit the question state, leave the room cleaned up
      */
-    var exitQuestionState = function initQuestionState(){
-        var widget      = this.widget;
+    var exitQuestionState = function exitQuestionState() {
+        var widget = this.widget;
         var interaction = widget.element;
-        var paper       = interaction.paper;
-        var valid       = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
+        var paper = interaction.paper;
+        var valid = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
 
         widget.isValid('graphicOrderInteraction', valid);
 
-        if(!paper){
+        if (!paper) {
             return;
         }
 
         $(window).off('resize.changestate');
 
-        if(widget._editor){
+        if (widget._editor) {
             widget._editor.destroy();
         }
         $('.image-editor.solid, .block-listing.source', this.widget.$container).css('min-width', 0);
@@ -203,30 +213,31 @@ define([
     /**
      * Initialize the form linked to the interaction
      */
-    GraphicOrderInteractionStateQuestion.prototype.initForm = function(){
-
+    GraphicOrderInteractionStateQuestion.prototype.initForm = function () {
         var widget = this.widget;
         var options = widget.options;
         var interaction = widget.element;
         var $form = widget.$form;
 
-        $form.html(formTpl({
-            baseUrl         : options.baseUrl,
-            data            : interaction.object.attr('data'),
-            width           : interaction.object.attr('width'),
-            height          : interaction.object.attr('height'),
-            type            : interaction.object.attr('type')
-        }));
+        $form.html(
+            formTpl({
+                baseUrl: options.baseUrl,
+                data: interaction.object.attr('data'),
+                width: interaction.object.attr('width'),
+                height: interaction.object.attr('height'),
+                type: interaction.object.attr('type')
+            })
+        );
 
         //controls min and max choices
         minMaxComponentFactory($form.find('.min-max-panel'), {
-            min : { value : _.parseInt(interaction.attr('minChoices')) || 0 },
-            max : { value : _.parseInt(interaction.attr('maxChoices')) || 0 },
-            upperThreshold : _.size(interaction.getChoices())
-        }).on('render', function(){
+            min: { value: _.parseInt(interaction.attr('minChoices')) || 0 },
+            max: { value: _.parseInt(interaction.attr('maxChoices')) || 0 },
+            upperThreshold: _.size(interaction.getChoices())
+        }).on('render', function () {
             var self = this;
-            widget.on('choiceCreated choiceDeleted', function(data){
-                if(data.interaction.serial === interaction.serial){
+            widget.on('choiceCreated choiceDeleted', function (data) {
+                if (data.interaction.serial === interaction.serial) {
                     self.updateThresholds(1, _.size(interaction.getChoices()));
                 }
             });
@@ -242,7 +253,7 @@ define([
         bgImage.setChangeCallbacks(
             widget,
             formElement,
-            formElement.getMinMaxAttributeCallbacks('minChoices', 'maxChoices', {updateCardinality:false})
+            formElement.getMinMaxAttributeCallbacks('minChoices', 'maxChoices', { updateCardinality: false })
         );
     };
 

--- a/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/states/Question.js
@@ -56,16 +56,16 @@ define([
     /**
      * Question State initialization: set up side bar, editors and shae factory
      */
-    var initQuestionState = function initQuestionState() {
-        var widget = this.widget;
-        var interaction = widget.element;
-        var paper = interaction.paper;
+    function initQuestionState() {
+        const widget = this.widget;
+        const interaction = widget.element;
+        const paper = interaction.paper;
 
-        var $choiceForm = widget.choiceForm;
-        var $formInteractionPanel = $('#item-editor-interaction-property-bar');
-        var $formChoicePanel = $('#item-editor-choice-property-bar');
+        const $choiceForm = widget.choiceForm;
+        const $formInteractionPanel = $('#item-editor-interaction-property-bar');
+        const $formChoicePanel = $('#item-editor-choice-property-bar');
 
-        var $left, $top, $width, $height;
+        let $left, $top, $width, $height;
 
         if (!paper) {
             return;
@@ -74,7 +74,7 @@ define([
         //instantiate the shape editor, attach it to the widget to retrieve it during the exit phase
         widget._editor = shapeEditor(widget, {
             shapeCreated: function (shape, type) {
-                var newChoice = interaction.createChoice({
+                const newChoice = interaction.createChoice({
                     shape: type === 'path' ? 'poly' : type,
                     coords: GraphicHelper.qtiCoords(shape)
                 });
@@ -92,13 +92,12 @@ define([
                 leaveChoiceForm();
             },
             shapeChange: function (shape) {
-                var bbox;
-                var choice = interaction.getChoice(shape.id);
+                const choice = interaction.getChoice(shape.id);
                 if (choice) {
                     choice.attr('coords', GraphicHelper.qtiCoords(shape, paper, interaction.object.attr('width')));
 
                     if ($left && $left.length) {
-                        bbox = shape.getBBox();
+                        const bbox = shape.getBBox();
                         $left.val(parseInt(bbox.x, 10));
                         $top.val(parseInt(bbox.y, 10));
                         $width.val(parseInt(bbox.width, 10));
@@ -128,12 +127,11 @@ define([
          * @param {String} serial - the choice serial
          */
         function enterChoiceForm(serial) {
-            var choice = interaction.getChoice(serial);
-            var element, bbox;
+            const choice = interaction.getChoice(serial);
             if (choice) {
                 //get shape bounding box
-                element = interaction.paper.getById(serial);
-                bbox = element.getBBox();
+                const element = interaction.paper.getById(serial);
+                const bbox = element.getBBox();
 
                 $choiceForm.empty().html(
                     choiceFormTpl({
@@ -178,16 +176,16 @@ define([
                 $choiceForm.empty();
             }
         }
-    };
+    }
 
     /**
      * Exit the question state, leave the room cleaned up
      */
-    var exitQuestionState = function exitQuestionState() {
-        var widget = this.widget;
-        var interaction = widget.element;
-        var paper = interaction.paper;
-        var valid = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
+    function exitQuestionState() {
+        const widget = this.widget;
+        const interaction = widget.element;
+        const paper = interaction.paper;
+        const valid = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
 
         widget.isValid('graphicOrderInteraction', valid);
 
@@ -201,23 +199,23 @@ define([
             widget._editor.destroy();
         }
         $('.image-editor.solid, .block-listing.source', this.widget.$container).css('min-width', 0);
-    };
+    }
 
     /**
      * The question state for the graphicOrder interaction
      * @extends taoQtiItem/qtiCreator/widgets/interactions/blockInteraction/states/Question
      * @exports taoQtiItem/qtiCreator/widgets/interactions/graphicOrderInteraction/states/Question
      */
-    var GraphicOrderInteractionStateQuestion = stateFactory.extend(Question, initQuestionState, exitQuestionState);
+    const GraphicOrderInteractionStateQuestion = stateFactory.extend(Question, initQuestionState, exitQuestionState);
 
     /**
      * Initialize the form linked to the interaction
      */
     GraphicOrderInteractionStateQuestion.prototype.initForm = function () {
-        var widget = this.widget;
-        var options = widget.options;
-        var interaction = widget.element;
-        var $form = widget.$form;
+        const widget = this.widget;
+        const options = widget.options;
+        const interaction = widget.element;
+        const $form = widget.$form;
 
         $form.html(
             formTpl({
@@ -235,10 +233,9 @@ define([
             max: { value: _.parseInt(interaction.attr('maxChoices')) || 0 },
             upperThreshold: _.size(interaction.getChoices())
         }).on('render', function () {
-            var self = this;
-            widget.on('choiceCreated choiceDeleted', function (data) {
+            widget.on('choiceCreated choiceDeleted', data => {
                 if (data.interaction.serial === interaction.serial) {
-                    self.updateThresholds(1, _.size(interaction.getChoices()));
+                    this.updateThresholds(1, _.size(interaction.getChoices()));
                 }
             });
         });

--- a/views/js/qtiCreator/widgets/interactions/helpers/bgImage.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/bgImage.js
@@ -114,7 +114,7 @@ define([
             responsive: false,
             parentSelector: widget.$original.attr('id'),
             applyToMedium: false,
-            maxWidth: parseInt(widget.element.object.attr('width'), 10)
+            maxWidth: parseInt(widget.$original.width())
         });
 
         $mediaSizer.on('sizechange.mediasizer', function (e, params) {

--- a/views/js/qtiCreator/widgets/interactions/hotspotInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/hotspotInteraction/Widget.js
@@ -13,21 +13,22 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
-
 
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'jquery', 'lodash', 'i18n',
+    'jquery',
+    'lodash',
+    'i18n',
     'taoQtiItem/qtiCreator/widgets/interactions/Widget',
     'taoQtiItem/qtiCreator/widgets/interactions/graphicInteraction/Widget',
-    'taoQtiItem/qtiCreator/widgets/interactions/hotspotInteraction/states/states'
-], function($, _, __, Widget, GraphicWidget, states){
-
+    'taoQtiItem/qtiCreator/widgets/interactions/hotspotInteraction/states/states',
+    'taoQtiItem/qtiCommonRenderer/helpers/Graphic'
+], function ($, _, __, Widget, GraphicWidget, states, GraphicHelper) {
     'use strict';
 
     /**
@@ -37,55 +38,62 @@ define([
      * @extends taoQtiItem/qtiCreator/widgets/interactions/GraphicInteraction/Widget
      *
      * @exports taoQtiItem/qtiCreator/widgets/interactions/hotspotInteraction/Widget
-     */      
-    var HotspotInteractionWidget = _.extend(Widget.clone(), GraphicWidget, {
-
+     */
+    const HotspotInteractionWidget = _.extend(Widget.clone(), GraphicWidget, {
         /**
          * Initialize the widget
          * @see {taoQtiItem/qtiCreator/widgets/interactions/Widget#initCreator}
-         * @param {Object} options - extra options 
+         * @param {Object} options - extra options
          * @param {String} options.baseUrl - the resource base url
          * @param {jQueryElement} options.choiceForm = a reference to the form of the choices
          */
-        initCreator : function(options){
-            var paper;
+        initCreator: function (options) {
             this.baseUrl = options.baseUrl;
             this.choiceForm = options.choiceForm;
-            
+
             this.registerStates(states);
-            
+
             //call parent initCreator
             Widget.initCreator.call(this);
-          
-            paper = this.createPaper(); 
-            if(paper){
+
+            const paper = this.createPaper(_.bind(this.scaleChoices, this));
+            if (paper) {
                 this.element.paper = paper;
-                this.createChoices();    
+                this.createChoices();
             }
         },
-
+        /**
+         * Called back on paper resize to scale the choices coords
+         */
+        scaleChoices: function () {
+            if (this.element.paper) {
+                const interaction = this.element;
+                const choices = interaction.getChoices();
+                _.forEach(choices, choice => {
+                    choice.attr(
+                        'coords',
+                        GraphicHelper.qtiCoords(interaction.paper.getById(choice.serial), interaction.paper, interaction.object.attr('width'))
+                    );
+                });
+            }
+        },
         /**
          * Gracefull destroy the widget
          * @see {taoQtiItem/qtiCreator/widgets/Widget#destroy}
-         * @param {Object} options - extra options 
-         * @param {String} options.baseUrl - the resource base url
-         * @param {jQueryElement} options.choiceForm = a reference to the form of the choices
          */
-        destroy : function(){
-
-            var $container = this.$original;
-            var $item      = $container.parents('.qti-item');
+        destroy: function () {
+            const $container = this.$original;
+            const $item = $container.parents('.qti-item');
 
             //stop listening the resize
-            $item.off('resize.gridEdit.' + this.element.serial);
-            $(window).off('resize.qti-widget.' + this.element.serial);
-            $container.off('resize.qti-widget.' + this.element.serial);
+            $item.off(`resize.gridEdit.${this.element.serial}`);
+            $(window).off(`resize.qti-widget.${this.element.serial}`);
+            $container.off(`resize.qti-widget.${this.element.serial}`);
 
             //call parent destroy
             Widget.destroy.call(this);
         }
-
-   });
+    });
 
     return HotspotInteractionWidget;
 });

--- a/views/js/qtiCreator/widgets/interactions/hotspotInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/hotspotInteraction/Widget.js
@@ -56,7 +56,7 @@ define([
             //call parent initCreator
             Widget.initCreator.call(this);
 
-            const paper = this.createPaper(_.bind(this.scaleChoices, this));
+            const paper = this.createPaper(() => this.scaleChoices());
             if (paper) {
                 this.element.paper = paper;
                 this.createChoices();

--- a/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Question.js
@@ -56,7 +56,7 @@ define([
     /**
      * Question State initialization: set up side bar, editors and shae factory
      */
-    const initQuestionState = function initQuestionState() {
+    function initQuestionState() {
         const widget = this.widget;
         const interaction = widget.element;
         const paper = interaction.paper;
@@ -177,7 +177,7 @@ define([
     /**
      * Exit the question state, leave the room cleaned up
      */
-    const exitQuestionState = function exitQuestionState() {
+    function exitQuestionState() {
         const widget = this.widget;
         const interaction = widget.element;
         const paper = interaction.paper;

--- a/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Question.js
@@ -13,10 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
-
 
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
@@ -36,57 +35,69 @@ define([
     'tpl!taoQtiItem/qtiCreator/tpl/forms/choices/hotspot',
     'taoQtiItem/qtiCreator/helper/panel',
     'taoQtiItem/qtiCreator/widgets/interactions/helpers/bgImage'
-], function($, _, GraphicHelper, stateFactory, Question, shapeEditor, imageSelector, formElement, minMaxComponentFactory,  identifierHelper, formTpl, choiceFormTpl, panel, bgImage){
-
+], function (
+    $,
+    _,
+    GraphicHelper,
+    stateFactory,
+    Question,
+    shapeEditor,
+    imageSelector,
+    formElement,
+    minMaxComponentFactory,
+    identifierHelper,
+    formTpl,
+    choiceFormTpl,
+    panel,
+    bgImage
+) {
     'use strict';
 
     /**
      * Question State initialization: set up side bar, editors and shae factory
      */
-    var initQuestionState = function initQuestionState(){
+    const initQuestionState = function initQuestionState() {
+        const widget = this.widget;
+        const interaction = widget.element;
+        const paper = interaction.paper;
 
-        var widget      = this.widget;
-        var interaction = widget.element;
-        var paper       = interaction.paper;
+        const $choiceForm = widget.choiceForm;
+        const $formInteractionPanel = $('#item-editor-interaction-property-bar');
+        const $formChoicePanel = $('#item-editor-choice-property-bar');
 
-        var $choiceForm  = widget.choiceForm;
-        var $formInteractionPanel = $('#item-editor-interaction-property-bar');
-        var $formChoicePanel = $('#item-editor-choice-property-bar');
+        let $left, $top, $width, $height;
 
-        var $left, $top, $width, $height;
-
-        if(!paper){
+        if (!paper) {
             return;
         }
 
         //instantiate the shape editor, attach it to the widget to retrieve it during the exit phase
         widget._editor = shapeEditor(widget, {
-            shapeCreated : function(shape, type){
-                var newChoice = interaction.createChoice({
-                    shape  : type === 'path' ? 'poly' : type,
-                    coords : GraphicHelper.qtiCoords(shape)
+            shapeCreated: function (shape, type) {
+                const newChoice = interaction.createChoice({
+                    shape: type === 'path' ? 'poly' : type,
+                    coords: GraphicHelper.qtiCoords(shape)
                 });
 
                 //link the shape to the choice
                 shape.id = newChoice.serial;
             },
-            shapeRemoved : function(id){
+            shapeRemoved: function (id) {
                 interaction.removeChoice(id);
             },
-            enterHandling : function(shape){
+            enterHandling: function (shape) {
                 enterChoiceForm(shape.id);
             },
-            quitHandling : function(){
+            quitHandling: function () {
                 leaveChoiceForm();
             },
-            shapeChange : function(shape){
-                var bbox;
-                var choice = interaction.getChoice(shape.id);
-                if(choice){
-                    choice.attr('coords', GraphicHelper.qtiCoords(shape));
+            shapeChange: function (shape) {
+                const choice = interaction.getChoice(shape.id);
+                if (choice) {
+                    choice.attr('coords', GraphicHelper.qtiCoords(shape, paper, interaction.object.attr('width')));
 
-                    if($left && $left.length){
-                        bbox = shape.getBBox();
+                    if ($left && $left.length) {
+                        const bbox = shape.getBBox();
                         $left.val(parseInt(bbox.x, 10));
                         $top.val(parseInt(bbox.y, 10));
                         $width.val(parseInt(bbox.width, 10));
@@ -101,7 +112,7 @@ define([
 
         //we need to stop the question mode on resize, to keep the coordinate system coherent,
         //even in responsive (the side bar introduce a biais)
-        $(window).on('resize.changestate', function(){
+        $(window).on('resize.changestate', function () {
             widget.changeState('sleep');
         });
 
@@ -110,25 +121,23 @@ define([
          * @private
          * @param {String} serial - the choice serial
          */
-        function enterChoiceForm(serial){
-            var choice = interaction.getChoice(serial);
-            var element, bbox;
+        function enterChoiceForm(serial) {
+            const choice = interaction.getChoice(serial);
 
-            if(choice){
-
+            if (choice) {
                 //get shape bounding box
-                element = interaction.paper.getById(serial);
-                bbox = element.getBBox();
+                const element = interaction.paper.getById(serial);
+                const bbox = element.getBBox();
 
                 $choiceForm.empty().html(
                     choiceFormTpl({
-                        identifier  : choice.id(),
-                        fixed       : choice.attr('fixed'),
-                        serial      : serial,
-                        x           : parseInt(bbox.x, 10),
-                        y           : parseInt(bbox.y, 10),
-                        width       : parseInt(bbox.width, 10),
-                        height      : parseInt(bbox.height, 10)
+                        identifier: choice.id(),
+                        fixed: choice.attr('fixed'),
+                        serial: serial,
+                        x: parseInt(bbox.x, 10),
+                        y: parseInt(bbox.y, 10),
+                        width: parseInt(bbox.width, 10),
+                        height: parseInt(bbox.height, 10)
                     })
                 );
 
@@ -136,8 +145,8 @@ define([
 
                 //init data validation and binding
                 formElement.setChangeCallbacks($choiceForm, choice, {
-                    identifier  : identifierHelper.updateChoiceIdentifier,
-                    fixed       : formElement.getAttributeChangeCallback()
+                    identifier: identifierHelper.updateChoiceIdentifier,
+                    fixed: formElement.getAttributeChangeCallback()
                 });
 
                 $formChoicePanel.show();
@@ -145,9 +154,9 @@ define([
                 panel.closeSections($formInteractionPanel.children('section'));
 
                 //change the nodes bound to the position fields
-                $left   = $('input[name=x]', $choiceForm);
-                $top    = $('input[name=y]', $choiceForm);
-                $width  = $('input[name=width]', $choiceForm);
+                $left = $('input[name=x]', $choiceForm);
+                $top = $('input[name=y]', $choiceForm);
+                $width = $('input[name=width]', $choiceForm);
                 $height = $('input[name=height]', $choiceForm);
             }
         }
@@ -156,8 +165,8 @@ define([
          * Leave the choice form
          * @private
          */
-        function leaveChoiceForm(){
-            if($formChoicePanel.css('display') !== 'none'){
+        function leaveChoiceForm() {
+            if ($formChoicePanel.css('display') !== 'none') {
                 panel.openSections($formInteractionPanel.children('section'));
                 $formChoicePanel.hide();
                 $choiceForm.empty();
@@ -168,21 +177,21 @@ define([
     /**
      * Exit the question state, leave the room cleaned up
      */
-    var exitQuestionState = function initQuestionState(){
-        var widget      = this.widget;
-        var interaction = widget.element;
-        var paper       = interaction.paper;
-        var valid       = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
+    const exitQuestionState = function exitQuestionState() {
+        const widget = this.widget;
+        const interaction = widget.element;
+        const paper = interaction.paper;
+        const valid = !!interaction.object.attr('data') && !_.isEmpty(interaction.choices);
 
         widget.isValid('hotspotInteraction', valid);
 
-        if(!paper){
+        if (!paper) {
             return;
         }
 
         $(window).off('resize.changestate');
 
-        if(widget._editor){
+        if (widget._editor) {
             widget._editor.destroy();
         }
         $('.image-editor.solid, .block-listing.source', widget.$container).css('min-width', 0);
@@ -193,36 +202,36 @@ define([
      * @extends taoQtiItem/qtiCreator/widgets/interactions/blockInteraction/states/Question
      * @exports taoQtiItem/qtiCreator/widgets/interactions/hotspotInteraction/states/Question
      */
-    var HotspotInteractionStateQuestion = stateFactory.extend(Question, initQuestionState, exitQuestionState);
+    const HotspotInteractionStateQuestion = stateFactory.extend(Question, initQuestionState, exitQuestionState);
 
     /**
      * Initialize the form linked to the interaction
      */
-    HotspotInteractionStateQuestion.prototype.initForm = function initForm(){
+    HotspotInteractionStateQuestion.prototype.initForm = function initForm() {
+        const widget = this.widget;
+        const options = widget.options;
+        const interaction = widget.element;
+        const $form = widget.$form;
 
-        var widget = this.widget;
-        var options = widget.options;
-        var interaction = widget.element;
-        var $form = widget.$form;
-
-        $form.html(formTpl({
-            baseUrl         : options.baseUrl,
-            data            : interaction.object.attr('data'),
-            width           : interaction.object.attr('width'),
-            height          : interaction.object.attr('height'),
-            type            : interaction.object.attr('type')
-        }));
+        $form.html(
+            formTpl({
+                baseUrl: options.baseUrl,
+                data: interaction.object.attr('data'),
+                width: interaction.object.attr('width'),
+                height: interaction.object.attr('height'),
+                type: interaction.object.attr('type')
+            })
+        );
 
         //controls the min and max choices
         minMaxComponentFactory($form.find('.min-max-panel'), {
-            min : { value : _.parseInt(interaction.attr('minChoices')) || 0 },
-            max : { value : _.parseInt(interaction.attr('maxChoices')) || 0 },
-            upperThreshold : _.size(interaction.getChoices())
-        }).on('render', function(){
-            var self = this;
-            widget.on('choiceCreated choiceDeleted', function(data){
-                if(data.interaction.serial === interaction.serial){
-                    self.updateThresholds(1, _.size(interaction.getChoices()));
+            min: { value: _.parseInt(interaction.attr('minChoices')) || 0 },
+            max: { value: _.parseInt(interaction.attr('maxChoices')) || 0 },
+            upperThreshold: _.size(interaction.getChoices())
+        }).on('render', function () {
+            widget.on('choiceCreated choiceDeleted', data => {
+                if (data.interaction.serial === interaction.serial) {
+                    this.updateThresholds(1, _.size(interaction.getChoices()));
                 }
             });
         });

--- a/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/hotspotInteraction/states/Question.js
@@ -172,7 +172,7 @@ define([
                 $choiceForm.empty();
             }
         }
-    };
+    }
 
     /**
      * Exit the question state, leave the room cleaned up
@@ -195,7 +195,7 @@ define([
             widget._editor.destroy();
         }
         $('.image-editor.solid, .block-listing.source', widget.$container).css('min-width', 0);
-    };
+    }
 
     /**
      * The question state for the hotspot interaction

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.6.1.tgz",
-            "integrity": "sha512-3m9gw3rxGlWM5x2tpEA96Mb9o3mIpDdZ4l7c2AItV5B7f06f3w9ZsvvxjmxDf242qXrFGY98DP6IM1d80Yp7Nw=="
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.6.2.tgz",
+            "integrity": "sha512-TYZswVSglzjjORvqeS2nsbCmBVYZlDYLl5WSagTM0tfM7NBSX5VAunPohiF0jh9a59mO8XRPi12HopJNkZ1VAg=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "1.6.1"
+        "@oat-sa/tao-item-runner-qti": "1.6.2"
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1910

**!Will be separate ticket to rework responsive and fixed sizes for graphic interactions**

**Lib should be updated :**

- [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/326

Issue: 
1. when size of background image for HotSpot updated - coords of shapes wasn't recalculated
2. size of image wasn't restored after reopening item in Authoring

How to test:
- go to item Authoring
- add HotSpot interaction
- add shapes on it
- go to item Style Editor, set Item width to Defined width
- set focus on HotSpot interaction
- update size
- save item
- reopen in Item Authoring, see the same size
- open in preview, see that HotSpots on proper positions and size in correct

![image](https://user-images.githubusercontent.com/25976342/196411024-fcb0a881-7e03-497a-b294-b5d45e39a2ed.png)
 
![image](https://user-images.githubusercontent.com/25976342/196411169-aefff6d0-ae16-4fe1-bff0-b77403e0bad1.png)
