### PR TITLE
fix: use id for input

### DIFF
--- a/views/js/qtiCreator/tpl/forms/interactions/choice.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/choice.tpl
@@ -19,7 +19,7 @@
     </span>
     <div>
         <label class="smaller-prompt">
-            <input type="radio" name="constraints" value="none" {{#equal constraints "none"}}checked{{/equal}}  for="constraints-none"/>
+            <input type="radio" name="constraints" value="none" {{#equal constraints "none"}}checked{{/equal}}  id="constraints-none"/>
             <span class="icon-radio"></span>
             <label for="constraints-none">{{__ 'None'}} </label>
         </label>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2150
## What's Changed
- Fixed label of constraint "None" is not clickable
## How to test
- Open item in authoring
- Open interaction properties
- Set constraints “Answer required“ by clicking on the label
- Set constraints “None“ by clicking on the label
Expected result: Constraint “none“ can be selected by clicking both radio button or the label.
<img width="1132" alt="image" src="https://github.com/oat-sa/extension-tao-itemqti/assets/135347298/f8c2818f-dd40-4f44-8199-d09cbae2a6a3">
