### PR TITLE
Backport/aut 2803/rewrite item unit test

### DIFF
--- a/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
+++ b/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
@@ -57,8 +57,12 @@ class ItemExporterTest extends TestCase
         $expectedOutputV21 = file_get_contents(dirname(__FILE__) . '/../../../samples/export/exported_item_2_1.xml');
         $expectedOutputV22 = file_get_contents(dirname(__FILE__) . '/../../../samples/export/exported_item_2_2.xml');
 
-        $coreKernelClassStub = $this->createStub(core_kernel_classes_Resource::class);
-        $zipArchiveStub = $this->createStub(ZipArchive::class);
+        $coreKernelClassStub = $this->createMock(core_kernel_classes_Resource::class);
+
+        //Need to remove all methods because of PHPUnit 8.5 doesn`t handles return union types used in PHP8
+        $zipArchiveStub = $this->getMockBuilder(ZipArchive::class)
+            ->onlyMethods([])
+            ->getMock();
 
         // To be able to test protected method
         $exporterV21 = new class($coreKernelClassStub, $zipArchiveStub) extends QTIPackedItemExporter {
@@ -69,7 +73,7 @@ class ItemExporterTest extends TestCase
         };
 
         $outputV21 = $exporterV21->setCorrectQTIVersion($input);
-        $this->assertEquals($expectedOutputV21, $outputV21);
+        self::assertEquals($expectedOutputV21, $outputV21);
 
         $exporterV22 = new class($coreKernelClassStub, $zipArchiveStub) extends QTIPackedItem22Exporter {
             public function setCorrectQTIVersion(string $itemQTI): string
@@ -79,6 +83,6 @@ class ItemExporterTest extends TestCase
         };
 
         $outputV22 = $exporterV22->setCorrectQTIVersion($input);
-        $this->assertEquals($expectedOutputV22, $outputV22);
+        self::assertEquals($expectedOutputV22, $outputV22);
     }
 }

--- a/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
+++ b/test/unit/model/flyExporter/simpleExporter/ItemExporterTest.php
@@ -8,6 +8,7 @@ use oat\taoQtiItem\model\Export\QTIPackedItem22Exporter;
 use oat\taoQtiItem\model\Export\QTIPackedItemExporter;
 use oat\taoQtiItem\model\flyExporter\simpleExporter\ItemExporter;
 use ZipArchive;
+
 use function Webmozart\Assert\Tests\StaticAnalysis\true;
 
 class ItemExporterTest extends TestCase
@@ -65,7 +66,7 @@ class ItemExporterTest extends TestCase
             ->getMock();
 
         // To be able to test protected method
-        $exporterV21 = new class($coreKernelClassStub, $zipArchiveStub) extends QTIPackedItemExporter {
+        $exporterV21 = new class ($coreKernelClassStub, $zipArchiveStub) extends QTIPackedItemExporter {
             public function setCorrectQTIVersion(string $itemQTI): string
             {
                 return parent::setCorrectQTIVersion($itemQTI);
@@ -75,7 +76,7 @@ class ItemExporterTest extends TestCase
         $outputV21 = $exporterV21->setCorrectQTIVersion($input);
         self::assertEquals($expectedOutputV21, $outputV21);
 
-        $exporterV22 = new class($coreKernelClassStub, $zipArchiveStub) extends QTIPackedItem22Exporter {
+        $exporterV22 = new class ($coreKernelClassStub, $zipArchiveStub) extends QTIPackedItem22Exporter {
             public function setCorrectQTIVersion(string $itemQTI): string
             {
                 return parent::setCorrectQTIVersion($itemQTI);

--- a/test/unit/model/qti/ItemTest.php
+++ b/test/unit/model/qti/ItemTest.php
@@ -21,57 +21,55 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\test\unit\mode\qti;
 
-use oat\generis\test\TestCase;
+use common_ext_Extension;
+use common_ext_ExtensionsManager;
+use oat\generis\test\ServiceManagerMockTrait;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\service\ApplicationService;
 use oat\taoQtiItem\model\qti\Item;
+use PHPUnit\Framework\TestCase;
 
 class ItemTest extends TestCase
 {
+    use ServiceManagerMockTrait;
+
     private const PRODUCT_NAME = 'TAO';
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        if (!defined('PRODUCT_NAME')) {
-            define('PRODUCT_NAME', self::PRODUCT_NAME);
-        }
-        if (!defined('ROOT_URL')) {
-            define('ROOT_URL', __DIR__ . '/../../../../../');
-        }
-        if (!defined('CONFIG_PATH')) {
-            define('CONFIG_PATH', ROOT_URL . 'config/');
-        }
-        if (!defined('EXTENSION_PATH')) {
-            define('EXTENSION_PATH', ROOT_URL);
-        }
+        define('PRODUCT_NAME', self::PRODUCT_NAME);
 
-        ServiceManager::getServiceManager()->overload(
-            ApplicationService::SERVICE_ID,
-            $this->createMock(ApplicationService::class)
-        );
+        $commonExtensionMock = $this->createMock(common_ext_Extension::class);
+        $commonExtensionMock
+            ->method('getDir')
+            ->willReturn(ROOT_PATH . DIRECTORY_SEPARATOR . 'taoQtiItem' . DIRECTORY_SEPARATOR);
+
+        $extensionsManagerMock = $this->createMock(common_ext_ExtensionsManager::class);
+        $extensionsManagerMock
+            ->method('getExtensionById')
+            ->willReturn($commonExtensionMock);
+
+        $applicationServiceMock = $this->createMock(ApplicationService::class);
+
+        $sm = $this->getServiceManagerMock([
+            ApplicationService::SERVICE_ID => $applicationServiceMock,
+            common_ext_ExtensionsManager::class => $extensionsManagerMock
+        ]);
+
+        ServiceManager::setServiceManager($sm);
     }
 
+    /**
+     * Testing toQTI() method on Item class
+     * @return void
+     */
     public function testToQTI(): void
     {
-        $expectedItemQti = <<<ITEM_QTI
-<?xml version="1.0" encoding="UTF-8"?><assessmentItem
-        xsi:schemaLocation=""
-     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO">
-
-    
-    
-    
-    <itemBody >
-	    </itemBody>
-
-    
-    
-    </assessmentItem>
-
-ITEM_QTI;
-
+        $expectedItemQti = file_get_contents(
+            dirname(__DIR__, 2) . '/samples/model/qti/item/testToQti_expectedItemQti.xml'
+        );
 
         $item = new Item();
         $itemQti = $this->removeToolVersionAttribute($item->toQTI());
@@ -79,30 +77,23 @@ ITEM_QTI;
         self::assertEquals($expectedItemQti, $itemQti);
     }
 
+    /**
+     * Testing toQTI() method on Item class with attribute dir=rtl
+     * @return void
+     * @throws \oat\taoQtiItem\model\qti\exception\QtiModelException
+     */
     public function testToQTIWithDirAttributeInItemBody(): void
     {
-        $expectedItemQti = <<<ITEM_QTI
-<?xml version="1.0" encoding="UTF-8"?><assessmentItem
-        xsi:schemaLocation=""
-     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO">
-
-    
-    
-    
-    <itemBody dir="rtl">
-	    </itemBody>
-
-    
-    
-    </assessmentItem>
-
-ITEM_QTI;
-
+        $expectedItemQti = file_get_contents(
+            dirname(
+                __DIR__,
+                2
+            ) . '/samples/model/qti/item/testToQTIWithDirAttributeInItemBody_expectedItemQti.xml'
+        );
 
         $item = new Item();
         $item->getBody()->setAttribute('dir', 'rtl');
         $itemQti = $this->removeToolVersionAttribute($item->toQTI());
-
 
         self::assertEquals($expectedItemQti, $itemQti);
     }

--- a/test/unit/model/qti/ItemTest.php
+++ b/test/unit/model/qti/ItemTest.php
@@ -19,7 +19,7 @@
  */
 declare(strict_types=1);
 
-namespace oat\taoQtiItem\test\unit\mode\qti;
+namespace oat\taoQtiItem\test\unit\model\qti;
 
 use common_ext_Extension;
 use common_ext_ExtensionsManager;

--- a/test/unit/model/qti/ItemTest.php
+++ b/test/unit/model/qti/ItemTest.php
@@ -17,6 +17,7 @@
  *
  * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
+
 declare(strict_types=1);
 
 namespace oat\taoQtiItem\test\unit\model\qti;
@@ -105,7 +106,7 @@ class ItemTest extends TestCase
      */
     private function removeToolVersionAttribute(string $itemQti): string
     {
-       return preg_replace('/toolVersion="[0-9]{4}\.[0-9]{2}"/u', 'toolVersion=""', $itemQti);
+        return preg_replace('/toolVersion="[0-9]{4}\.[0-9]{2}"/u', 'toolVersion=""', $itemQti);
     }
 
     /**

--- a/test/unit/model/qti/ParserFactoryTest.php
+++ b/test/unit/model/qti/ParserFactoryTest.php
@@ -19,61 +19,62 @@
  */
 declare(strict_types=1);
 
-namespace oat\taoQtiItem\test\unit\mode\qti;
+namespace oat\taoQtiItem\test\unit\model\qti;
 
+use common_ext_Extension;
+use common_ext_ExtensionsManager;
 use DOMDocument;
+use oat\oatbox\service\ServiceManager;
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\tao\model\service\ApplicationService;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\ParserFactory;
-use oat\generis\test\TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local;
 
 class ParserFactoryTest extends TestCase
 {
+    use ServiceManagerMockTrait;
+
     private const PRODUCT_NAME = 'TAO';
 
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->logger = $this->createMock(LoggerInterface::class);
-
         if (!defined('PRODUCT_NAME')) {
             define('PRODUCT_NAME', self::PRODUCT_NAME);
         }
-        if (!defined('ROOT_URL')) {
-            define('ROOT_URL', __DIR__ . '/../../../../../');
-        }
-        if (!defined('CONFIG_PATH')) {
-            define('CONFIG_PATH', ROOT_URL . 'config/');
-        }
-        if (!defined('EXTENSION_PATH')) {
-            define('EXTENSION_PATH', ROOT_URL);
-        }
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $commonExtensionMock = $this->createMock(common_ext_Extension::class);
+        $commonExtensionMock
+            ->method('getDir')
+            ->willReturn(ROOT_PATH . DIRECTORY_SEPARATOR . 'taoQtiItem' . DIRECTORY_SEPARATOR);
+
+        $extensionsManagerMock = $this->createMock(common_ext_ExtensionsManager::class);
+        $extensionsManagerMock
+            ->method('getExtensionById')
+            ->willReturn($commonExtensionMock);
+
+        $applicationServiceMock = $this->createMock(ApplicationService::class);
+
+        $sm = $this->getServiceManagerMock([
+            ApplicationService::SERVICE_ID => $applicationServiceMock,
+            common_ext_ExtensionsManager::class => $extensionsManagerMock
+        ]);
+
+        ServiceManager::setServiceManager($sm);
     }
 
     public function testParseItem(): void
     {
-        $itemDocument = <<<ITEM_DOC
-<?xml version="1.0" encoding="UTF-8"?>
-<assessmentItem
-        xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:m="http://www.w3.org/1998/Math/MathML"
-        xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
-        identifier="i61dbf0028b0ca4904497f514befea47f" title="Item 1" adaptive="false" timeDependent="false"
-        xml:lang="en-US">
-    <itemBody>
-        <div class="grid-row">
-            <div class="col-12">
-                <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...</p>
-            </div>
-        </div>
-    </itemBody>
-</assessmentItem>
-ITEM_DOC;
-
+        $itemDocument = $this->readSampleFile('testParseItem_itemDocument.xml');
         $dom = new DOMDocument();
         $dom->loadXML($itemDocument);
 
@@ -101,30 +102,15 @@ ITEM_DOC;
 
     public function testParseItemWithDirAttributeOnItemBody(): void
     {
-        $itemDocument = <<<ITEM_DOC
-<?xml version="1.0" encoding="UTF-8"?>
-<assessmentItem
-        xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:m="http://www.w3.org/1998/Math/MathML"
-        xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
-        identifier="i61dbf0028b0ca4904497f514befea47f" title="Item 1" adaptive="false" timeDependent="false"
-        xml:lang="en-US">
-    <itemBody dir="rtl">
-        <div class="grid-row">
-            <div class="col-12">
-                <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...</p>
-            </div>
-        </div>
-    </itemBody>
-</assessmentItem>
-ITEM_DOC;
+        $itemDocument = $this->readSampleFile('testParseItemWithDirAttributeOnItemBody_itemDocument.xml');
 
         $dom = new DOMDocument();
         $dom->loadXML($itemDocument);
 
         $parser = new ParserFactory($dom);
 
-        $this->logger->expects($this->once())->method('debug')
+        $this->logger->expects($this->once())
+            ->method('debug')
             ->with('Started parsing of QTI item i61dbf0028b0ca4904497f514befea47f', ['TAOITEMS']);
         $parser->setLogger($this->logger);
         $item = $parser->load();
@@ -141,5 +127,21 @@ ITEM_DOC;
     ',
             $item->getBody()->getBody()
         );
+    }
+
+    /**
+     * @param string $name
+     * @return string
+     * @throws \League\Flysystem\FileNotFoundException
+     */
+    private function readSampleFile(string $name): string
+    {
+        $adapter = new Local(
+            dirname(__DIR__, 2) . '/samples/model/qti/parserFactory'
+        );
+
+        $filesystem = new Filesystem($adapter);
+
+        return $filesystem->read($name);
     }
 }

--- a/test/unit/model/qti/ParserFactoryTest.php
+++ b/test/unit/model/qti/ParserFactoryTest.php
@@ -17,6 +17,7 @@
  *
  * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
+
 declare(strict_types=1);
 
 namespace oat\taoQtiItem\test\unit\model\qti;

--- a/test/unit/model/qti/container/ContainerItemBodyTest.php
+++ b/test/unit/model/qti/container/ContainerItemBodyTest.php
@@ -17,6 +17,7 @@
  *
  * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
+
 declare(strict_types=1);
 
 namespace oat\taoQtiItem\test\unit\model\qti\container;

--- a/test/unit/model/qti/container/ContainerItemBodyTest.php
+++ b/test/unit/model/qti/container/ContainerItemBodyTest.php
@@ -19,7 +19,7 @@
  */
 declare(strict_types=1);
 
-namespace oat\taoQtiItem\test\unit\mode\qti\container;
+namespace oat\taoQtiItem\test\unit\model\qti\container;
 
 use oat\generis\test\TestCase;
 use oat\taoQtiItem\model\qti\container\ContainerItemBody;

--- a/test/unit/samples/model/qti/item/testToQTIWithDirAttributeInItemBody_expectedItemQti.xml
+++ b/test/unit/samples/model/qti/item/testToQTIWithDirAttributeInItemBody_expectedItemQti.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?><assessmentItem
+        xsi:schemaLocation=""
+     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO">
+
+    
+    
+    
+    <itemBody dir="rtl">
+	    </itemBody>
+
+    
+    
+    </assessmentItem>

--- a/test/unit/samples/model/qti/item/testToQti_expectedItemQti.xml
+++ b/test/unit/samples/model/qti/item/testToQti_expectedItemQti.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?><assessmentItem
+        xsi:schemaLocation=""
+     identifier="Item_1" title="" label="" adaptive="false" timeDependent="false" toolName="TAO">
+
+    
+    
+    
+    <itemBody >
+	    </itemBody>
+
+    
+    
+    </assessmentItem>

--- a/test/unit/samples/model/qti/parserFactory/testParseItemWithDirAttributeOnItemBody_itemDocument.xml
+++ b/test/unit/samples/model/qti/parserFactory/testParseItemWithDirAttributeOnItemBody_itemDocument.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem
+        xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:m="http://www.w3.org/1998/Math/MathML"
+        xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
+        identifier="i61dbf0028b0ca4904497f514befea47f" title="Item 1" adaptive="false" timeDependent="false"
+        xml:lang="en-US">
+    <itemBody dir="rtl">
+        <div class="grid-row">
+            <div class="col-12">
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...</p>
+            </div>
+        </div>
+    </itemBody>
+</assessmentItem>

--- a/test/unit/samples/model/qti/parserFactory/testParseItem_itemDocument.xml
+++ b/test/unit/samples/model/qti/parserFactory/testParseItem_itemDocument.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem
+        xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:m="http://www.w3.org/1998/Math/MathML"
+        xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
+        identifier="i61dbf0028b0ca4904497f514befea47f" title="Item 1" adaptive="false" timeDependent="false"
+        xml:lang="en-US">
+    <itemBody>
+        <div class="grid-row">
+            <div class="col-12">
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...</p>
+            </div>
+        </div>
+    </itemBody>
+</assessmentItem>


### PR DESCRIPTION
fix: ContainerItemBodyTest.php, ItemTest.php, ParserFactoryTest.php changed namespace to proper one
fix: ItemExporterTest.php remove methods from mocked ZipArchive class as workaround for PHPUnit 8.5 fail to mock PHP8.1 features (union types)
refactor: ParserFactoryTest.php remove deprecated code, test is working running PHP8.1