### PR TITLE
fix: catch not found exception

### DIFF
--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -508,8 +508,11 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
      */
     protected function getZipLocation(PortableElementObject $object)
     {
-        return \tao_helpers_Export::getExportPath() . DIRECTORY_SEPARATOR . 'pciPackage_' . $object->getTypeIdentifier(
-            ) . '.zip';
+        return \tao_helpers_Export::getExportPath()
+            . DIRECTORY_SEPARATOR
+            . 'pciPackage_'
+            . $object->getTypeIdentifier()
+            . '.zip';
     }
 
     /**

--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -44,7 +44,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
     use PortableElementModelTrait;
     use LoggerAwareTrait;
 
-    /** @var PortableElementFileStorage  */
+    /** @var PortableElementFileStorage */
     protected $storage;
 
     protected $fileSystemId = 'taoQtiItem';
@@ -57,13 +57,13 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
 
     /**
      *
-     * @author Lionel Lecaque, lionel@taotesting.com
      * @return PortableElementRegistry
+     * @author Lionel Lecaque, lionel@taotesting.com
      */
     public static function getRegistry()
     {
         $class = get_called_class();
-        if (! isset(self::$registries[$class])) {
+        if (!isset(self::$registries[$class])) {
             self::$registries[$class] = new $class();
         }
 
@@ -194,7 +194,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
     public function has($identifier, $version = null)
     {
         try {
-            return (bool) $this->fetch($identifier, $version);
+            return (bool)$this->fetch($identifier, $version);
         } catch (PortableElementNotFoundException $e) {
             return false;
         }
@@ -206,7 +206,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
     public function update(PortableElementObject $object)
     {
         $mapByIdentifier = $this->get($object->getTypeIdentifier());
-        if (! is_array($mapByIdentifier)) {
+        if (!is_array($mapByIdentifier)) {
             $mapByIdentifier = [];
         }
         $mapByIdentifier[$object->getVersion()] = $object->toArray();
@@ -223,7 +223,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
     {
         $portableElements = $this->getAllVersions($object->getTypeIdentifier());
 
-        if (! isset($portableElements[$object->getVersion()])) {
+        if (!isset($portableElements[$object->getVersion()])) {
             throw new PortableElementVersionIncompatibilityException(
                 $this->getModel()->getId() . ' with identifier ' . $object->getTypeIdentifier() . ' found, '
                 . 'but version ' . $object->getVersion() . ' does not exist. Deletion impossible.'
@@ -244,7 +244,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
      */
     public function removeAllVersions($identifier)
     {
-        if (! $this->has($identifier)) {
+        if (!$this->has($identifier)) {
             throw new PortableElementNotFoundException(
                 'Unable to find portable element (' . $identifier . ') into registry. Deletion impossible.'
             );
@@ -280,7 +280,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
     {
         $object = $this->fetch($object->getTypeIdentifier(), $object->getVersion());
 
-        if (! $object->hasVersion()) {
+        if (!$object->hasVersion()) {
             $this->removeAllVersions($object);
         } else {
             $this->removeAssets($object);
@@ -298,7 +298,9 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
         $portableElements = $this->getAllVersions($identifier);
 
         if (empty($portableElements)) {
-            throw new PortableElementNotFoundException('Unable to find any version of protable element "' . $identifier . '"');
+            throw new PortableElementNotFoundException(
+                'Unable to find any version of protable element "' . $identifier . '"'
+            );
         }
 
         $this->krsortByVersion($portableElements);
@@ -315,7 +317,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
         }
         $this->krsortByVersion($registered);
 
-        foreach ($registered as $registeredVersion=>$model) {
+        foreach ($registered as $registeredVersion => $model) {
             if (intval($targetVersion) === intval($registeredVersion)) {
                 return $this->getModel()->createDataObject($model);
             }
@@ -336,11 +338,12 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
             $latestVersion = $this->getLatestVersion($object->getTypeIdentifier());
             if (version_compare($object->getVersion(), $latestVersion->getVersion(), '<')) {
                 throw new PortableElementVersionIncompatibilityException(
-                    'A newer version of the code already exists ' . $latestVersion->getVersion() . ' > ' . $object->getVersion()
+                    'A newer version of the code already exists ' . $latestVersion->getVersion(
+                    ) . ' > ' . $object->getVersion()
                 );
             }
         } catch (PortableElementNotFoundException $e) {
-            if (! $object->hasVersion()) {
+            if (!$object->hasVersion()) {
                 $object->setVersion('0.0.0');
             }
             // The portable element to register does not exist, continue
@@ -466,8 +469,10 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
      */
     protected function removeAssets(PortableElementObject $object)
     {
-        if (! $object->hasVersion()) {
-            throw new PortableElementVersionIncompatibilityException('Unable to delete asset files whitout model version.');
+        if (!$object->hasVersion()) {
+            throw new PortableElementVersionIncompatibilityException(
+                'Unable to delete asset files whitout model version.'
+            );
         }
 
         $object = $this->fetch($object->getTypeIdentifier(), $object->getVersion());
@@ -486,7 +491,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
             return true;
         }
 
-        if (! $this->getFileSystem()->unregisterFiles($object, $filesToRemove)) {
+        if (!$this->getFileSystem()->unregisterFiles($object, $filesToRemove)) {
             throw new PortableElementFileStorageException(
                 'Unable to delete asset files for PCI "' . $object->getTypeIdentifier()
                 . '" at version "' . $object->getVersion() . '"'
@@ -503,7 +508,8 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
      */
     protected function getZipLocation(PortableElementObject $object)
     {
-        return \tao_helpers_Export::getExportPath() . DIRECTORY_SEPARATOR . 'pciPackage_' . $object->getTypeIdentifier() . '.zip';
+        return \tao_helpers_Export::getExportPath() . DIRECTORY_SEPARATOR . 'pciPackage_' . $object->getTypeIdentifier(
+            ) . '.zip';
     }
 
     /**
@@ -558,7 +564,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
      */
     public function getFileSystem()
     {
-        if (! $this->storage) {
+        if (!$this->storage) {
             $this->storage = $this->getServiceLocator()->get(PortableElementFileStorage::SERVICE_ID);
             $this->storage->setServiceLocator($this->getServiceLocator());
             $this->storage->setModel($this->getModel());

--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -306,7 +306,11 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
 
     public function getLatestCompatibleVersion(string $identifier, string $targetVersion): ?PortableElementObject
     {
-        $registered = $this->getAllVersions($identifier);
+        try {
+            $registered = $this->getAllVersions($identifier);
+        } catch (PortableElementNotFoundException $e) {
+            return null;
+        }
         $this->krsortByVersion($registered);
 
         foreach ($registered as $registeredVersion=>$model) {

--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -21,8 +21,8 @@
 
 namespace oat\taoQtiItem\model\portableElement\storage;
 
-use oat\oatbox\AbstractRegistry;
 use oat\oatbox\filesystem\FileSystemService;
+use oat\oatbox\log\LoggerAwareTrait;
 use oat\taoQtiItem\model\portableElement\exception\PortableElementFileStorageException;
 use oat\taoQtiItem\model\portableElement\exception\PortableElementInconsistencyModelException;
 use oat\taoQtiItem\model\portableElement\exception\PortableElementNotFoundException;
@@ -42,6 +42,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
 {
     use ServiceLocatorAwareTrait;
     use PortableElementModelTrait;
+    use LoggerAwareTrait;
 
     /** @var PortableElementFileStorage  */
     protected $storage;
@@ -309,6 +310,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
         try {
             $registered = $this->getAllVersions($identifier);
         } catch (PortableElementNotFoundException $e) {
+            $this->logDebug($e->getMessage());
             return null;
         }
         $this->krsortByVersion($registered);

--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2016-2022 (original work) Open Assessment Technologies SA;
  *
  */
 

--- a/test/integration/portableElement/PortableElementServiceTest.php
+++ b/test/integration/portableElement/PortableElementServiceTest.php
@@ -15,9 +15,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2018-2022 (original work) Open Assessment Technologies SA;
  *
  */
+
 declare(strict_types=1);
 
 namespace oat\taoQtiItem\portableElement\test;

--- a/test/integration/portableElement/PortableElementServiceTest.php
+++ b/test/integration/portableElement/PortableElementServiceTest.php
@@ -154,6 +154,9 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
 
         $lower = $this->service->getLatestCompatibleVersionElementById('PCI', 'pciSampleA', '0.2.1');
         $this->assertEquals('0.4.0', $lower->getVersion());
+
+        $notExisting = $this->service->getLatestCompatibleVersionElementById('PCI', 'Unknown', '1.0.*');
+        $this->assertNull($notExisting);
     }
 
     public function testGetPortableElementByClass()

--- a/test/integration/portableElement/PortableElementServiceTest.php
+++ b/test/integration/portableElement/PortableElementServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -38,7 +39,7 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
      */
     protected $instance;
 
-    /** @var PortableElementService  */
+    /** @var PortableElementService */
     private $service;
 
     public function setUp(): void
@@ -57,7 +58,7 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
         if (!ServiceManager::getServiceManager()->has(FileSystemService::SERVICE_ID)) {
             ServiceManager::getServiceManager()->registerService(FileSystemService::SERVICE_ID, $fsm);
         }
-        if (! $fsm->hasDirectory($fsId)) {
+        if (!$fsm->hasDirectory($fsId)) {
             $fsm->createFileSystem($fsId);
         }
         $itemImsPci = 'qtiItemImsPci';
@@ -65,13 +66,15 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
             $fsm->createFileSystem($itemImsPci);
         }
 
-        if (!ServiceManager::getServiceManager()->has(PortableElementFileStorage::SERVICE_ID) ) {
+        if (!ServiceManager::getServiceManager()->has(PortableElementFileStorage::SERVICE_ID)) {
             $portableElementStorage = new PortableElementFileStorage([
                 PortableElementFileStorage::OPTION_FILESYSTEM => $fsId,
                 PortableElementFileStorage::OPTION_WEBSOURCE => ActionWebSource::spawnWebsource($fsId)->getId()
             ]);
-            ServiceManager::getServiceManager()->register(PortableElementFileStorage::SERVICE_ID,
-                $portableElementStorage);
+            ServiceManager::getServiceManager()->register(
+                PortableElementFileStorage::SERVICE_ID,
+                $portableElementStorage
+            );
         }
     }
 
@@ -98,37 +101,51 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
         $pciLast = $this->service->getPortableElementByIdentifier('PCI', 'pciSampleA');
         $registry = $pciLast->getModel()->getRegistry();
         $this->assertEquals('0.4.0', $pciLast->getVersion());
-        $this->assertNotFalse(strpos($registry->getFileStream($pciLast, 'pciCreator.js')->getContents(), '[version=0.4.0]'));
+        $this->assertNotFalse(
+            strpos($registry->getFileStream($pciLast, 'pciCreator.js')->getContents(), '[version=0.4.0]')
+        );
 
         $pci040 = $this->service->getPortableElementByIdentifier('PCI', 'pciSampleA', '0.4.0');
         $this->assertEquals('0.4.0', $pci040->getVersion());
-        $this->assertNotFalse(strpos($registry->getFileStream($pci040, 'pciCreator.js')->getContents(), '[version=0.4.0]'));
+        $this->assertNotFalse(
+            strpos($registry->getFileStream($pci040, 'pciCreator.js')->getContents(), '[version=0.4.0]')
+        );
 
         //check that the actual file is the same as 0.4.0
         $pciAlias = $this->service->getPortableElementByIdentifier('PCI', 'pciSampleA', '0.4.*');
         $this->assertEquals('0.4.*', $pciAlias->getVersion());
-        $this->assertNotFalse(strpos($registry->getFileStream($pciAlias, 'pciCreator.js')->getContents(), '[version=0.4.0]'));
+        $this->assertNotFalse(
+            strpos($registry->getFileStream($pciAlias, 'pciCreator.js')->getContents(), '[version=0.4.0]')
+        );
 
         //register a fix v0.4.1
         $this->service->registerFromDirectorySource(dirname(__FILE__) . '/samples/pciDir041');
 
         $pci040 = $this->service->getPortableElementByIdentifier('PCI', 'pciSampleA', '0.4.0');
         $this->assertEquals('0.4.0', $pci040->getVersion());
-        $this->assertNotFalse(strpos($registry->getFileStream($pci040, 'pciCreator.js')->getContents(), '[version=0.4.0]'));
+        $this->assertNotFalse(
+            strpos($registry->getFileStream($pci040, 'pciCreator.js')->getContents(), '[version=0.4.0]')
+        );
 
         $pci041 = $this->service->getPortableElementByIdentifier('PCI', 'pciSampleA', '0.4.1');
         $this->assertEquals('0.4.1', $pci041->getVersion());
-        $this->assertNotFalse(strpos($registry->getFileStream($pci041, 'pciCreator.js')->getContents(), '[version=0.4.1]'));
+        $this->assertNotFalse(
+            strpos($registry->getFileStream($pci041, 'pciCreator.js')->getContents(), '[version=0.4.1]')
+        );
 
         //check that the alias points to the same files as the new v0.4.1
         $pciAlias = $this->service->getPortableElementByIdentifier('PCI', 'pciSampleA', '0.4.*');
         $this->assertEquals('0.4.*', $pciAlias->getVersion());
-        $this->assertNotFalse(strpos($registry->getFileStream($pciAlias, 'pciCreator.js')->getContents(), '[version=0.4.1]'));
+        $this->assertNotFalse(
+            strpos($registry->getFileStream($pciAlias, 'pciCreator.js')->getContents(), '[version=0.4.1]')
+        );
 
         //the most recent version is still v0.4.1
         $pciLast = $this->service->getPortableElementByIdentifier('PCI', 'pciSampleA');
         $this->assertEquals('0.4.1', $pciLast->getVersion());
-        $this->assertNotFalse(strpos($registry->getFileStream($pciLast, 'pciCreator.js')->getContents(), '[version=0.4.1]'));
+        $this->assertNotFalse(
+            strpos($registry->getFileStream($pciLast, 'pciCreator.js')->getContents(), '[version=0.4.1]')
+        );
     }
 
     public function testGetLatestCompatibleVersionElementById(): void
@@ -161,7 +178,6 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
 
     public function testGetPortableElementByClass()
     {
-
         $xml = new \DOMDocument();
         $xml->load(__DIR__ . '/samples/item/pci_pic_sample_1.xml');
         $parser = new ParserFactory($xml);
@@ -178,7 +194,6 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
 
     public function testGetPortableElementByClassAlias()
     {
-
         $xml = new \DOMDocument();
         $xml->load(__DIR__ . '/samples/item/pci_sample_1.xml');
         $parser = new ParserFactory($xml);
@@ -192,7 +207,11 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
         $pci = reset($pcis['pciSampleA']);
         $this->assertEquals('0.4.0', $pci['version']);
 
-        $pcis = $this->service->getPortableElementByClass(PortableElementService::PORTABLE_CLASS_INTERACTION, $item, true);
+        $pcis = $this->service->getPortableElementByClass(
+            PortableElementService::PORTABLE_CLASS_INTERACTION,
+            $item,
+            true
+        );
         $pci = reset($pcis['pciSampleA']);
         $this->assertEquals('0.4.*', $pci['version']);
 
@@ -202,14 +221,17 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
         $pci = reset($pcis['pciSampleA']);
         $this->assertEquals('0.4.1', $pci['version']);
 
-        $pcis = $this->service->getPortableElementByClass(PortableElementService::PORTABLE_CLASS_INTERACTION, $item, true);
+        $pcis = $this->service->getPortableElementByClass(
+            PortableElementService::PORTABLE_CLASS_INTERACTION,
+            $item,
+            true
+        );
         $pci = reset($pcis['pciSampleA']);
         $this->assertEquals('0.4.*', $pci['version']);
     }
 
     public function testSetBaseUrlToPortableData()
     {
-
         $xml = new \DOMDocument();
         $xml->load(__DIR__ . '/samples/item/pci_sample_1.xml');
         $parser = new ParserFactory($xml);
@@ -229,7 +251,6 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
 
     public function testSetBaseUrlToPortableDataUnknownVersion()
     {
-
         $this->expectException(PortableElementNotFoundException::class);
 
         $xml = new \DOMDocument();
@@ -251,7 +272,6 @@ class PortableElementServiceTest extends TaoPhpUnitTestRunner
 
     public function testSetBaseUrlToPortableDataUnknownModel()
     {
-
         $this->expectException(PortableModelMissing::class);
 
         $xml = new \DOMDocument();


### PR DESCRIPTION
When importing item with not yet known PCI the import should not break cause it is a valid case. The problem was an exception which been not intercepting.