### PR TITLE
chore: update dependency version

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
             "integrity": "sha512-KgC+Se8AyLDd3CoGaIPMRorihdN7ch/3RajkgSvlrz+yLLPrpZ71qGHm1rtM83ti9qyfA5gA7cgSjmHp4H7MOQ=="
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.10.1.tgz",
-            "integrity": "sha512-JMSw9XqmESHOvTzFggHqwiGQxnf/t4b3sk9oGk6oQ5dgoSncAytrAkyKRla524JtYhC6ZEpnbORKCY/njpjJaQ=="
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-1.11.0.tgz",
+            "integrity": "sha512-D7ekB+bMZ6Vjn8gvboLaTiqa1gGvRPrG8IVoey7BagTZJ5ZOTn5r/7btxnGgRU5vy1PSBOBIGB+Dc+TSwkYh7g=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "0.8.1",
-        "@oat-sa/tao-item-runner-qti": "1.10.1"
+        "@oat-sa/tao-item-runner-qti": "1.11.0"
     }
 }


### PR DESCRIPTION
coming from [https://oat-sa.atlassian.net/browse/AUT-3093](https://oat-sa.atlassian.net/browse/AUT-3093)

changes: updates version of tao-item-runner-qti-fe version
how to test:
* open an item in authoring
* add a associate interaction
* add mathjax long expression as one of the choices
* choice block should stretch and no overflow should be seen 