### PR TITLE
Feature/BSA-391/Allow to disable figure widgets

### DIFF
--- a/views/js/qtiCreator/helper/changeTracker.js
+++ b/views/js/qtiCreator/helper/changeTracker.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2023 Open Assessment Technologies SA ;
  */
 /**
  * Track the change within the itemCreator
@@ -24,11 +24,12 @@ define([
     'jquery',
     'lodash',
     'i18n',
+    'context',
     'lib/uuid',
     'core/eventifier',
     'ui/dialog',
     'taoQtiItem/qtiCreator/helper/saveChanges'
-], function ($, _, __, uuid, eventifier, dialog, saveChanges) {
+], function ($, _, __, context, uuid, eventifier, dialog, saveChanges) {
     'use strict';
 
     /**
@@ -119,7 +120,8 @@ define([
                         !$.contains(container, e.target) &&
                         !$(e.target).parents('#feedback-box').length &&
                         !$(e.target).parents('.outcome-container').length &&
-                        !$(e.target).parents('.media-alignment').length &&
+                        (context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'] ||
+                            !$(e.target).parents('.media-alignment').length) &&
                         !$(e.target).hasClass('icon-close') &&
                         this.hasChanged()
                     ) {

--- a/views/js/qtiCreator/model/Figure.js
+++ b/views/js/qtiCreator/model/Figure.js
@@ -13,26 +13,28 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2022-2023 (original work) Open Assessment Technologies SA
  *
  */
 define([
     'lodash',
+    'context',
     'taoQtiItem/qtiCreator/model/mixin/editable',
     'taoQtiItem/qtiItem/core/Figure',
     'taoQtiItem/qtiCreator/model/Img',
     'taoQtiItem/qtiCreator/model/Figcaption'
-], function (_, editable, Figure, Img, Figcaption) {
+], function (_, context, editable, Figure, Img, Figcaption) {
     'use strict';
+    const DISABLE_FIGURE_WIDGET = context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'];
     const methods = {};
     _.extend(methods, editable);
     _.extend(methods, {
-        getDefaultAttributes: function () {
+        getDefaultAttributes() {
             return {
-                showFigure: false
+                showFigure: DISABLE_FIGURE_WIDGET || false
             };
         },
-        afterCreate: function () {
+        afterCreate() {
             this.getNamespace();
             const img = new Img();
             this.setElement(img);
@@ -40,7 +42,7 @@ define([
                 img.setRenderer(this.getRenderer());
             }
         },
-        addCaption: function (text) {
+        addCaption(text) {
             // check that caption doesn't exist
             let figcaption = _.find(this.getBody().elements, elem => elem.is('figcaption'));
             if (!figcaption) {
@@ -57,7 +59,7 @@ define([
             }
             return figcaption;
         },
-        removeCaption: function () {
+        removeCaption() {
             const figcaption = _.find(this.getBody().elements, elem => elem.is('figcaption'));
             if (figcaption) {
                 this.removeElement(figcaption);

--- a/views/js/qtiCreator/widgets/static/figure/Widget.js
+++ b/views/js/qtiCreator/widgets/static/figure/Widget.js
@@ -13,22 +13,24 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2022-2023 (original work) Open Assessment Technologies SA ;
  *
  */
 define([
     'jquery',
     'lodash',
+    'context',
     'taoQtiItem/qtiCreator/widgets/static/Widget',
     'taoQtiItem/qtiCreator/widgets/static/figure/states/states',
     'taoQtiItem/qtiCreator/widgets/static/helpers/widget',
     'tpl!taoQtiItem/qtiCreator/tpl/toolbars/media',
     'taoQtiItem/qtiCreator/widgets/static/helpers/inline',
     'ui/mediaEditor/plugins/mediaAlignment/helper'
-], function ($, _, Widget, states, helper, toolbarTpl, inlineHelper, alignmentHelper) {
+], function ($, _, context, Widget, states, helper, toolbarTpl, inlineHelper, alignmentHelper) {
     'use strict';
 
     const FigureWidget = Widget.clone();
+    const DISABLE_FIGURE_WIDGET = context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'];
 
     FigureWidget.initCreator = function initCreator(options) {
         const figure = this.element;
@@ -61,7 +63,7 @@ define([
     };
 
     FigureWidget.buildContainer = function buildContainer() {
-        if (this.element.attr('showFigure')) {
+        if (DISABLE_FIGURE_WIDGET || this.element.attr('showFigure')) {
             // If it is aligned to left or right, it will have FigCaption and will need Figure tag
             helper.buildBlockContainer(this);
         } else {

--- a/views/js/qtiCreator/widgets/static/text/states/Sleep.js
+++ b/views/js/qtiCreator/widgets/static/text/states/Sleep.js
@@ -1,27 +1,39 @@
 define([
+    'context',
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/static/states/Sleep',
     'taoQtiItem/qtiCreator/editor/gridEditor/content'
-], function(stateFactory, SleepState, contentHelper){
+], function (context, stateFactory, SleepState, contentHelper) {
+    const DISABLE_FIGURE_WIDGET = context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'];
 
-    var TextBlockStateSleep = stateFactory.extend(SleepState, function(){
-        const widget = this.widget;
-        widget.afterStateExit(function(e, element, state){
-            const serial = element.getSerial();
-            if (state.name === 'active' && serial !== widget.serial && (element.qtiClass === 'include' || element.qtiClass === 'figure')){
-                // update bdy of container in case include is wrapped in custom-include-box
-                const composingElts = widget.element.getComposingElements();
-                if(composingElts[serial]){
-                    const $pseudoContainer = $('<div>').html(widget.$container.find('[data-html-editable="true"]').html());
-                    const newBody = contentHelper.getContent($pseudoContainer);
-                    const container = widget.element;
-                    container.body(newBody);
+    const TextBlockStateSleep = stateFactory.extend(
+        SleepState,
+        function () {
+            const widget = this.widget;
+            widget.afterStateExit(function (e, element, state) {
+                const serial = element.getSerial();
+                if (
+                    state.name === 'active' &&
+                    serial !== widget.serial &&
+                    (element.qtiClass === 'include' || (!DISABLE_FIGURE_WIDGET && element.qtiClass === 'figure'))
+                ) {
+                    // update bdy of container in case include is wrapped in custom-include-box
+                    const composingElts = widget.element.getComposingElements();
+                    if (composingElts[serial]) {
+                        const $pseudoContainer = $('<div>').html(
+                            widget.$container.find('[data-html-editable="true"]').html()
+                        );
+                        const newBody = contentHelper.getContent($pseudoContainer);
+                        const container = widget.element;
+                        container.body(newBody);
+                    }
                 }
-            }
-        }, 'question');
-    }, function(){
-        this.widget.offEvents('question');
-    });
+            }, 'question');
+        },
+        function () {
+            this.widget.offEvents('question');
+        }
+    );
 
     return TextBlockStateSleep;
 });

--- a/views/js/qtiXmlRenderer/renderers/Figure.js
+++ b/views/js/qtiXmlRenderer/renderers/Figure.js
@@ -13,20 +13,26 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2022-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
-define(['tpl!taoQtiItem/qtiXmlRenderer/tpl/figure'], function (tpl) {
+define(['context', 'tpl!taoQtiItem/qtiXmlRenderer/tpl/figure', 'tpl!taoQtiItem/qtiXmlRenderer/tpl/element'], function (
+    context,
+    figureTpl,
+    elementTpl
+) {
+    const DISABLE_FIGURE_WIDGET = context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'];
+
     return {
         qtiClass: 'figure',
-        template: tpl,
-        getData: function (figure, data) {
+        template: DISABLE_FIGURE_WIDGET ? elementTpl : figureTpl,
+        getData(figure, data) {
             const ns = figure.getNamespace();
 
             if (ns && ns.name) {
                 data.tag = `${ns.name}:figure`;
             }
 
-            if (!figure.attr('showFigure')) {
+            if (!DISABLE_FIGURE_WIDGET && !figure.attr('showFigure')) {
                 data.tag = 'img';
                 const cleanImg = data.body.split('<qh5:figcaption');
                 data.body = cleanImg[0];

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@oat-sa/tao-item-runner": "^0.8.2",
-                "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#feature/BSA-391/allow-to-disable-figure-widgets"
+                "@oat-sa/tao-item-runner-qti": "^2.2.0"
             }
         },
         "node_modules/@oat-sa/tao-item-runner": {
@@ -19,9 +19,9 @@
             "integrity": "sha512-JSP/NRUjn6dImcfLGgpguItB5Q6t+Gf1lWj8ibx7VlImBKQ305/aHxM+M1H1A5p/nSlIxdtD+t5HHwICi9RUQQ=="
         },
         "node_modules/@oat-sa/tao-item-runner-qti": {
-            "version": "2.1.0",
-            "resolved": "git+ssh://git@github.com/oat-sa/tao-item-runner-qti-fe.git#80e25cee235bd0b4affe5c51f98b439d2818f572",
-            "license": "GPL-2.0"
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-2.2.0.tgz",
+            "integrity": "sha512-8zIaX7xihE0QxgMZU/BcRXQ5LOaUOQeJukYCbapB+aH/Ozxk0Uuh3FDD6XheDSEhInFwjFL1S52K2xBlhs4j4Q=="
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,18 +1,27 @@
 {
     "name": "@oat-sa/tao-qti-item",
     "version": "0.4.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 3,
     "requires": true,
-    "dependencies": {
-        "@oat-sa/tao-item-runner": {
+    "packages": {
+        "": {
+            "name": "@oat-sa/tao-qti-item",
+            "version": "0.4.0",
+            "license": "GPL-2.0",
+            "dependencies": {
+                "@oat-sa/tao-item-runner": "^0.8.2",
+                "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#feature/BSA-391/allow-to-disable-figure-widgets"
+            }
+        },
+        "node_modules/@oat-sa/tao-item-runner": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.8.2.tgz",
             "integrity": "sha512-JSP/NRUjn6dImcfLGgpguItB5Q6t+Gf1lWj8ibx7VlImBKQ305/aHxM+M1H1A5p/nSlIxdtD+t5HHwICi9RUQQ=="
         },
-        "@oat-sa/tao-item-runner-qti": {
+        "node_modules/@oat-sa/tao-item-runner-qti": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-2.1.0.tgz",
-            "integrity": "sha512-aBzipGHzQnPq3ZhN9hcaVNCyuTzRUFx9zXf6j7XFMQUzIsYUL3RkaLAa/NqYo9doYrHDETxKkSPT6MrXGMHXoQ=="
+            "resolved": "git+ssh://git@github.com/oat-sa/tao-item-runner-qti-fe.git#80e25cee235bd0b4affe5c51f98b439d2818f572",
+            "license": "GPL-2.0"
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,24 +1,15 @@
 {
     "name": "@oat-sa/tao-qti-item",
     "version": "0.4.0",
-    "lockfileVersion": 3,
+    "lockfileVersion": 1,
     "requires": true,
-    "packages": {
-        "": {
-            "name": "@oat-sa/tao-qti-item",
-            "version": "0.4.0",
-            "license": "GPL-2.0",
-            "dependencies": {
-                "@oat-sa/tao-item-runner": "^0.8.2",
-                "@oat-sa/tao-item-runner-qti": "^2.2.0"
-            }
-        },
-        "node_modules/@oat-sa/tao-item-runner": {
+    "dependencies": {
+        "@oat-sa/tao-item-runner": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.8.2.tgz",
             "integrity": "sha512-JSP/NRUjn6dImcfLGgpguItB5Q6t+Gf1lWj8ibx7VlImBKQ305/aHxM+M1H1A5p/nSlIxdtD+t5HHwICi9RUQQ=="
         },
-        "node_modules/@oat-sa/tao-item-runner-qti": {
+        "@oat-sa/tao-item-runner-qti": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-2.2.0.tgz",
             "integrity": "sha512-8zIaX7xihE0QxgMZU/BcRXQ5LOaUOQeJukYCbapB+aH/Ozxk0Uuh3FDD6XheDSEhInFwjFL1S52K2xBlhs4j4Q=="

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "^0.8.2",
-        "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#feature/BSA-391/allow-to-disable-figure-widgets"
+        "@oat-sa/tao-item-runner-qti": "^2.2.0"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "^0.8.2",
-        "@oat-sa/tao-item-runner-qti": "^2.1.0"
+        "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#feature/BSA-391/allow-to-disable-figure-widgets"
     }
 }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/BSA-391

Requires: 
 - [x] https://github.com/oat-sa/tao-core-ui-fe/pull/580
 - [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/389
 - [x] https://github.com/oat-sa/tao-core/pull/3935

### Summary

Manage a feature flag for disabling the figure widget.

### Details

Some customers rely on the block positioning of the figures for aligning images in columns. The figure widget sets them to inline positioning, hence the need to have a feature flag for disabling it. The other possibility is to roll back the feature, but this is less handy.

The feature can be disabled thanks to the feature flag `FEATURE_FLAG_DISABLE_FIGURE_WIDGET`.
The feature is enabled by default

### How to test

- have all dependencies (other PR) installed
- edit an item and place images on the canvas. Check the attached ticket for a sample item.
- turn the feature flag on and off, and see the differences

### Tidbit

To set and manage the feature flag, take a look at this [documentation](https://github.com/oat-sa/tao-core/blob/master/models/classes/featureFlag/README.md).

```
php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_DISABLE_FIGURE_WIDGET -v true
```