### PR TITLE
issue Match interaction: Delete column functionality deletes only column label

### DIFF
--- a/views/js/qtiCreator/widgets/states/Deleting.js
+++ b/views/js/qtiCreator/widgets/states/Deleting.js
@@ -62,7 +62,7 @@ define([
                 if ($container.parent().parent().prop('tagName') === 'THEAD') {
                     //hide col
                     const $tbody = $container.closest('table.matrix').children('tbody');
-                    const $tds = $tbody.children('tr').find('td:last');
+                    const $tds = $tbody.children('tr').find('td:visible:last');
                     return $container.add($tds);
                 } else if ($container.parent().parent().prop('tagName') === 'TBODY') {
                     //hide row


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2798

Issue was that because of `undo` plugin cells of table are hidden by `display: none`
Function that get elements for delete has selector to get last cells
Solution: Add in selector condition `visible`

**Steps to reproduce:**

- Add Match interaction to the canvas
- Add several columns 
- Delete columns (while message with undo is displayed!)
- Actual result: one column is deleted, however the second deleted column gets only label deleted remaining all cells