### PR TITLE
fix: add translation

### DIFF
--- a/locales/nb-NO/messages.po
+++ b/locales/nb-NO/messages.po
@@ -1,17 +1,24 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: TAO 2023.02 LTS\n"
-"PO-Revision-Date: 2023-02-03T13:45:06\n"
+"Project-Id-Version: tao-open-source\n"
+"PO-Revision-Date: 2023-06-07 09:16\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
-"Language: nb-NO\n"
+"Language: nb_NO\n"
 "sourceLanguage: en-US\n"
-"targetLanguage: nb-NO\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"targetLanguage: en-US\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Basepath: ../../\n"
 "X-Poedit-KeywordsList: __\n"
 "X-Poedit-SearchPath-0: .\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: tao-open-source\n"
+"X-Crowdin-Project-ID: 590867\n"
+"X-Crowdin-Language: nb\n"
+"X-Crowdin-File: /[oat-sa.extension-tao-itemqti] develop/locales/en-US/messages.po\n"
+"X-Crowdin-File-ID: 519\n"
+"Language-Team: Norwegian Bokmal\n"
 
 msgid " Fill in the gaps in a text from a set of choices."
 msgstr " Fyll ut mellomrommene i en tekst med de gitte alternativene."
@@ -29,7 +36,7 @@ msgid "%d Item(s) of %d imported from the given IMS QTI Package."
 msgstr ""
 
 msgid "%d/%d"
-msgstr "%d/%d"
+msgstr ""
 
 msgid "%s metadata values found in source by extractor(s)."
 msgstr "%s metadataverdier funnet i kilden av ekstraktor(er)."
@@ -46,9 +53,6 @@ msgstr ""
 msgid "-- Any kind of file --"
 msgstr "--Hvilken som helst fil--"
 
-msgid "--- leave empty ---"
-msgstr "la stå tom"
-
 msgid "1 item imported from the given QTI/APIP XML Item Document."
 msgstr "1 oppgave importert fra det gitte QTI/APIP XML-oppgavedokumentet."
 
@@ -64,9 +68,6 @@ msgstr ""
 msgid "3/4 of height"
 msgstr ""
 
-msgid "7-zip archive"
-msgstr "7-zip arkiv"
-
 msgid "A choice must be selected"
 msgstr "Du må gjøre et valg"
 
@@ -74,9 +75,7 @@ msgid "A human interpretation of the variable's value."
 msgstr "En manuell tolkning av variablens verdi."
 
 msgid "A QTI component is not supported. The system returned the following error: %s\n"
-""
 msgstr "En QTI-komponent støttes ikke. Systemet returnerte følgende feil: %s\n"
-""
 
 msgid "A rubric block identifies part of an assessmentItem's itemBody that represents instructions to one or more of the actors that view the item. Although rubric blocks are defined as simpleBlocks they must not contain interactions."
 msgstr "En boks identifiserer en del av en vurdering som representerer instruksjoner til en eller flere av aktørene som ser oppgaven. Selv om bokser er definert som \"simple Blocks\", må de ikke inneholde oppgavetyper."
@@ -100,7 +99,7 @@ msgid "Add a ZIP file containing QTI/APIP items"
 msgstr "Legg til en ZIP-fil som inneholder QTI/APIP-oppgaver"
 
 msgid "Add an outcome"
-msgstr ""
+msgstr "Legg til vurderings-alternativ"
 
 msgid "Add another option"
 msgstr "Legg til et annet alternativ"
@@ -122,9 +121,6 @@ msgstr ""
 
 msgid "Add Style Sheet"
 msgstr "Legg til stilark"
-
-msgid "Adobe Flash file"
-msgstr "Adobe Flash-fil"
 
 msgid "Alignment"
 msgstr "Justering"
@@ -163,7 +159,7 @@ msgid "An error occurred at the level of the QTI model."
 msgstr "Det oppstod en feil på nivået til QTI-modellen."
 
 msgid "An optional link to an extended interpretation of the outcome variable."
-msgstr "En valgfri lenke til en utvidet tolkning av resultatvariabelen."
+msgstr "Lenke til veiledning/ kriterier til den som skal vurdere i skåringsverktøyet."
 
 msgid "An unexpected error occured during the import of the IMS QTI Item Package."
 msgstr "En uventet feil oppstod under importen av IMS QTI-oppgavene."
@@ -178,9 +174,7 @@ msgid "An unexpected error occurred during the import of the IMS QTI Item Packag
 msgstr "En uventet feil oppstod under importen av IMS QTI-oppgavene. Systemet returnerte følgende feil: \"%s"
 
 msgid "An unexpected error occurred during the import of the QTI Item. The system returned the following error: %s\n"
-""
 msgstr "Det oppstod en uventet feil under importen av QTI-oppgaven. Systemet returnerte følgende feil: %s\n"
-""
 
 msgid "An unknown error occured while importing the IMS QTI Package with identifier: "
 msgstr ""
@@ -212,11 +206,8 @@ msgstr "minst"
 msgid "Attempting to inject \"%s\" metadata values for target \"%s\" with metadata Injector \"%s\"."
 msgstr ""
 
-msgid "Audio Video Interleave"
-msgstr "Lyd og video sammen"
-
 msgid "Autostart"
-msgstr "Autostart"
+msgstr ""
 
 msgid "Back to Manage Items"
 msgstr "Tilbake til administrer oppgaver"
@@ -226,9 +217,6 @@ msgstr "Bakgrunnsfarge"
 
 msgid "Base"
 msgstr "Utgangspunkt"
-
-msgid "Bitmap image"
-msgstr "Bitmap-bilde"
 
 msgid "block"
 msgstr "tekstboks"
@@ -251,20 +239,11 @@ msgstr "Søk gjennom maskinen din og velg riktig fil."
 msgid "Browse..."
 msgstr "Søk..."
 
-msgid "C file"
-msgstr "C-fil"
-
-msgid "C++ file (.cpp)"
-msgstr "C++ fil (.cpp)"
-
-msgid "Calc speadsheet (Staroffice)"
-msgstr "Calc-regneark (Staroffice)"
+msgid "cancel"
+msgstr "avbryt"
 
 msgid "Cancel"
 msgstr "Avbryt"
-
-msgid "cancel"
-msgstr "avbryt"
 
 msgid "Cannot create gap from this selection. Please check that you do not have partially selected elements."
 msgstr "Kan ikke lage mellomrom fra dette valget. Kontroller at du ikke har delvis utvalgte elementer."
@@ -293,17 +272,11 @@ msgstr "kan ikke laste inn QTI XML"
 msgid "Cannot locate the file \"%s"
 msgstr "Finner ikke filen \"%s"
 
-msgid "Cascading Style Sheets"
-msgstr "Stilark"
-
 msgid "Center"
 msgstr "Senter"
 
 msgid "Change the width of the item. By default the item has a width of 100% and adapts to the size of any screen. The maximal width is by default 1024px - this will also change when you set a custom with."
 msgstr ""
-
-msgid "characters"
-msgstr "tegn"
 
 msgid "chars"
 msgstr "tegn"
@@ -362,9 +335,6 @@ msgstr "Fargevelger"
 msgid "Common Interactions"
 msgstr "Vanlige oppgavetyper"
 
-msgid "Compressed tar file"
-msgstr "Komprimert tar-fil"
-
 msgid "Constraints"
 msgstr "Begrensninger"
 
@@ -378,7 +348,7 @@ msgid "correct"
 msgstr "riktig"
 
 msgid "Cosinus"
-msgstr "Cosinus"
+msgstr ""
 
 msgid "Create assocations and fill the score in the form below"
 msgstr "Opprett koblingerer og fyll ut poengsummen i skjemaet under"
@@ -401,9 +371,6 @@ msgstr "Lag par ut fra en rekke valg."
 msgid "CSV content + metadata"
 msgstr "CSV-innhold + metadata"
 
-msgid "CSV file"
-msgstr "CSV-fil"
-
 msgid "Current value:"
 msgstr "Verdi:"
 
@@ -418,9 +385,6 @@ msgstr ""
 
 msgid "Custom Response Processing Mode"
 msgstr "Egendefinert skåringsinnstilling"
-
-msgid "Database file"
-msgstr "Database-fil"
 
 msgid "default"
 msgstr "standard"
@@ -455,11 +419,11 @@ msgstr "Definer bredde"
 msgid "Defines the maximum magnitude of numeric outcome variables, the maximum must be a positive value and the minimum may be negative."
 msgstr "Definerer maksimal størrelse på numeriske resultatvariabler, maksimum må være en positiv verdi og minimum kan være en negativ verdi."
 
-msgid "delete"
-msgstr "slett"
-
 msgid "Delete"
 msgstr "Slett"
+
+msgid "delete"
+msgstr "slett"
 
 msgid "Delete else statement"
 msgstr "Slett annet utsagn"
@@ -485,17 +449,14 @@ msgstr "Vis valgene enten horisontalt eller vertikalt"
 msgid "Divide"
 msgstr "Dele opp"
 
-msgid "Document templates (Staroffice)"
-msgstr "Dokumentmaler (Staroffice)"
-
 msgid "Don't save"
 msgstr "Ikke lagre"
 
-msgid "Done"
-msgstr "Ferdig"
-
 msgid "done"
 msgstr "ferdig"
+
+msgid "Done"
+msgstr "Ferdig"
 
 msgid "Download"
 msgstr "Last ned"
@@ -533,7 +494,7 @@ msgstr "Redigere"
 msgid "edit choices"
 msgstr "redigere valg"
 
-msgid "Edit math expression using LaTex type setting system, e.g. e^{i \pi} = -1"
+msgid "Edit math expression using LaTex type setting system, e.g. e^{i \\pi} = -1"
 msgstr "Rediger matematisk uttrykk ved hjelp av LaTex type innstillingssystem, f.eks. e^{i \\ pi} = -1"
 
 msgid "Edit math expression using MathML"
@@ -575,9 +536,6 @@ msgstr "End attempt"
 msgid "End Attempt Interaction"
 msgstr "Oppgavetype end attempt"
 
-msgid "Enhanced metafile"
-msgstr "Forbedret metafil"
-
 msgid "Enlarge font size"
 msgstr "Forstørr skriftstørrelse"
 
@@ -611,7 +569,7 @@ msgstr "Feil på oppgave %s"
 msgid "Error to export item %s: %s"
 msgstr "Feil ved eksport av element %s: %s"
 
-msgid "Euler\'s constant"
+msgid "Euler\\'s constant"
 msgstr "Eulers konstante"
 
 msgid "Exponent"
@@ -645,10 +603,10 @@ msgid "Extended Text Interaction"
 msgstr "Oppgavetype fritekst"
 
 msgid "External Machine"
-msgstr "Automatisk"
+msgstr "Plagiatkontroll"
 
 msgid "External Scored"
-msgstr "Ekstern skåring"
+msgstr "Manuell skåring / Plagiat"
 
 msgid "Fail to export item"
 msgstr "Kunne ikke eksportere oppgave"
@@ -680,14 +638,8 @@ msgstr "Oppgavetype filopplasting"
 msgid "Fill in the gaps on a picture with a set of image choices."
 msgstr "Fyll inn mellomrommene i et bilde med et gitt sett av bildevalg."
 
-msgid "Flash video"
-msgstr "Flash-video"
-
 msgid "float"
 msgstr ""
-
-msgid "Flowchart-based programming environment & TI Interactive Workbook"
-msgstr "Flytskjema-basert programmeringsmiljø og TI interaktiv arbeidsbok"
 
 msgid "Font family"
 msgstr "Skrifttype"
@@ -696,7 +648,7 @@ msgid "Font size"
 msgstr "Skriftstørrelse"
 
 msgid "Format"
-msgstr "Format"
+msgstr ""
 
 msgid "Fraction"
 msgstr "Brøk"
@@ -712,12 +664,6 @@ msgstr "Fyll inn"
 
 msgid "Gap Match Interaction"
 msgstr "Oppgavetype fyll inn"
-
-msgid "Geogebra data file"
-msgstr "Geogebra data-fil"
-
-msgid "GIF image"
-msgstr "GIF-bilde"
 
 msgid "Graphic Associate Interaction"
 msgstr "Grafisk oppgavetype - kobling"
@@ -735,28 +681,22 @@ msgid "Greater than or equal"
 msgstr "Større enn eller lik"
 
 msgid "Guard for resource \"%s\"..."
-msgstr "Guard for resource \"%s\"..."
-
-msgid "GZip Compressed Archive"
-msgstr "GZip komprimert arkiv"
+msgstr ""
 
 msgid "Half height"
 msgstr ""
-
-msgid "Header file with extensions"
-msgstr "Toppfil med utvidelser"
 
 msgid "Height"
 msgstr "Høyde"
 
 msgid "Here you can provide scoring aspects for manual scoring/marking, e.g. CONTENT, GRAMMAR, SPELLING"
-msgstr "Her kan du definere poeng for manuell skåring, f.eks. av INNHOLD, GRAMATIKK, STAVNING"
+msgstr "Her kan du definere alternativer for plagiatkontroll og manuell skåring, f.eks. av INNHOLD, GRAMATIKK, STAVING"
 
 msgid "Horizontal"
 msgstr "Horisontal"
 
 msgid "Hotspot"
-msgstr "Klikk bilde"
+msgstr ""
 
 msgid "Hotspot Interaction"
 msgstr "Oppgavetype klikk bilde"
@@ -774,10 +714,7 @@ msgid "How the math expression should be edited"
 msgstr "Hvordan det matematiske uttrykket skal redigeres"
 
 msgid "Human"
-msgstr "Manuell"
-
-msgid "Hypertext markup language"
-msgstr "Markeringsspråk for hypertekst"
+msgstr "Manuell skåring"
 
 msgid "identical pair already exists"
 msgstr "identisk par eksisterer allerede"
@@ -808,12 +745,6 @@ msgstr "Hvis variabelverdien er et flyt- og powerForm som er satt til \"false\",
 
 msgid "If this box is checked the student will be able to eliminate choices."
 msgstr "Hvis denne boksen er huket av, vil eleven kunne eliminere ulike valgalternativer."
-
-msgid "Image caption"
-msgstr ""
-
-msgid "Image caption not enabled when position is set to inline"
-msgstr ""
 
 msgid "Import"
 msgstr "Importer"
@@ -942,12 +873,6 @@ msgstr "Oppgavebredde"
 msgid "Items"
 msgstr "Oppgaver"
 
-msgid "Javascript code"
-msgstr "Jacascript kode"
-
-msgid "JPEG image"
-msgstr "JPEG-bilde"
-
 msgid "Label"
 msgstr "Navn"
 
@@ -961,16 +886,19 @@ msgid "LaTeX"
 msgstr "LaTex"
 
 msgid "Latex"
-msgstr "Latex"
+msgstr ""
 
 msgid "Layout"
 msgstr "Oppsett"
 
-msgid "Left"
-msgstr "Venstre"
+msgid "--- leave empty ---"
+msgstr "la stå tom"
 
 msgid "left"
 msgstr "venstre"
+
+msgid "Left"
+msgstr "Venstre"
 
 msgid "Left bracket"
 msgstr "Venstre parentes"
@@ -988,16 +916,16 @@ msgid "List Style"
 msgstr "Listestil"
 
 msgid "Ln"
-msgstr "Ln"
+msgstr ""
 
 msgid "Log"
-msgstr "Log"
+msgstr ""
 
 msgid "Long interpretation"
-msgstr "Kriterier"
+msgstr "Vurderingskriterier"
 
 msgid "Loop"
-msgstr "Loop"
+msgstr ""
 
 msgid "Lower Bound"
 msgstr "Nedre grense"
@@ -1041,7 +969,7 @@ msgid "MathJax is not installed."
 msgstr "MathJax er ikke installert."
 
 msgid "MathML"
-msgstr "MathML"
+msgstr ""
 
 msgid "Max"
 msgstr "Maks"
@@ -1077,7 +1005,7 @@ msgid "Maximum number of choices reached."
 msgstr "Maks antall valg er nådd."
 
 msgid "Media"
-msgstr "Media"
+msgstr ""
 
 msgid "Media file path or YouTube video address"
 msgstr "Mediefilbane eller YouTube-videoadresse"
@@ -1100,41 +1028,11 @@ msgstr "Metadataimport krever en forekomst av DomManifest for å trekke ut metad
 msgid "Metadata service successfully registered."
 msgstr "Metadatatjenesten ble registrert."
 
-msgid "Microsoft Excel"
-msgstr "Microsoft Excel"
-
-msgid "Microsoft Office Document Imaging"
-msgstr "Microsoft Office Document Imaging"
-
-msgid "Microsoft Powerpoint"
-msgstr "Microsoft Powerpoint"
-
-msgid "Microsoft Project file"
-msgstr "Microsoft Project-fil"
-
-msgid "Microsoft Visio file"
-msgstr "Microsoft Visio-fil"
-
-msgid "Microsoft Word"
-msgstr "Microsoft Word"
-
-msgid "Microsoft Works file"
-msgstr "Microsoft Works-fil"
-
-msgid "Microsoft XPS file"
-msgstr "Microsoft XPS-fil"
-
-msgid "MIME encapsulation of aggregate HTML documents"
-msgstr "MIME-samling av aggregerte HTML-dokumenter"
-
 msgid "MIME-type"
-msgstr "MIME-type"
+msgstr ""
 
 msgid "Min"
-msgstr "Min"
-
-msgid "Mind mapping software application (free mind open source)"
-msgstr "Mind-mapping programvare (gratis åpen kildekode)"
+msgstr ""
 
 msgid "Minimal  score for this interaction."
 msgstr "Minimun poengsum for denne oppgavetypen."
@@ -1151,18 +1049,6 @@ msgstr "tilbakemeldingstittel"
 msgid "Modal Feedbacks"
 msgstr "Tilbakemeldinger"
 
-msgid "MP4 video"
-msgstr "MP4-video"
-
-msgid "MPEG audio"
-msgstr "MPEG-lyd"
-
-msgid "MPEG video"
-msgstr "MPEG video"
-
-msgid "MPEG-4 audio file"
-msgstr "MPEG-4 lydfil"
-
 msgid "Multiple choices"
 msgstr ""
 
@@ -1170,7 +1056,7 @@ msgid "Multiply"
 msgstr "Multiplisere"
 
 msgid "negative"
-msgstr "negative"
+msgstr ""
 
 #, tao-public
 msgid "New item"
@@ -1200,11 +1086,11 @@ msgstr "Ingen opplastet fil"
 msgid "No value set"
 msgstr "Ingen verdi er angitt"
 
-msgid "None"
-msgstr "Ingen"
-
 msgid "none"
 msgstr "ingen"
+
+msgid "None"
+msgstr "Ingen"
 
 msgid "None defined yet."
 msgstr "Ingen er definert ennå."
@@ -1219,30 +1105,13 @@ msgid "of"
 msgstr "av"
 
 msgid "OK"
-msgstr "OK"
+msgstr ""
 
 msgid "one association pair"
 msgstr "kobling av et par"
 
 msgid "One or more QTI components are not supported by the system. The system returned the following error: %s\n"
-""
 msgstr "En eller flere QTI-komponenter støttes ikke av systemet. Systemet returnerte følgende feil: %s\n"
-""
-
-msgid "OpenDocument Database"
-msgstr "OpenDocument Database"
-
-msgid "OpenDocument Presentation"
-msgstr "OpenDocument presentasjon"
-
-msgid "OpenDocument spreadsheet document"
-msgstr "OpenDocument regnearkdokument"
-
-msgid "OpenDocument text document"
-msgstr "OpenDocument tekstdokument"
-
-msgid "OpenDocument Text Template"
-msgstr "OpenDocument tekstmal"
 
 msgid "Order"
 msgstr "Sortering"
@@ -1260,25 +1129,19 @@ msgid "Other constraints"
 msgstr ""
 
 msgid "Outcome Declarations"
-msgstr "Skåringsvariabler"
+msgstr "Vurderingsalternativer"
 
 msgid "Pair scoring"
 msgstr "Skåring av par"
-
-msgid "Pascal file (.pas)"
-msgstr "Pascal fil (.pas)"
 
 msgid "Pattern"
 msgstr "Mønster"
 
 msgid "Pause"
-msgstr "Pause"
-
-msgid "PDF file"
-msgstr "PDF-fil"
+msgstr ""
 
 msgid "Pi"
-msgstr "Pi"
+msgstr ""
 
 msgid "Placeholder Text"
 msgstr ""
@@ -1288,11 +1151,6 @@ msgstr "Ren tekst"
 
 msgid "Please add one or more gaps to the text in question mode."
 msgstr "Legg til ett eller flere mellomrom i teksten i spørsmålsfeltet."
-
-msgid "Please create areas that correspond to the response and associate them a score.\n"
-""
-msgstr "Opprett områder som tilsvarer svaret, og gi dem en poengsum.\n"
-""
 
 msgid "Please create areas that correspond to the response and associate them a score. You can also position the target to the exact point as the correct response."
 msgstr ""
@@ -1363,9 +1221,6 @@ msgstr "Skriv inn riktig svar nedenfor."
 msgid "Please type the correct response in the box below."
 msgstr "Skriv inn riktig svar i boksen nedenfor."
 
-msgid "PNG image"
-msgstr "PNG-bilde"
-
 msgid "Portable element model %s not found. Required extension might be missing"
 msgstr "Bærbar elementmodell %s ble ikke funnet. Nødvendig utvidelse kan mangle"
 
@@ -1373,7 +1228,7 @@ msgid "Position one or more points on a picture (response areas are not displaye
 msgstr "Plasser ett eller flere punkter på et bilde (svarområder vises ikke)."
 
 msgid "positive"
-msgstr "positive"
+msgstr ""
 
 msgid "Power form"
 msgstr "Maktform"
@@ -1421,10 +1276,10 @@ msgid "Published %s"
 msgstr "Publisert %s"
 
 msgid "QTI Item Runner"
-msgstr "QTI Item Runner"
+msgstr ""
 
 msgid "QTI Metadata"
-msgstr "QTI Metadata"
+msgstr ""
 
 msgid "QTI Package 2.1"
 msgstr "QTI-Pakke 2.1"
@@ -1444,15 +1299,6 @@ msgstr "QTI/APIP XML-oppgavedokument"
 msgid "Question"
 msgstr "Spørsmål"
 
-msgid "Quicktime video"
-msgstr "Quicktime-video"
-
-msgid "RAR archive"
-msgstr "RAR arkiv"
-
-msgid "RealMedia file"
-msgstr "RealMedia-fil"
-
 msgid "Recommendations"
 msgstr "Anbefalinger"
 
@@ -1468,11 +1314,11 @@ msgstr "Registreringsmetoden forventer parametere for $key og $name"
 msgid "Register method expects $key and $name parameters."
 msgstr "Registreringsmetoden forventer parametere for $key og $name."
 
-msgid "Remove"
-msgstr "Fjern"
-
 msgid "remove"
 msgstr "fjern"
+
+msgid "Remove"
+msgstr "Fjern"
 
 msgid "Remove custom background color"
 msgstr "Fjern tilpasset bakgrunnsfarge"
@@ -1546,9 +1392,6 @@ msgstr "Rik tekst"
 msgid "Rich text + math"
 msgstr "Rik tekst + math"
 
-msgid "Rich Text Format file"
-msgstr "Rik Tekst Format-fil"
-
 msgid "Right"
 msgstr "Høyre"
 
@@ -1588,9 +1431,6 @@ msgstr "Skrollbar flerkolonne"
 msgid "Select"
 msgstr "Velge"
 
-msgid "Select a "
-msgstr "Velg en "
-
 msgid "select a choice"
 msgstr "velg et alternativ"
 
@@ -1621,20 +1461,14 @@ msgstr "Velg et bilde først."
 msgid "select correct choice"
 msgstr "velg riktig alternativ"
 
-msgid "Select height of passage base of conatainer height"
-msgstr "Velg passasjens høyde på beholderhøyden"
-
 msgid "Select height of passage base of container height"
 msgstr ""
-
-msgid "Select height of text block base of conatainer height"
-msgstr "Velg tekstblokkens høyde på beholderhøyde"
 
 msgid "Select height of text block base of container height"
 msgstr ""
 
 msgid "Select if you want the outcome declaration to be processed by an external system or human scorer. This is typically the case for items asking candidates to write an essay."
-msgstr "Velg om du vil at resultatet skal behandles av et eksternt system eller en menneskelig skårer. Dette er typisk for oppgaver der elever blir spurt om å skrive et essay."
+msgstr "Velg om oppgaven skal manuelt skåres i skåringsverktøyet eller sendes til plagiatkontroll. Du må legge til flere vurderingsalternativer dersom oppgaven både skal skåres manuelt og plagiatkontrolleres."
 
 msgid "Select image"
 msgstr "Velg bilde"
@@ -1693,14 +1527,11 @@ msgstr "Sett posisjon"
 msgid "Shuffle choices"
 msgstr "Tilfeldig rekkefølge for svaralternativer"
 
-msgid "Sibelius music notation"
-msgstr "Sibelius musikknotasjon"
-
 msgid "Single choice"
-msgstr ""
+msgstr "Enkelt valg"
 
 msgid "Sinus"
-msgstr "Sinus"
+msgstr ""
 
 msgid "Size and position"
 msgstr "Størrelse og posisjon"
@@ -1724,13 +1555,10 @@ msgid "Square root"
 msgstr "Kvadratrot"
 
 msgid "standard"
-msgstr "standard"
+msgstr ""
 
 msgid "Step"
 msgstr "Steg"
-
-msgid "Storing digital video data on a computer game"
-msgstr "Lagring av digitale videodata på et dataspill"
 
 msgid "string"
 msgstr ""
@@ -1753,26 +1581,14 @@ msgstr "Kompilert \"%s"
 msgid "Successfully created item \"%s"
 msgstr "Opprettet oppgave %s"
 
-msgid "SVG image"
-msgstr "SVG-bilde"
-
 msgid "Table headings"
 msgstr "Tabelloverskrifter"
 
-msgid "Tagged image file"
-msgstr "Merket bildefil"
-
 msgid "TAO default styles"
-msgstr "TAO default styles"
-
-msgid "Tape Archive (TAR)"
-msgstr "Tape Archive (TAR)"
+msgstr ""
 
 msgid "Target Class Lookup for resource \"%s\"..."
 msgstr "Søk for ressursen \"%s\"..."
-
-msgid "TeX file"
-msgstr "TeX-fil"
 
 msgid "Text Block"
 msgstr "Tekstboks"
@@ -1785,9 +1601,6 @@ msgstr "Tekstboks egenskaper"
 
 msgid "Text color"
 msgstr "Tekstfarge"
-
-msgid "Text document file format (Staroffice)"
-msgstr "Tekstdokument filformat (Staroffice)"
 
 msgid "Text Entry"
 msgstr "Skriv inn tekst"
@@ -1915,20 +1728,17 @@ msgstr "Maksimalt antall forbindelser som eleven har lov til å lage."
 msgid "The maximum number of choices that the candidate is allowed to select."
 msgstr "Maks antall valg som eleven har lov til å velge."
 
-msgid "The maximum number of choices that the candidate is required to select to form a valid response."
-msgstr "Maksimalt antall valg som eleven må velge for å lage et gyldig svar."
-
 msgid "The maximum number of choices this choice may be associated with."
 msgstr "Maksimalt antall valg dette alternativet kan være kobles med."
 
 msgid "The maximum number of choices this choice may be associated with. If matchMax is 0 there is no restriction."
 msgstr "Maksimalt antall valg dette alternativet kan være koblet med. Hvis matchMax er 0 er det ingen begrensning."
 
+msgid "The maximum number of choices that the candidate is required to select to form a valid response."
+msgstr "Maksimalt antall valg som eleven må velge for å lage et gyldig svar."
+
 msgid "The maxPlays attribute indicates that the media object can be played at most maxPlays times - it must not be possible for the candidate to play the media object more than maxPlay times. A value of 0 (the default) indicates that there is no limit."
 msgstr "MaxPlays-attributtet indikerer at medieobjektet kan spilles opptil maxPlays ganger - det må ikke være mulig for eleven å spille medieobjektet mer enn maxPlay ganger. En verdi på 0 (standard) indikerer at det ikke er noen grense."
-
-msgid "The MAXSCORE of this item is removed because the current interaction settings allow an infinite value to the score."
-msgstr ""
 
 msgid "The MIME-type attribute describes which kind of file may be uploaded."
 msgstr "Attributtet MIME-type beskriver hvilken type fil som kan lastes opp."
@@ -1984,9 +1794,6 @@ msgstr "Formbredden i piksler. Denne verdien kan skaleres når bakgrunnsbildest�
 msgid "The target must be an instance of DOMDocument"
 msgstr "Målet må være en forekomst av DOMDocumentet"
 
-msgid "The text to be displayed below the image."
-msgstr ""
-
 msgid "The text to be displayed if the image is not available."
 msgstr "Teksten som skal vises hvis bildet ikke er tilgjengelig."
 
@@ -1997,9 +1804,7 @@ msgid "The upper bound of the slider"
 msgstr "Linjalens øvre grense"
 
 msgid "The validation of the imported QTI item failed. The system returned the following error:%s\n"
-""
 msgstr "Valideringen av den importerte QTI-oppgaven mislyktes. Systemet returnerte følgende feil:%s\n"
-""
 
 msgid "The ZIP archive containing the IMS QTI Item cannot be extracted."
 msgstr "ZIP-arkivet som inneholder IMS QTI-oppgaven kan ikke hentes."
@@ -2076,14 +1881,11 @@ msgstr "Kan ikke hente oppgave: \"%s"
 msgid "Unable to validate %s: %s"
 msgstr "Kan ikke validere %s: %s"
 
-msgid "undo"
-msgstr "angre"
-
 msgid "Undo"
 msgstr "Angre"
 
-msgid "UNIX Compressed Archive File"
-msgstr "UNIX komprimert arkivfil"
+msgid "undo"
+msgstr "angre"
 
 msgid "Unknown $key to register MetadataService instance"
 msgstr "Ukjent $-nøkkel for å registrere MetadataService-forekomst"
@@ -2112,26 +1914,11 @@ msgstr "Vertikal"
 msgid "warning"
 msgstr ""
 
-msgid "WAV audio"
-msgstr "WAV lyd"
-
 msgid "We will use the patternMask to do this, to be compliant with the IMS standard"
 msgstr "Vi vil bruke patternMask for å utføre dette, slik at det blir i samsvar med IMS-standarden"
 
 msgid "Width"
 msgstr "Bredde"
-
-msgid "Windows help file"
-msgstr "Windows hjelpefil"
-
-msgid "Windows Media audio"
-msgstr "Windows Media-lyd"
-
-msgid "Windows Media file (metafile)"
-msgstr "Windows Media-fil (metafil)"
-
-msgid "Windows Media video"
-msgstr "Windows Media-video"
 
 msgid "words"
 msgstr "ord"
@@ -2139,20 +1926,14 @@ msgstr "ord"
 msgid "Would you like to replace the alt text"
 msgstr "Vil du bytte ut alt-teksten"
 
-msgid "Write Document"
-msgstr "Skriv dokument"
-
 msgid "WYSIWYG editor"
-msgstr "WYSIWYG editor"
+msgstr ""
 
 msgid "XML error \"%1$s\"."
 msgstr ""
 
 msgid "XML error at line %1$d \"%2$s\"."
 msgstr ""
-
-msgid "XML file"
-msgstr "XML-fil"
 
 msgid "Yes"
 msgstr "Ja"
@@ -2162,12 +1943,6 @@ msgstr "Du kan velge maksimalt %d valg"
 
 msgid "You can select maximum %d choices"
 msgstr "Du kan velge maksimalt %d valg"
-
-msgid "You can select maximum of %s choices"
-msgstr "Du kan velge maksimalt %s valg"
-
-msgid "You can select maximum of 1 choice"
-msgstr "Du må velge ett svar"
 
 msgid "You can select up to %s choices."
 msgstr ""
@@ -2199,12 +1974,6 @@ msgstr "Du må velge minst %d alternativ"
 msgid "You must select at least %d choices"
 msgstr "Du må velge minst %d alternativer"
 
-msgid "You must select at least %s choices"
-msgstr "Du må velge minst %s alternativer"
-
-msgid "You must select at least 1 choice"
-msgstr "Du må velge minst ett alternativ"
-
 msgid "You must select exactly %d choice"
 msgstr "Du må velge nøyaktig %d alternativ"
 
@@ -2213,9 +1982,6 @@ msgstr "Du må velge nøyaktig %d alternativ(er)."
 
 msgid "You must select exactly %d choices"
 msgstr "Du må velge nøyaktig %d alternativer"
-
-msgid "You must select exactly %s choices"
-msgstr "Du må velge nøyaktig %s alternativer"
 
 msgid "You must use at least %d choices"
 msgstr "Du må bruke minst %d alternativer"
@@ -2237,7 +2003,4 @@ msgstr ""
 
 msgid "Your item has been saved"
 msgstr "Oppgaven din ble lagret"
-
-msgid "ZIP archive"
-msgstr "ZIP-arkiv"
 


### PR DESCRIPTION
Add required translations:



English
--
Outcome Declarations
Here you can provide scoring aspects for manual scoring/marking, e.g. CONTENT, GRAMMAR, SPELLING
Long interpretation
An optional link to an extended interpretation of the outcome variable.
External Scored
Select if you want the outcome declaration to be processed by an external system or human scorer. This is typically the case for items asking candidates to write an essay.
Human
External Machine
Add an outcome



New text (BM)
--
Vurderingsalternativer
Her kan du definere alternativer for plagiatkontroll og manuell skåring, f.eks. av INNHOLD, GRAMATIKK, STAVING
Vurderingskriterier
Lenke til veiledning/ kriterier til den som skal vurdere i skåringsverktøyet.
Manuell skåring / Plagiat
Velg om oppgaven skal manuelt skåres i skåringsverktøyet eller sendes til plagiatkontroll. Du må legge til flere vurderingsalternativer dersom oppgaven både skal skåres manuelt og plagiatkontrolleres.
Manuell skåring
Plagiatkontroll
Legg til vurderings-alternativ

