### PR TITLE
Fix/INV-707/Missing tooltip

### DIFF
--- a/views/js/portableLib/jquery.qtip.js
+++ b/views/js/portableLib/jquery.qtip.js
@@ -11,7 +11,7 @@
  * Styles: core basic css3
  *
  * =====================================================================
- * OAT WARNING : Line 25 has been changed from the original source code.
+ * OAT WARNING : Lines 25 and 1946 have been changed from the original source code.
  * =====================================================================
  */
 /*global window: false, jQuery: false, console: false, define: false */
@@ -1943,7 +1943,7 @@
 		QTIP.inactiveEvents = INACTIVE_EVENTS;
 
 // Base z-index for all qTips
-		QTIP.zindex = 15000;
+		QTIP.zindex = 1500000;
 
 // Define configuration defaults
 		QTIP.defaults = {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/INV-707

### Summary

When previewing a PCI in the authoring, the tooltips never show up.

### Details

The Z-index for the PCI-specific tooltips has been increased.

### How to test
- have the extension pciSamples installed
- checkout the branch
- bundle the textReader PCI
- preview an item containing the textReader PCI with a tooltip (you can use the sample attached to the ticket)