### PR TITLE
[Fix] Accept lowercase letters for second part in languages codes

### DIFF
--- a/model/qti/datatype/Language.php
+++ b/model/qti/datatype/Language.php
@@ -29,11 +29,10 @@ class Language extends Datatype
 {
     public static function validate($value): bool
     {
-        $pattern =
-            '/(?:^[a-z]{2}$)|(?:^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2,3}|-[0-9]{3})'
-            . '(?:(?:-x)?-[a-z0-9]{5,8})?$)/';
-
-        return preg_match($pattern, $value);
+        return preg_match(
+            '/^[a-z]{2}$|^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[a-zA-Z]{2,3}|-\d{3})(?:(?:-x)?-[a-z\d]{5,8})?$/',
+            $value
+        );
     }
 
     public static function fix($value)

--- a/test/resources/supported-locales.json
+++ b/test/resources/supported-locales.json
@@ -64,6 +64,10 @@
     "title": "Arabic (ARB)"
   },
   {
+    "code": "ar-arb",
+    "title": "Arabic (ARB)"
+  },
+  {
     "code": "ar-BH",
     "title": "Arabic (BH)"
   },

--- a/test/unit/model/qti/datatype/LanguageValidateLanguageCodesTest.php
+++ b/test/unit/model/qti/datatype/LanguageValidateLanguageCodesTest.php
@@ -89,7 +89,6 @@ class LanguageValidateLanguageCodesTest extends TestCase
             [false, 'aa-BB-x-12'],
             [false, 'aa-BB-x-1234'],
             [false, 'aa-BB-x-123456789'],
-            [false, 'lo-wer'],
 
             // No uppercase letters allowed after "-x-"
             [false, 'en-GB-x-Excscotl'],


### PR DESCRIPTION
# [AUT-3264](https://oat-sa.atlassian.net/browse/AUT-3264)

## Changelog
* Language regexp changed to accept lowercase letters in second part, e.t. `ar-arb`

## Related PRs
* https://github.com/oat-sa/tao-deliver-be/pull/1200

[AUT-3264]: https://oat-sa.atlassian.net/browse/AUT-3264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ