### PR TITLE
fix: change shuffle pin state after shuffle toggle is disabled

### DIFF
--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -23,6 +23,16 @@ define(['jquery'], function ($) {
                 interaction = choice.getInteraction(),
                 $shuffleToggle = $container.find('[data-role="shuffle-pin"]');
 
+            const pinIcon = function (icon) {
+                icon.removeClass('icon-shuffle').addClass('icon-pin');
+                choice.attr('fixed', true);
+            }
+
+            const unPinIcon = function (icon) {
+                icon.removeClass('icon-pin').addClass('icon-shuffle');
+                choice.attr('fixed', false);
+            }
+
             const toggleVisibility = function (show) {
                 if (show === 'true' || show === true) {
                     $shuffleToggle.show();
@@ -32,10 +42,7 @@ define(['jquery'], function ($) {
                     if (icon.length === 0) {
                         icon = $($shuffleToggle);
                     }
-                    if (icon.hasClass('icon-pin')) {
-                        icon.removeClass('icon-pin').addClass('icon-shuffle');
-                        choice.attr('fixed', false);
-                    }
+                    unPinIcon(icon);
                 }
                 $('.qti-item').trigger('toolbarchange', {
                     callee: 'formElementHelper'
@@ -45,16 +52,13 @@ define(['jquery'], function ($) {
             $shuffleToggle.off('mousedown').on('mousedown', function (e) {
                 let $icon = $(this).children();
                 e.stopPropagation();
-
                 if ($icon.length === 0) {
                     $icon = $(this);
                 }
                 if ($icon.hasClass('icon-shuffle')) {
-                    $icon.removeClass('icon-shuffle').addClass('icon-pin');
-                    choice.attr('fixed', true);
+                    pinIcon($icon);
                 } else {
-                    $icon.removeClass('icon-pin').addClass('icon-shuffle');
-                    choice.attr('fixed', false);
+                    unPinIcon($icon);
                 }
             });
 

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -23,13 +23,13 @@ define(['jquery'], function ($) {
                 interaction = choice.getInteraction(),
                 $shuffleToggle = $container.find('[data-role="shuffle-pin"]');
 
-            const pinIcon = function (icon) {
-                icon.removeClass('icon-shuffle').addClass('icon-pin');
+            const pinIcon = function ($icon) {
+                $icon.removeClass('icon-shuffle').addClass('icon-pin');
                 choice.attr('fixed', true);
             }
 
-            const unPinIcon = function (icon) {
-                icon.removeClass('icon-pin').addClass('icon-shuffle');
+            const unPinIcon = function ($icon) {
+                $icon.removeClass('icon-pin').addClass('icon-shuffle');
                 choice.attr('fixed', false);
             }
 
@@ -38,11 +38,11 @@ define(['jquery'], function ($) {
                     $shuffleToggle.show();
                 } else {
                     $shuffleToggle.hide();
-                    let icon = $shuffleToggle.children();
-                    if (icon.length === 0) {
-                        icon = $($shuffleToggle);
+                    let $icon = $shuffleToggle.children();
+                    if ($icon.length === 0) {
+                        $icon = $($shuffleToggle);
                     }
-                    unPinIcon(icon);
+                    unPinIcon($icon);
                 }
                 $('.qti-item').trigger('toolbarchange', {
                     callee: 'formElementHelper'

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -30,9 +30,9 @@ define(['jquery'], function ($) {
                     $shuffleToggle.hide();
                     let icon = $shuffleToggle.children();
                     if (icon.length === 0) {
-                        icon = $(this);
+                        icon = $($shuffleToggle);
                     }
-                    if (icon && icon.hasClass('icon-pin')) {
+                    if (icon.hasClass('icon-pin')) {
                         icon.removeClass('icon-pin').addClass('icon-shuffle');
                         choice.attr('fixed', false);
                     }

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -29,7 +29,10 @@ define(['jquery'], function ($) {
                 } else {
                     $shuffleToggle.hide();
                     let icon = $shuffleToggle.children();
-                    if (icon.hasClass('icon-pin')) {
+                    if (icon.length === 0) {
+                        icon = $(this);
+                    }
+                    if (icon && icon.hasClass('icon-pin')) {
                         icon.removeClass('icon-pin').addClass('icon-shuffle');
                         choice.attr('fixed', false);
                     }

--- a/views/js/qtiCreator/widgets/choices/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/choices/helpers/formElement.js
@@ -28,6 +28,11 @@ define(['jquery'], function ($) {
                     $shuffleToggle.show();
                 } else {
                     $shuffleToggle.hide();
+                    let icon = $shuffleToggle.children();
+                    if (icon.hasClass('icon-pin')) {
+                        icon.removeClass('icon-pin').addClass('icon-shuffle');
+                        choice.attr('fixed', false);
+                    }
                 }
                 $('.qti-item').trigger('toolbarchange', {
                     callee: 'formElementHelper'


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3008

## What's Changed

- Disabling shuffle choices checkbox in authoring item also removes changes on shuffle pins

## How to test
- Open item in Authoring mode
- Tick “Shuffle choices“ option 
- Pin all choices and save
- Tick off “Shuffle choices“ option  and save
- Tick “Shuffle choices“ option again
- Observe Shuffling interface

![image](https://user-images.githubusercontent.com/118974926/228157098-d8138b59-18ab-484b-b35e-7b2e859634fc.png)
