### PR TITLE
fix: Gcp filesystem for portableElement issue

### DIFF
--- a/model/portableElement/storage/PortableElementFileStorage.php
+++ b/model/portableElement/storage/PortableElementFileStorage.php
@@ -109,7 +109,9 @@ class PortableElementFileStorage extends ConfigurableService
             } else {
                 $registered = $fileSystem->writeStream($fileId, $resource);
             }
-            fclose($resource);
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
             \common_Logger::i('Portable element asset file "' . $fileId . '" copied.');
         }
         return $registered;


### PR DESCRIPTION
If filesystem is set as gcp (`oat\\oatbox\\filesystem\\wrapper\\GoogleStorageWrapper`) in `config/generis/filesystem.conf.php` for `portableElementStorage` the following issue occurs during `qtiItemPci` extension installation:
```
/var/www/html $ php tao/scripts/installExtension.php qtiItemPci
2023-09-14 15:34:44 [INFO] [tao] 'Installing extension qtiItemPci' /var/www/html/generis/helpers/class.InstallHelper.php 111
2023-09-14 15:34:44 [INFO] [tao] 'Installing extension qtiItemPci' /var/www/html/generis/common/ext/class.ExtensionHandler.php 131
PHP Fatal error:  Uncaught TypeError: fclose(): supplied resource is not a valid stream resource in /var/www/html/taoQtiItem/model/portableElement/storage/PortableElementFileStorage.php:114
Stack trace:
#0 /var/www/html/taoQtiItem/model/portableElement/storage/PortableElementFileStorage.php(114): fclose()
#1 /var/www/html/taoQtiItem/model/portableElement/storage/PortableElementRegistry.php(353): oat\taoQtiItem\model\portableElement\storage\PortableElementFileStorage->registerFiles()
#2 /var/www/html/taoQtiItem/model/portableElement/PortableElementService.php(90): oat\taoQtiItem\model\portableElement\storage\PortableElementRegistry->register()
#3 /var/www/html/taoQtiItem/model/portableElement/PortableElementService.php(283): oat\taoQtiItem\model\portableElement\PortableElementService->registerModel()
#4 /var/www/html/taoQtiItem/model/portableElement/action/RegisterPortableElement.php(71): oat\taoQtiItem\model\portableElement\PortableElementService->registerFromDirectorySource()
#5 /var/www/html/generis/common/ext/class.ExtensionHandler.php(91): oat\taoQtiItem\model\portableElement\action\RegisterPortableElement->__invoke()
#6 /var/www/html/generis/common/ext/class.ExtensionInstaller.php(197): common_ext_ExtensionHandler->runExtensionScript()
#7 /var/www/html/generis/common/ext/class.ExtensionInstaller.php(103): common_ext_ExtensionInstaller->installCustomScript()
#8 /var/www/html/generis/helpers/class.InstallHelper.php(111): common_ext_ExtensionInstaller->install()
#9 /var/www/html/generis/helpers/class.InstallHelper.php(81): helpers_InstallHelper::install()
#10 /var/www/html/tao/helpers/InstallHelper.php(46): helpers_InstallHelper::installRecursively()
#11 /var/www/html/tao/scripts/installExtension.php(36): oat\tao\helpers\InstallHelper::installRecursively()
#12 {main}
  thrown in /var/www/html/taoQtiItem/model/portableElement/storage/PortableElementFileStorage.php on line 114
2023-09-14 15:34:45 [ERROR] [tao] 'php error(1) in /var/www/html/taoQtiItem/model/portableElement/storage/PortableElementFileStorage.php@114: Uncaught TypeError: fclose(): supplied resource is not a valid stream resource in /var/www/html/taoQtiItem/model/portableElement/storage/PortableElementFileStorage.php:114
```