### PR TITLE
fix: modal feedback image

### DIFF
--- a/views/js/qtiCreator/renderers/Img.js
+++ b/views/js/qtiCreator/renderers/Img.js
@@ -48,7 +48,8 @@ define([
 
         if (
             !$container.closest('.qti-choice, .qti-flow-container').length &&
-            !$container.closest('.qti-table caption').length
+            !$container.closest('.qti-table caption').length &&
+            !$container.closest('.qti-modalFeedback').length
         ) {
             const parent = findParentElement(img.rootElement, img.serial);
             parent.removeElement(img);


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3341

## What's Changed

- Added modal feedback image in the exceptions in renderer (it will not be converted in the `Figure` element)
- Fixed the error: 
_Uncaught TypeError: Cannot read properties of null (reading 'removeElement')
    at CreatorImg.render (Img.js?buster=651c01ffe0d00:54:20)_

## How to test
- Create test item with modal feedback containing image
- Save the test item
- Open the test item in authoring mode
- Try to edit feedback (click 'Feedback')
- No error happens

**Deployed** to http://test-viktar.playground.kitchen.it.taocloud.org:41531/tao/Main/ and the appropriate item exists there