### PR TITLE
fix: Wrong shuffle feature id

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -187,7 +187,7 @@ define([
         constraints = selectedCase.constraints;
 
         const allowElimination = features.isVisible('taoQtiItem/creator/interaction/choice/property/allowElimination');
-        const shuffleChoices = features.isVisible('taoQtiItem/creator/interaction/choice/property/allowElimination');
+        const shuffleChoices = features.isVisible('taoQtiItem/creator/interaction/choice/property/shuffle');
         const choiceOptionsAvailable = allowElimination || shuffleChoices;
         $form.html(
             formTpl({


### PR DESCRIPTION
Related incident - https://oat-sa.atlassian.net/browse/OATSD-2958

After the fix the `shuffle` feature is enabled for Simple Choice interaction even though `allowElimination` feature is disabled.

![Screenshot from 2023-11-22 12-46-09](https://github.com/oat-sa/extension-tao-itemqti/assets/72205523/0c5da45a-af10-4b09-ae6f-3c6a98a47bbc)
