### PR TITLE
[PISA25-101] [FIX] sanitize path when importing items

### DIFF
--- a/model/qti/metadata/ontology/GenericLomOntologyClassificationInjector.php
+++ b/model/qti/metadata/ontology/GenericLomOntologyClassificationInjector.php
@@ -91,7 +91,7 @@ class GenericLomOntologyClassificationInjector implements MetadataInjector
             foreach ($metadataValues as $metadataValue) {
                 $lang = $metadataValue->getLanguage() ?: DEFAULT_LANG;
                 $path = $metadataValue->getPath();
-                $valuePath = trim(end($path));
+                $valuePath = trim((string)end($path));
 
                 if (in_array($valuePath, $propertyURIs)) {
                     if (!isset($newPropertyValues[$lang])) {

--- a/model/qti/metadata/ontology/GenericLomOntologyClassificationInjector.php
+++ b/model/qti/metadata/ontology/GenericLomOntologyClassificationInjector.php
@@ -91,7 +91,7 @@ class GenericLomOntologyClassificationInjector implements MetadataInjector
             foreach ($metadataValues as $metadataValue) {
                 $lang = $metadataValue->getLanguage() ?: DEFAULT_LANG;
                 $path = $metadataValue->getPath();
-                $valuePath = end($path);
+                $valuePath = trim(end($path));
 
                 if (in_array($valuePath, $propertyURIs)) {
                     if (!isset($newPropertyValues[$lang])) {

--- a/test/unit/model/qti/metadata/ontology/GenericLomOntologyClassificationInjectorTest.php
+++ b/test/unit/model/qti/metadata/ontology/GenericLomOntologyClassificationInjectorTest.php
@@ -62,6 +62,8 @@ class GenericLomOntologyClassificationInjectorTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!defined('DEFAULT_LANG')) define('DEFAULT_LANG','en-US');
+
         $this->ontologyMock = $this->createMock(Ontology::class);
         $this->classMock = $this->createMock(core_kernel_classes_Class::class);
         $this->property1Mock = $this->createMock(
@@ -159,6 +161,60 @@ class GenericLomOntologyClassificationInjectorTest extends TestCase
 
         $this->sut->inject($this->resourceMock, ['choice' => [$metadataValue]]);
     }
+
+    public function testInjectPathWithSpacesShouldTrimSpaces(): void
+    {
+        $this->setupOntologyMock(1, ['property://1' => $this->property1Mock]);
+        $this->classMock
+            ->expects($this->atLeastOnce())
+            ->method('getProperties')
+            ->with(true)
+            ->willReturn(
+                [
+                    $this->property1Mock
+                ]
+            );
+
+        $this->previousValuesMock
+            ->expects($this->once())
+            ->method('count')
+            ->willReturn(1);
+
+        $this->resourceMock
+            ->expects($this->once())
+            ->method('getPropertyValuesByLg')
+            ->with($this->property1Mock, 'en-US')
+            ->willReturn($this->previousValuesMock);
+
+        $this->resourceMock
+            ->expects($this->never())
+            ->method('setPropertyValueByLg');
+
+        $this->resourceMock
+            ->expects($this->once())
+            ->method('editPropertyValueByLg')
+            ->with($this->property1Mock, 'qti_v2_item_01', 'en-US');
+
+        $this->ontologyMock
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('property://1');
+
+        $metadataValue = new SimpleMetadataValue(
+            'choice',
+            [
+                'http://www.imsglobal.org/xsd/imsmd_v1p2#lom',
+                'http://www.imsglobal.org/xsd/imsmd_v1p2#general',
+                PHP_EOL . '   property://1   ' . PHP_EOL,
+            ],
+            'qti_v2_item_01'
+        );
+
+        $this->sut->inject($this->resourceMock, ['choice' => [$metadataValue]]);
+    }
+
+
+
 
     public function testInjectMappedMultiValuePropertyWithPreviousValue(): void
     {

--- a/test/unit/model/qti/metadata/ontology/GenericLomOntologyClassificationInjectorTest.php
+++ b/test/unit/model/qti/metadata/ontology/GenericLomOntologyClassificationInjectorTest.php
@@ -62,8 +62,6 @@ class GenericLomOntologyClassificationInjectorTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!defined('DEFAULT_LANG')) define('DEFAULT_LANG','en-US');
-
         $this->ontologyMock = $this->createMock(Ontology::class);
         $this->classMock = $this->createMock(core_kernel_classes_Class::class);
         $this->property1Mock = $this->createMock(


### PR DESCRIPTION
## Overview
When importing items, it might happen that nodes inside imsmanifest.xml can be with break lines or empty space due to file identation. For thoses cases, the import was not working. That's why the sanitization was required

Refs: https://oat-sa.atlassian.net/browse/PISA25-101

## How to test:
Please take a look: https://oat-sa.atlassian.net/browse/PISA25-101?focusedCommentId=203236