### PR TITLE
feat: place imported assets to correct class

### DIFF
--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -94,6 +94,8 @@ class ImportService extends ConfigurableService
 
     public const PROPERTY_QTI_ITEM_IDENTIFIER = 'http://www.tao.lu/Ontologies/TAOItem.rdf#QtiItemIdentifier';
 
+    private const MEDIA_ROOT_CLASS = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#Media';
+
     /**
      * @return ImportService
      */
@@ -577,12 +579,7 @@ class ImportService extends ConfigurableService
                         ->get(\common_ext_ExtensionsManager::SERVICE_ID)
                         ->isInstalled('taoMediaManager')
                 ) {
-                    // Media manager path where to store the stimulus.
-                    $path = $this->retrieveFullPathLabels($itemClass);
-                    // Uses the first created item's label as the leaf class.
-                    if (is_array($path)) {
-                        array_unshift($path, $rdfItem->getLabel());
-                    }
+                    $mediaClass = $this->getTargetClassForAssets($itemClass, $rdfItem);
                     /** Shared stimulus handler */
                     $sharedStimulusHandler = new SharedStimulusAssetHandler();
                     $sharedStimulusHandler->setServiceLocator($this->getServiceLocator());
@@ -590,7 +587,7 @@ class ImportService extends ConfigurableService
                         ->setQtiModel($qtiModel)
                         ->setItemSource(new ItemMediaResolver($rdfItem, ''))
                         ->setSharedFiles($sharedFiles)
-                        ->setParentPath(json_encode($path));
+                        ->setTargetClass($mediaClass);
                     $itemAssetManager->loadAssetHandler($sharedStimulusHandler);
                 } else {
                     $handler = new StimulusHandler();
@@ -883,28 +880,33 @@ class ImportService extends ConfigurableService
 
     /**
      * Retrieve the labels of all parent classes up to base item class.
-     *
-     * Return values: an empty string if the $class parameter is not a class object
-     *                an empty array if the $class parameter is the base item class
-     *                an array in other cases, ordered from base item class to the class given as parameter
-     *
-     * @param mixed $class Class from which to retrieve.
-     * @return array|string
      */
-    public function retrieveFullPathLabels($class)
-    {
-        if (!$class instanceof core_kernel_classes_Class) {
-            return '';
-        }
-
+    public function getTargetClassForAssets(
+        core_kernel_classes_Class $itemClass,
+        core_kernel_classes_Resource $itemResource
+    ): core_kernel_classes_Class {
+        // Collecting labels path from item root to the class where the item resource is stored
         $labels = [];
-        while ($class->getUri() !== TaoOntology::CLASS_URI_ITEM) {
-            $labels [] = $class->getLabel();
-            $parentClasses = $class->getParentClasses();
-            $class = reset($parentClasses);
+        while ($itemClass->getUri() !== TaoOntology::CLASS_URI_ITEM) {
+            $labels [] = $itemClass->getLabel();
+            $parentClasses = $itemClass->getParentClasses();
+            $itemClass = reset($parentClasses);
         }
 
-        return array_reverse($labels);
+        $path = array_reverse($labels);
+
+        // Adding item's label as the leaf class.
+        $path[] = $itemResource->getLabel();
+
+        $mediaClass = $this->getClass(self::MEDIA_ROOT_CLASS);
+
+        // Creating same classes in the media root
+        foreach ($path as $classLabel) {
+            $mediaClass = $mediaClass->retrieveSubClassByLabel($classLabel)
+                ?: $mediaClass->createSubClass($classLabel);
+        }
+
+        return $mediaClass;
     }
 
     private function getItemEventDispatcher(): UpdatedItemEventDispatcher

--- a/model/qti/asset/factory/SharedStimulusFactory.php
+++ b/model/qti/asset/factory/SharedStimulusFactory.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\model\qti\asset\factory;
 
+use core_kernel_classes_Class;
 use Laminas\ServiceManager\ServiceLocatorAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\user\UserLanguageService;
@@ -38,13 +39,12 @@ class SharedStimulusFactory extends ConfigurableService
     use ServiceLocatorAwareTrait;
     use GenerisServiceTrait;
 
-    private const ASSET_ROOT_CLASS_URI = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#Media';
-
     public function createShardedStimulusFromSourceFiles(
         string $newXmlFile,
         string $relativePath,
         string $absolutePath,
-        string $label
+        core_kernel_classes_Class $targetClass
+
     ): string {
         $assetWithCss = $this->getStoreService()->store(
             $newXmlFile,
@@ -54,7 +54,7 @@ class SharedStimulusFactory extends ConfigurableService
 
         return $this->getMediaService()->createSharedStimulusInstance(
             $assetWithCss . DIRECTORY_SEPARATOR . basename($relativePath),
-            $this->getParentClassUri($label),
+            $targetClass->getUri(),
             $this->getUserLanguageService()->getAuthoringLanguage()
         );
     }
@@ -97,16 +97,6 @@ class SharedStimulusFactory extends ConfigurableService
         }
 
         return false;
-    }
-
-    private function getParentClassUri(string $label): string
-    {
-        $parentClass = $this->createSubClass(
-            $this->getClass(self::ASSET_ROOT_CLASS_URI),
-            $label
-        );
-
-        return $parentClass->getUri();
     }
 
     private function getStoreService(): StoreService

--- a/model/qti/asset/factory/SharedStimulusFactory.php
+++ b/model/qti/asset/factory/SharedStimulusFactory.php
@@ -44,7 +44,6 @@ class SharedStimulusFactory extends ConfigurableService
         string $relativePath,
         string $absolutePath,
         core_kernel_classes_Class $targetClass
-
     ): string {
         $assetWithCss = $this->getStoreService()->store(
             $newXmlFile,

--- a/model/qti/asset/handler/SharedStimulusAssetHandler.php
+++ b/model/qti/asset/handler/SharedStimulusAssetHandler.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoQtiItem\model\qti\asset\handler;
 
+use core_kernel_classes_Class;
 use Laminas\ServiceManager\ServiceLocatorAwareTrait;
 use oat\generis\model\OntologyAwareTrait;
 use oat\tao\helpers\FileUploadException;
@@ -48,7 +49,7 @@ class SharedStimulusAssetHandler implements AssetHandler
 
     protected $qtiModel;
     protected $sharedFiles = [];
-    protected $parentPath;
+    private core_kernel_classes_Class $targetClass;
 
     /**
      * MediaAssetHandler constructor.
@@ -98,7 +99,7 @@ class SharedStimulusAssetHandler implements AssetHandler
             $newXmlFile,
             $relativePath,
             $absolutePath,
-            $this->buildLabelBaseOnParentPath()
+            $this->getTargetClass()
         );
 
         \common_Logger::i('Auxiliary file \'' . $absolutePath . '\' added to shared storage.');
@@ -183,21 +184,14 @@ class SharedStimulusAssetHandler implements AssetHandler
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getParentPath()
+    public function getTargetClass(): core_kernel_classes_Class
     {
-        return $this->parentPath;
+        return $this->targetClass;
     }
 
-    /**
-     * @param mixed $parentPath
-     * @return $this
-     */
-    public function setParentPath($parentPath)
+    public function setTargetClass(core_kernel_classes_Class $targetClass): self
     {
-        $this->parentPath = $parentPath;
+        $this->targetClass = $targetClass;
         return $this;
     }
 
@@ -217,13 +211,5 @@ class SharedStimulusAssetHandler implements AssetHandler
     private function getSharedStimulusFactory(): SharedStimulusFactory
     {
         return $this->getServiceLocator()->get(SharedStimulusFactory::class);
-    }
-
-    private function buildLabelBaseOnParentPath()
-    {
-        $parentPath = $this->getParentPath();
-        $decodedParentPath = json_decode($parentPath);
-
-        return reset($decodedParentPath);
     }
 }

--- a/test/unit/model/qti/ImportServiceTest.php
+++ b/test/unit/model/qti/ImportServiceTest.php
@@ -24,7 +24,7 @@ namespace oat\taoQtiItem\test\unit\model\qti;
 
 use oat\generis\model\data\Ontology;
 use oat\generis\test\ServiceManagerMockTrait;
-use \PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
 use core_kernel_classes_Class as RdfClass;
 use core_kernel_classes_Resource as RdfResource;
 use oat\tao\model\TaoOntology;
@@ -79,7 +79,7 @@ class ImportServiceTest extends TestCase
             ->method('getClass')
             ->willReturn($mediaRootClassMock);
 
-        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClassMock,  $this->itemResourceMock));
+        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClassMock, $this->itemResourceMock));
     }
 
     public function testGetTargetClassForAssetsReturnsExistingMediaClasses()
@@ -112,7 +112,7 @@ class ImportServiceTest extends TestCase
             ->method('getClass')
             ->willReturn($mediaRootClassMock);
 
-        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClass,  $this->itemResourceMock));
+        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClass, $this->itemResourceMock));
     }
 
     public function testGetTargetClassForAssetsCreatesMediaClasses()
@@ -157,7 +157,7 @@ class ImportServiceTest extends TestCase
             ->method('getClass')
             ->willReturn($mediaRootClassMock);
 
-        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClass,  $this->itemResourceMock));
+        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClass, $this->itemResourceMock));
     }
 
     private function prepareItemClassStructureMock($label1, $label2): RdfClass

--- a/test/unit/model/qti/ImportServiceTest.php
+++ b/test/unit/model/qti/ImportServiceTest.php
@@ -20,74 +20,172 @@
  * @author Julien Sébire, <julien@taotesting.com>
  */
 
-namespace oat\taoQtiItem\test\unit\model;
+namespace oat\taoQtiItem\test\unit\model\qti;
 
+use oat\generis\model\data\Ontology;
+use oat\generis\test\ServiceManagerMockTrait;
+use \PHPUnit\Framework\TestCase;
 use core_kernel_classes_Class as RdfClass;
-use oat\generis\test\TestCase;
+use core_kernel_classes_Resource as RdfResource;
 use oat\tao\model\TaoOntology;
 use oat\taoQtiItem\model\qti\ImportService;
 
 class ImportServiceTest extends TestCase
 {
-    /**
-     * @return array
-     */
-    public function testRetrieveFullPathLabelsWithNonClassResourceReturnsEmptyString()
+    use ServiceManagerMockTrait;
+
+    private const ITEM_LABEL = 'item label';
+
+    private ImportService $subject;
+    private Ontology $ontologyMock;
+    private RdfResource $itemResourceMock;
+
+    public function setUp(): void
     {
-        $subject = new ImportService();
-        $this->assertEquals('', $subject->retrieveFullPathLabels('whatever'));
+        $this->subject = new ImportService();
+        $this->ontologyMock = $this->createMock(Ontology::class);
+
+        $this->subject->setServiceManager(
+            $this->getServiceManagerMock(
+                [
+                    Ontology::SERVICE_ID => $this->ontologyMock,
+                ]
+            )
+        );
+
+        $this->itemResourceMock = $this->createMock(RdfResource::class);
+        $this->itemResourceMock->expects($this->once())
+            ->method('getLabel')
+            ->willReturn(self::ITEM_LABEL);
     }
 
-    /**
-     * @return array
-     */
-    public function testRetrieveFullPathLabelsWithRootClassResourceReturnsEmptyArray()
+    public function testGetTargetClassForAssetsReturnsRoot()
     {
-        $class = $this->getMockBuilder(RdfClass::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getUri'])
-            ->getMock();
-        $class->method('getUri')->willReturn(TaoOntology::CLASS_URI_ITEM);
+        $itemClassMock = $this->createMock(RdfClass::class);
+        $itemClassMock->expects($this->once())
+            ->method('getUri')
+            ->willReturn(TaoOntology::CLASS_URI_ITEM);
 
-        $subject = new ImportService();
-        $this->assertEquals([], $subject->retrieveFullPathLabels($class));
+        $result = new \core_kernel_classes_Class('fake uri');
+
+        $mediaRootClassMock = $this->createMock(RdfClass::class);
+        $mediaRootClassMock->expects($this->once())
+            ->method('retrieveSubClassByLabel')
+            ->with(self::ITEM_LABEL)
+            ->willReturn($result);
+
+        $this->ontologyMock
+            ->expects($this->once())
+            ->method('getClass')
+            ->willReturn($mediaRootClassMock);
+
+        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClassMock,  $this->itemResourceMock));
     }
 
-    /**
-     * @return array
-     */
-    public function testRetrieveFullPathLabelsWithSeveralClassResourcesReturnsArray()
+    public function testGetTargetClassForAssetsReturnsExistingMediaClasses()
+    {
+        $label1 = 'First subclass label';
+        $label2 = 'Second subclass label';
+
+        $itemClass = $this->prepareItemClassStructureMock($label1, $label2);
+
+        $result = new \core_kernel_classes_Class('fake uri');
+        $mediaSubclass2 = $this->createMock(RdfClass::class);
+        $mediaSubclass2->expects($this->once())
+            ->method('retrieveSubClassByLabel')
+            ->with(self::ITEM_LABEL)
+            ->willReturn($result);
+
+        $mediaSubclass1 = $this->createMock(RdfClass::class);
+        $mediaSubclass1->expects($this->once())
+            ->method('retrieveSubClassByLabel')
+            ->with($label2)
+            ->willReturn($mediaSubclass2);
+
+        $mediaRootClassMock = $this->createMock(RdfClass::class);
+        $mediaRootClassMock->expects($this->once())
+            ->method('retrieveSubClassByLabel')
+            ->with($label1)
+            ->willReturn($mediaSubclass1);
+
+        $this->ontologyMock->expects($this->once())
+            ->method('getClass')
+            ->willReturn($mediaRootClassMock);
+
+        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClass,  $this->itemResourceMock));
+    }
+
+    public function testGetTargetClassForAssetsCreatesMediaClasses()
+    {
+        $label1 = 'First subclass label';
+        $label2 = 'Second subclass label';
+
+        $itemClass = $this->prepareItemClassStructureMock($label1, $label2);
+
+        $result = new \core_kernel_classes_Class('fake uri');
+        $mediaSubclass2 = $this->createMock(RdfClass::class);
+        $mediaSubclass2->expects($this->once())
+            ->method('retrieveSubClassByLabel')
+            ->with(self::ITEM_LABEL)
+            ->willReturn(null);
+        $mediaSubclass2->expects($this->once())
+            ->method('createSubClass')
+            ->with(self::ITEM_LABEL)
+            ->willReturn($result);
+
+        $mediaSubclass1 = $this->createMock(RdfClass::class);
+        $mediaSubclass1->expects($this->once())
+            ->method('retrieveSubClassByLabel')
+            ->with($label2)
+            ->willReturn(null);
+        $mediaSubclass1->expects($this->once())
+            ->method('createSubClass')
+            ->with($label2)
+            ->willReturn($mediaSubclass2);
+
+        $mediaRootClassMock = $this->createMock(RdfClass::class);
+        $mediaRootClassMock->expects($this->once())
+            ->method('retrieveSubClassByLabel')
+            ->with($label1)
+            ->willReturn(null);
+        $mediaRootClassMock->expects($this->once())
+            ->method('createSubClass')
+            ->with($label1)
+            ->willReturn($mediaSubclass1);
+
+        $this->ontologyMock->expects($this->once())
+            ->method('getClass')
+            ->willReturn($mediaRootClassMock);
+
+        $this->assertEquals($result, $this->subject->getTargetClassForAssets($itemClass,  $this->itemResourceMock));
+    }
+
+    private function prepareItemClassStructureMock($label1, $label2): RdfClass
     {
         $rootUri = TaoOntology::CLASS_URI_ITEM;
-        $uri1 = 'http://example.com/uri2';
-        $uri2 = 'http://example.com/uri3';
+        $uri1 = 'https://example.com/uri2';
+        $uri2 = 'https://example.com/uri3';
 
-        $label1 = 'First subbclass label';
-        $label2 = 'second subbclass label';
+        $rootClass = $this->createMock(RdfClass::class);
+        $rootClass->expects($this->once())
+            ->method('getUri')->willReturn($rootUri);
 
-        $rootClass = $this->getMockBuilder(RdfClass::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getUri'])
-            ->getMock();
-        $rootClass->method('getUri')->willReturn($rootUri);
+        $subclass1 =  $this->createMock(RdfClass::class);
+        $subclass1->expects($this->once())
+            ->method('getUri')->willReturn($uri1);
+        $subclass1->expects($this->once())
+            ->method('getLabel')->willReturn($label1);
+        $subclass1->expects($this->once())
+            ->method('getParentClasses')->willReturn([$rootUri => $rootClass]);
 
-        $subclass1 = $this->getMockBuilder(RdfClass::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getUri', 'getLabel', 'getParentClasses'])
-            ->getMock();
-        $subclass1->method('getUri')->willReturn($uri1);
-        $subclass1->method('getLabel')->willReturn($label1);
-        $subclass1->method('getParentClasses')->willReturn([$rootUri => $rootClass]);
+        $subclass2 = $this->createMock(RdfClass::class);
+        $subclass2->expects($this->once())
+            ->method('getUri')->willReturn($uri2);
+        $subclass2->expects($this->once())
+            ->method('getLabel')->willReturn($label2);
+        $subclass2->expects($this->once())
+            ->method('getParentClasses')->willReturn([$uri1 => $subclass1]);
 
-        $subclass2 = $this->getMockBuilder(RdfClass::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getUri', 'getLabel', 'getParentClasses'])
-            ->getMock();
-        $subclass2->method('getUri')->willReturn($uri2);
-        $subclass2->method('getLabel')->willReturn($label2);
-        $subclass2->method('getParentClasses')->willReturn([$uri1 => $subclass1]);
-
-        $subject = new ImportService();
-        $this->assertEquals([$label1, $label2], $subject->retrieveFullPathLabels($subclass2));
+        return $subclass2;
     }
 }

--- a/test/unit/model/qti/asset/factory/SharedStimulusFactoryTest.php
+++ b/test/unit/model/qti/asset/factory/SharedStimulusFactoryTest.php
@@ -23,33 +23,22 @@ declare(strict_types=1);
 namespace oat\taoQtiItem\test\unit\model\qti\asset\factory;
 
 use core_kernel_classes_Class;
-use oat\generis\model\data\Ontology;
-use oat\generis\test\TestCase;
+use oat\generis\test\ServiceManagerMockTrait;
+use \PHPUnit\Framework\TestCase;
 use oat\oatbox\user\UserLanguageService;
 use oat\taoMediaManager\model\MediaService;
 use oat\taoMediaManager\model\sharedStimulus\service\StoreService;
 use oat\taoQtiItem\model\qti\asset\factory\SharedStimulusFactory;
-use PHPUnit\Framework\MockObject\MockObject;
 
 class SharedStimulusFactoryTest extends TestCase
 {
-    /** @var SharedStimulusFactory */
-    private $subject;
+    use ServiceManagerMockTrait;
 
-    /** @var StoreService|MockObject */
-    private $storeServiceMock;
-
-    /** @var MediaService|MockObject */
-    private $mediaServiceMock;
-
-    /** @var UserLanguageService|MockObject */
-    private $userLanguageServiceMock;
-
-    /** @var Ontology|MockObject */
-    private $ontologyMock;
-
-    /** @var core_kernel_classes_Class|MockObject */
-    private $classMock;
+    private SharedStimulusFactory $subject;
+    private StoreService $storeServiceMock;
+    private MediaService $mediaServiceMock;
+    private UserLanguageService $userLanguageServiceMock;
+    private core_kernel_classes_Class $classMock;
 
     public function setUp(): void
     {
@@ -57,11 +46,10 @@ class SharedStimulusFactoryTest extends TestCase
         $this->storeServiceMock = $this->createMock(StoreService::class);
         $this->mediaServiceMock = $this->createMock(MediaService::class);
         $this->userLanguageServiceMock = $this->createMock(UserLanguageService::class);
-        $this->ontologyMock = $this->createMock(Ontology::class);
         $this->classMock = $this->createMock(core_kernel_classes_Class::class);
 
-        $this->subject->setServiceLocator(
-            $this->getServiceLocatorMock(
+        $this->subject->setServiceManager(
+            $this->getServiceManagerMock(
                 [
                     StoreService::class => $this->storeServiceMock,
                     MediaService::class => $this->mediaServiceMock,
@@ -70,18 +58,9 @@ class SharedStimulusFactoryTest extends TestCase
             )
         );
 
-        $this->subject->setModel(
-            $this->ontologyMock
-        );
-
-        $this->ontologyMock
-            ->expects($this->once())
-            ->method('getClass')
-            ->willReturn($this->classMock);
-
         $this->classMock
-            ->method('createSubClass')
-            ->willReturn($this->classMock);
+            ->method('getLabel')
+            ->willReturn('class label');
     }
 
     public function testCreateShardedStimulusFromSourceFiles(): void
@@ -95,16 +74,11 @@ class SharedStimulusFactoryTest extends TestCase
             ->method('createSharedStimulusInstance')
             ->willReturn('id');
 
-        $this->classMock
-            ->expects($this->once())
-            ->method('getUri')
-            ->willReturn('classUri');
-
         $result = $this->subject->createShardedStimulusFromSourceFiles(
             'file.xml',
             'path/to/xml/filename.xml',
             'absolute/path/to/asset/passage.xml',
-            'Item Label'
+            $this->classMock
         );
 
         $this->assertEquals($result, 'id');

--- a/test/unit/model/qti/asset/factory/SharedStimulusFactoryTest.php
+++ b/test/unit/model/qti/asset/factory/SharedStimulusFactoryTest.php
@@ -24,7 +24,7 @@ namespace oat\taoQtiItem\test\unit\model\qti\asset\factory;
 
 use core_kernel_classes_Class;
 use oat\generis\test\ServiceManagerMockTrait;
-use \PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
 use oat\oatbox\user\UserLanguageService;
 use oat\taoMediaManager\model\MediaService;
 use oat\taoMediaManager\model\sharedStimulus\service\StoreService;
@@ -81,7 +81,7 @@ class SharedStimulusFactoryTest extends TestCase
             $this->classMock
         );
 
-        $this->assertEquals($result, 'id');
+        $this->assertEquals('id', $result);
     }
 }
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/PISA25-561
## What's Changed

- Passages related to imported items will be placed to classes with path `{test name}/{item name}` or `{target class}/{test name}/{item name}` in case if test is imported by API [/taoQtiTest/RestQtiTests/importDeferred](https://github.com/oat-sa/extension-tao-testqti/blob/master/doc/swagger.json#L347) and `itemClassUri` specified.

## How to test
- Import test with passage via UI
- Import test with passage via API
- Check path where passage assets saved