### PR TITLE
fix: allow to inject new namespace for PCI

### DIFF
--- a/model/qti/interaction/PortableCustomInteraction.php
+++ b/model/qti/interaction/PortableCustomInteraction.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -15,10 +15,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
+ * Copyright (c) 2013-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\taoQtiItem\model\qti\interaction;
 
@@ -52,27 +53,27 @@ class PortableCustomInteraction extends CustomInteraction
     protected $typeIdentifier = '';
     protected $entryPoint = '';
     protected $version = '0.0.0';
-    
+
     public function setTypeIdentifier($typeIdentifier)
     {
         $this->typeIdentifier = $typeIdentifier;
     }
-    
+
     public function setEntryPoint($entryPoint)
     {
         $this->entryPoint = $entryPoint;
     }
-    
+
     public function getTypeIdentifier()
     {
         return $this->typeIdentifier;
     }
-    
+
     public function getEntryPoint()
     {
         return $this->entryPoint;
     }
-    
+
     public function getProperties()
     {
         return $this->properties;
@@ -91,22 +92,22 @@ class PortableCustomInteraction extends CustomInteraction
     {
         return $this->stylesheets;
     }
-    
+
     public function setStylesheets($stylesheets)
     {
         $this->stylesheets = $stylesheets;
     }
-    
+
     public function getMediaFiles()
     {
         return $this->mediaFiles;
     }
-    
+
     public function setMediaFiles($mediaFiles)
     {
         $this->mediaFiles = $mediaFiles;
     }
-    
+
     public function getVersion()
     {
         return $this->version;
@@ -133,7 +134,7 @@ class PortableCustomInteraction extends CustomInteraction
 
     public function toArray($filterVariableContent = false, &$filtered = [])
     {
-        
+
         $returnValue = parent::toArray($filterVariableContent, $filtered);
 
         $returnValue['typeIdentifier'] = $this->typeIdentifier;
@@ -152,10 +153,9 @@ class PortableCustomInteraction extends CustomInteraction
     {
         return static::getTemplatePath() . 'interactions/qti.portableCustomInteraction.tpl.php';
     }
-    
+
     protected function getTemplateQtiVariables()
     {
-
         $variables = parent::getTemplateQtiVariables();
         $variables['libraries'] = $this->libraries;
         $variables['stylesheets'] = $this->stylesheets;
@@ -163,10 +163,12 @@ class PortableCustomInteraction extends CustomInteraction
         $variables['serializedProperties'] = $this->serializePortableProperties($this->properties);
         $variables['entryPoint'] = $this->entryPoint;
         $variables['typeIdentifier'] = $this->typeIdentifier;
+        $variables['xmlns'] = isset($this->ns) ? $this->ns->getUri() : self::NS_URI;
         $this->getRelatedItem()->addNamespace($this->markupNs, $this->markupNs);
+
         return $variables;
     }
-    
+
     /**
      * Feed the pci instance with data provided in the pci dom node
      *
@@ -177,7 +179,6 @@ class PortableCustomInteraction extends CustomInteraction
      */
     public function feed(ParserFactory $parser, DOMElement $data, QtiNamespace $xmlns = null)
     {
-
         $this->setNamespace($xmlns);
         $xmlnsName = $xmlns->getName();
 

--- a/model/qti/templates/interactions/qti.portableCustomInteraction.tpl.php
+++ b/model/qti/templates/interactions/qti.portableCustomInteraction.tpl.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -14,13 +14,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * 
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *               
- * 
+ * Copyright (c) 2013-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
  */
 ?>
+
 <customInteraction <?=get_data('attributes')?>>
-    <portableCustomInteraction customInteractionTypeIdentifier="<?=get_data('typeIdentifier')?>" hook="<?=get_data('entryPoint')?>" version="<?=get_data('version')?>" xmlns="http://www.imsglobal.org/xsd/portableCustomInteraction">
+    <portableCustomInteraction xmlns="<?=get_data('xmlns')?>" customInteractionTypeIdentifier="<?=get_data('typeIdentifier')?>" hook="<?=get_data('entryPoint')?>" version="<?=get_data('version')?>">
         <resources>
             <?php if(count(get_data('libraries'))):?><libraries>
                 <?php foreach(get_data('libraries') as $lib):?>


### PR DESCRIPTION
**Ticket**
https://oat-sa.atlassian.net/browse/OATSD-2274
https://oat-sa.atlassian.net/browse/AUT-2683
https://oat-sa.atlassian.net/browse/LSI-1594

**Description**
While moving PCI from IMS to OAT, migration script [try to inject new namespace](https://github.com/oat-sa/extension-pcisample/blob/master/model/LegacyPciHelper/Task/UpgradeTextReaderInteractionTask.php#L165) to PciObject, unfortunately objects are loaded from namespace. For old PCI, it results on PortableCustomInteraction object and not ImsPortableCustomInteraction.
This PortableCustomInteraction has template with [hardcoded namespace](https://github.com/oat-sa/extension-tao-itemqti/compare/fix/OATSD-2274/remove-hardcoded-pci-namespace?expand=1#diff-fec7f9e8b135c401b3e96e879ffab5db52208c7c75514c5752a46ea2c593b245L23) value that does not allow to update it 😓 

**How to test**
Create item with TextReader and image in it, set PCI namespace within item files.
```xml
<portableCustomInteraction xmlns="http://www.imsglobal.org/xsd/portableCustomInteraction">
```
Launch the command:
```shell
php index.php `\oat\pciSamples\model\LegacyPciHelper\LegacyTextReaderItemUpdate'
```
Item should be updated with _v1 namespace suffix
```xml
<portableCustomInteraction xmlns="http://www.imsglobal.org/xsd/portableCustomInteraction_v1">
```
