### PR TITLE
fix: get rid of redundant FS call

### DIFF
--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -383,7 +383,6 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
      */
     protected function getRuntime(PortableElementObject $object)
     {
-        $object = $this->fetch($object->getTypeIdentifier(), $object->getVersion());
         $runtime = $object->toArray();
         $runtime['model'] = $object->getModelId();
         $runtime['xmlns'] = $object->getNamespace();


### PR DESCRIPTION
The aim of the change is to reduce time of getting all latest versions of all registered PCIs: https://github.com/oat-sa/extension-tao-itemqti-pci/blob/master/controller/PciLoader.php#L40

We do not need to run `fetch` method again, cause we doing there [completely same job](https://github.com/oat-sa/extension-tao-itemqti/blob/master/model/portableElement/storage/PortableElementRegistry.php#L93) as previously for each element of array [here](https://github.com/oat-sa/extension-tao-itemqti/blob/master/model/portableElement/storage/PortableElementRegistry.php#L426). Moreover, `getRuntime` argument `$object` has explicit type `PortableElementObject` no need to get data and create object again. As far as I was able to check, method `getRuntime` used in single place to form response data for the endpoint.



How to test:
- Register significant number of PCIs > 200
- Check load time
- Switch to feature branch and compare load time with it
- Validate that any other feature related to PCIs was not affected: PCI manager, item/test pacakge export/import, delivery compilation, test runner, item/test previewers