### PR TITLE
bugfix: reset correct responses when changing to cardinality - single

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/choiceInteraction/states/Question.js
@@ -300,6 +300,7 @@ define([
                 $form.find('[name="constraints"][value="other"]').prop('disabled', true);
                 deleteMinMax();
                 response.attr('cardinality', 'single');
+                response.setCorrect({});
             } else {
                 $form.find('[name="constraints"][value="other"]').prop('disabled', false);
                 response.attr('cardinality', 'multiple');


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3123

## What's Changed

- When changing cardinality from **multiple** to **single** we reset the correct questions because they are not longer valid. 

## How to test
- Explaination is in task

## Video

https://github.com/oat-sa/extension-tao-itemqti/assets/118974926/81954923-89ba-4db3-9947-50600141c1df


