### PR TITLE
fix: compatibility with text-based inline choice options

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.9.1.tgz",
-            "integrity": "sha512-+5LivAAB6nLgsAqrGbbbMWuu3f/D0eYNqqljXtxqwOUEt4B7BUp47UmK1mGAS5HY3nAukzassZrBXPiKxB+syA=="
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.9.2.tgz",
+            "integrity": "sha512-D6MnBQ0ld916htMadYZyYcEipu276BllYQRPdXLv9g5WRQ5nnKUTlaMPQFwRKv23maHN0VhCeGy/39Eb9rBQCQ=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "1.9.1"
+        "@oat-sa/tao-item-runner-qti": "1.9.2"
     }
 }


### PR DESCRIPTION
# [OATSD-2361](https://oat-sa.atlassian.net/browse/OATSD-2361)

Requires: 
 - [ ] [https://github.com/oat-sa/<EXT>/pull/<PR>](https://github.com/oat-sa/tao-item-runner-qti-fe/pull/354)

This PR aims to fix `inlineChoice`'s compatibility with its older data format relying on `text` attribute while keeping the new implementation relying on the `body` element.

https://user-images.githubusercontent.com/2943256/221191076-4bea3b63-1c02-4e7f-ad43-620dc5e4a284.mov

[OATSD-2361]: https://oat-sa.atlassian.net/browse/OATSD-2361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ