### PR TITLE
Fix/aut 2967/upper bound field value

### DIFF
--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -198,6 +198,19 @@ define([
                         }
 
                         config[field].value = intValue;
+                    } else {
+                        // const fieldConfig = config[field];
+                        // const fieldControl = controls[field];
+                        // fieldControl.input = $(`[name=${fieldConfig.fieldName}]`, this.getElement());
+                        //
+                        // // if (fieldConfig.toggler) {
+                        // //     fieldControl.toggler.prop('checked', false);
+                        // // }
+                        //     // this.setValue(field, lowerThreshold);
+                        //     //
+                        //     // this.disableField(field);
+                        //     // isNaN(this.getValue(field)) === false
+
                     }
                     return this;
                 },
@@ -359,6 +372,13 @@ define([
                     const config = this.getConfig();
 
                     fromField = fromField || fields.min;
+
+                    if (isNaN(this.getMinValue())) {
+                        this.setMinValue(config.lowerThreshold);
+                    }
+                    if (isNaN(this.getMaxValue())) {
+                        this.setMaxValue(config.lowerThreshold);
+                    }
 
                     if (isFieldSupported(fromField) && this.is('rendered') && config.syncValues) {
                         const minValue = this.getMinValue();

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -198,19 +198,6 @@ define([
                         }
 
                         config[field].value = intValue;
-                    } else {
-                        // const fieldConfig = config[field];
-                        // const fieldControl = controls[field];
-                        // fieldControl.input = $(`[name=${fieldConfig.fieldName}]`, this.getElement());
-                        //
-                        // // if (fieldConfig.toggler) {
-                        // //     fieldControl.toggler.prop('checked', false);
-                        // // }
-                        //     // this.setValue(field, lowerThreshold);
-                        //     //
-                        //     // this.disableField(field);
-                        //     // isNaN(this.getValue(field)) === false
-
                     }
                     return this;
                 },

--- a/views/js/test/qtiCreator/widgets/component/minMax/test.js
+++ b/views/js/test/qtiCreator/widgets/component/minMax/test.js
@@ -453,7 +453,7 @@ define(['taoQtiItem/qtiCreator/widgets/component/minMax/minMax'], function(minMa
         var ready = assert.async();
         var container = document.getElementById('qunit-fixture');
 
-        assert.expect(11);
+        assert.expect(15);
 
         assert.equal(container.querySelector('.min-max'), null, 'The component does not exists yet');
 
@@ -497,6 +497,22 @@ define(['taoQtiItem/qtiCreator/widgets/component/minMax/minMax'], function(minMa
 
             assert.equal(this.getMinValue(), 2, 'min has been updated according to max');
             assert.equal(minInput.value, 2, 'min has been updated according to max');
+
+            minInput.value = NaN;
+            this.syncValues('min');
+
+            assert.equal(
+                this.getMinValue(), this.getConfig().lowerThreshold, 'min value changed from NaN to lowerThreshold'
+            );
+            assert.equal(minInput.value, this.getConfig().lowerThreshold, 'min value field has been updated');
+
+            maxInput.value = NaN;
+            this.syncValues('max');
+
+            assert.equal(
+                this.getMaxValue(), this.getConfig().lowerThreshold, 'max value changed from NaN to lowerThreshold'
+            );
+            assert.equal(maxInput.value, this.getConfig().lowerThreshold, 'max value field has been updated');
 
             ready();
         });


### PR DESCRIPTION
Add isNaN() checks for value set in Min and Max fields. Now you can't use delete key on value and save empty min max input.

Here's the link to [task](https://oat-sa.atlassian.net/browse/AUT-2967)  In it we have description how to test it