### PR TITLE
fix: map item cardinality based on max choices

### DIFF
--- a/model/import/Template/ItemsQtiTemplateRender.php
+++ b/model/import/Template/ItemsQtiTemplateRender.php
@@ -62,7 +62,7 @@ class ItemsQtiTemplateRender extends ConfigurableService implements ItemsTemplat
                 'name' => $item->getName(),
                 'question' => $item->getQuestion(),
                 'shuffle' => $item->isShuffle() ? 'true' : 'false',
-                'responseDeclarationCardinality' => $item->getMaxChoices() > 1 ? 'multiple' : 'single',
+                'responseDeclarationCardinality' => $item->getMaxChoices() === 1 ? 'single' : 'multiple',
                 'outcomeDeclarationScoreCardinality' => 'single',
                 'outcomeDeclarationMaxScoreCardinality' => 'single'
             ]

--- a/model/import/Template/ItemsQtiTemplateRender.php
+++ b/model/import/Template/ItemsQtiTemplateRender.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2021-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 declare(strict_types=1);
@@ -62,8 +62,12 @@ class ItemsQtiTemplateRender extends ConfigurableService implements ItemsTemplat
                 'name' => $item->getName(),
                 'question' => $item->getQuestion(),
                 'shuffle' => $item->isShuffle() ? 'true' : 'false',
+                'responseDeclarationCardinality' => $item->getMaxChoices() > 1 ? 'multiple' : 'single',
+                'outcomeDeclarationScoreCardinality' => 'single',
+                'outcomeDeclarationMaxScoreCardinality' => 'single'
             ]
         );
+
         return $renderer->render();
     }
 
@@ -79,6 +83,9 @@ class ItemsQtiTemplateRender extends ConfigurableService implements ItemsTemplat
                 $item->getMetadata()
             );
         }
+
+        exit('___________________');//FIXME @TODO Remove after tests
+
         return $result;
     }
 

--- a/model/import/Template/ItemsQtiTemplateRender.php
+++ b/model/import/Template/ItemsQtiTemplateRender.php
@@ -84,8 +84,6 @@ class ItemsQtiTemplateRender extends ConfigurableService implements ItemsTemplat
             );
         }
 
-        exit('___________________');//FIXME @TODO Remove after tests
-
         return $result;
     }
 

--- a/templates/import/item_map_response.xml.tpl
+++ b/templates/import/item_map_response.xml.tpl
@@ -11,7 +11,7 @@
     timeDependent="false"
     toolName="TAO"
     toolVersion="3.4.0-sprint146">
-    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="identifier">
+    <responseDeclaration identifier="RESPONSE" cardinality="<?=get_data('responseDeclarationCardinality')?>" baseType="identifier">
         <?php if(get_data('hasCorrectChoices')): ?>
             <correctResponse>
                 <?php foreach(get_data('correctChoices') as $choice):?>
@@ -25,8 +25,8 @@
             <?php endforeach ?>
         </mapping>
     </responseDeclaration>
-    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="<?=get_data('maxScore')?>" />
-    <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+    <outcomeDeclaration identifier="SCORE" cardinality="<?=get_data('outcomeDeclarationScoreCardinality')?>" baseType="float" normalMaximum="<?=get_data('maxScore')?>" />
+    <outcomeDeclaration identifier="MAXSCORE" cardinality="<?=get_data('outcomeDeclarationMaxScoreCardinality')?>" baseType="float">
         <defaultValue>
             <value><?=get_data('maxScore')?></value>
         </defaultValue>

--- a/templates/import/item_match_correct_response.xml.tpl
+++ b/templates/import/item_match_correct_response.xml.tpl
@@ -11,15 +11,15 @@
     timeDependent="false"
     toolName="TAO"
     toolVersion="3.4.0-sprint146">
-    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="identifier">
+    <responseDeclaration identifier="RESPONSE" cardinality="<?=get_data('responseDeclarationCardinality')?>" baseType="identifier">
         <correctResponse>
             <?php foreach(get_data('correctChoices') as $choice):?>
                 <value><![CDATA[<?=$choice->getId()?>]]></value>
             <?php endforeach ?>
         </correctResponse>
     </responseDeclaration>
-    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="1" />
-    <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+    <outcomeDeclaration identifier="SCORE" cardinality="<?=get_data('outcomeDeclarationScoreCardinality')?>" baseType="float" normalMaximum="1" />
+    <outcomeDeclaration identifier="MAXSCORE" cardinality="<?=get_data('outcomeDeclarationMaxScoreCardinality')?>" baseType="float">
         <defaultValue>
             <value>1</value>
         </defaultValue>

--- a/templates/import/item_none_response.xml.tpl
+++ b/templates/import/item_none_response.xml.tpl
@@ -11,7 +11,7 @@
     timeDependent="false"
     toolName="TAO"
     toolVersion="3.4.0-sprint146">
-    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="identifier"/>
+    <responseDeclaration identifier="RESPONSE" cardinality="<?=get_data('responseDeclarationCardinality')?>" baseType="identifier"/>
     <itemBody>
         <div class="grid-row">
             <div class="col-12">


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-3023

# Goal

map cardinality on item qti based on max choices

# How to test

- Enable tabular import by adding this feature flag `FEATURE_FLAG_TABULAR_IMPORT_ENABLED=true` to `.env` file.
- Go to Items -> Import -> `CSV content + metadata`
- Import the attached file and check QTI content of the items

FILE ==> [Import-csv-Cardinality-NL(TEST).csv](https://github.com/oat-sa/extension-tao-itemqti/files/11111384/Import-csv-Cardinality-NL.TEST.csv)