### PR TITLE
Hotfix: do not hardcode namespace in PCI template

### DIFF
--- a/model/qti/interaction/PortableCustomInteraction.php
+++ b/model/qti/interaction/PortableCustomInteraction.php
@@ -52,27 +52,27 @@ class PortableCustomInteraction extends CustomInteraction
     protected $typeIdentifier = '';
     protected $entryPoint = '';
     protected $version = '0.0.0';
-    
+
     public function setTypeIdentifier($typeIdentifier)
     {
         $this->typeIdentifier = $typeIdentifier;
     }
-    
+
     public function setEntryPoint($entryPoint)
     {
         $this->entryPoint = $entryPoint;
     }
-    
+
     public function getTypeIdentifier()
     {
         return $this->typeIdentifier;
     }
-    
+
     public function getEntryPoint()
     {
         return $this->entryPoint;
     }
-    
+
     public function getProperties()
     {
         return $this->properties;
@@ -91,22 +91,22 @@ class PortableCustomInteraction extends CustomInteraction
     {
         return $this->stylesheets;
     }
-    
+
     public function setStylesheets($stylesheets)
     {
         $this->stylesheets = $stylesheets;
     }
-    
+
     public function getMediaFiles()
     {
         return $this->mediaFiles;
     }
-    
+
     public function setMediaFiles($mediaFiles)
     {
         $this->mediaFiles = $mediaFiles;
     }
-    
+
     public function getVersion()
     {
         return $this->version;
@@ -133,7 +133,7 @@ class PortableCustomInteraction extends CustomInteraction
 
     public function toArray($filterVariableContent = false, &$filtered = [])
     {
-        
+
         $returnValue = parent::toArray($filterVariableContent, $filtered);
 
         $returnValue['typeIdentifier'] = $this->typeIdentifier;
@@ -152,7 +152,7 @@ class PortableCustomInteraction extends CustomInteraction
     {
         return static::getTemplatePath() . 'interactions/qti.portableCustomInteraction.tpl.php';
     }
-    
+
     protected function getTemplateQtiVariables()
     {
 
@@ -163,10 +163,12 @@ class PortableCustomInteraction extends CustomInteraction
         $variables['serializedProperties'] = $this->serializePortableProperties($this->properties);
         $variables['entryPoint'] = $this->entryPoint;
         $variables['typeIdentifier'] = $this->typeIdentifier;
+        $variables['namespaceUri'] = $this->getNamespace()->getUri();
+
         $this->getRelatedItem()->addNamespace($this->markupNs, $this->markupNs);
         return $variables;
     }
-    
+
     /**
      * Feed the pci instance with data provided in the pci dom node
      *

--- a/model/qti/templates/interactions/qti.portableCustomInteraction.tpl.php
+++ b/model/qti/templates/interactions/qti.portableCustomInteraction.tpl.php
@@ -4,23 +4,23 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *               
- * 
+ *
+ *
  */
 ?>
 <customInteraction <?=get_data('attributes')?>>
-    <portableCustomInteraction customInteractionTypeIdentifier="<?=get_data('typeIdentifier')?>" hook="<?=get_data('entryPoint')?>" version="<?=get_data('version')?>" xmlns="http://www.imsglobal.org/xsd/portableCustomInteraction">
+    <portableCustomInteraction customInteractionTypeIdentifier="<?=get_data('typeIdentifier')?>" hook="<?=get_data('entryPoint')?>" version="<?=get_data('version')?>" xmlns="<?=get_data('namespaceUri') ?: 'http://www.imsglobal.org/xsd/portableCustomInteraction'?>">
         <resources>
             <?php if(count(get_data('libraries'))):?><libraries>
                 <?php foreach(get_data('libraries') as $lib):?>


### PR DESCRIPTION
This change needed for a script that does upgrade text reader to IMS version. Applying it as a hotfix cause it is one time manual action.