### PR TITLE
feat(item.tpl): rendering 'dir' if set as attribute

### DIFF
--- a/views/js/qtiCreator/tpl/item.tpl
+++ b/views/js/qtiCreator/tpl/item.tpl
@@ -1,4 +1,4 @@
 <div class="tao-scope qti-item item-editor-item clearfix" data-serial="{{serial}}" data-identifier="{{attributes.identifier}}">
     <div id="modalFeedbacks"></div>
-    <div{{#if attributes.id}} id="{{attributes.id}}"{{/if}} class="qti-itemBody item-editor-drop-area hoverable{{#if attributes.class}} {{attributes.class}}{{/if}}">{{{body}}}</div>
+    <div{{#if attributes.id}} id="{{attributes.id}}"{{/if}} class="qti-itemBody item-editor-drop-area hoverable{{#if attributes.class}} {{attributes.class}}{{/if}}"{{#if attributes.dir}} dir="{{attributes.dir}}"{{/if}}>{{{body}}}</div>
 </div>


### PR DESCRIPTION
Fixes [AUT-2939](https://oat-sa.atlassian.net/browse/AUT-2939)

## What's changed

Item template renders dir when is setup properly.

Needed for https://github.com/oat-sa/extension-tao-mediamanager/pull/470

[AUT-2939]: https://oat-sa.atlassian.net/browse/AUT-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ