### PR TITLE
fix: Adding images/media in prompt field by double-click

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -156,6 +156,9 @@ define([
                                 _activateInnerWidget(options.data.widget, createdWidget);
                             }
                         );
+                        // hide toolbar to prevent double click
+                        const editor = $editable.data('editor');
+                        editor.focusManager.blur(true);
                     }
                 }
             },


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2752

**Steps to reproduce:**
1. Open item in Authoring mode
2. DnD any Interaction into canvas (e.g Choice Interaction)
3. Set cursor into “Prompt” field
4. Double click on Image icon within CKEditor toolbar
Actual result: 2 image blocks are added, console errors are shown
5. Delete images from “Prompt” field by clicking on “trash bin” icon
Actual result: images can’t be deleted, user can type within “trash bin” icon after clicking on it multiple times
6. Invoke CKEditor toolbar by clicking within “choice” area 
Actual result: CKEditor toolbar couldn’t be invoked in all interactions (only after user clears cache)