### PR TITLE
fix: use flag to skip replaceNonBreakingSpaceCharacters

### DIFF
--- a/views/js/qtiXmlRenderer/renderers/Container.js
+++ b/views/js/qtiXmlRenderer/renderers/Container.js
@@ -16,7 +16,9 @@
  * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA
  */
 
-define(['tpl!taoQtiItem/qtiXmlRenderer/tpl/container'], function(tpl){
+define(['module', 'tpl!taoQtiItem/qtiXmlRenderer/tpl/container'], function(module, tpl){
+    
+    const config = module.config();
     /**
      * Elements that need to be prefixed
      *
@@ -55,8 +57,9 @@ define(['tpl!taoQtiItem/qtiXmlRenderer/tpl/container'], function(tpl){
                 function($0){
                     return $0.replace('</rt', '&nbsp;</rt');
                 });
-
-            returnValue = replaceNonBreakingSpaceCharacters(returnValue);
+            if (!config.skipReplaceNonBreakingSpaceCharacters) {
+                returnValue = replaceNonBreakingSpaceCharacters(returnValue);
+            }
             returnValue = mergeSiblings(returnValue);
         }
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-5339

Add flag that allows skip replaceNonBreakingSpaceCharacters

How to test:
create item
add A-block
put text, empty lines, then text
save, check Payload in devTools
see `<p> </p>`
![image](https://user-images.githubusercontent.com/25976342/231463416-156a4de5-0d94-4e8d-80b6-9b88aa9eb498.png)
Set feature flag:
add to config/tao/client_lib_config_registry.conf.php
```
        'taoQtiItem/qtiXmlRenderer/renderers/Container'=> array(
            'skipReplaceNonBreakingSpaceCharacters' => true
        ),
```
check in Payload `<p>&nbsp;</p>`
![image](https://user-images.githubusercontent.com/25976342/231462959-722f438f-115d-453f-bfaf-6ab6dcec0747.png)

