### PR TITLE
fix: disabled properties in Feedback Modal

### DIFF
--- a/views/templates/QtiCreator/index.tpl
+++ b/views/templates/QtiCreator/index.tpl
@@ -50,7 +50,7 @@ use oat\tao\helpers\Template;
     </main>
 
     <!-- properties panel -->
-    <div class="item-editor-sidebar-wrapper right-bar sidebar-popup-parent">
+    <div class="select2-container item-editor-sidebar-wrapper right-bar sidebar-popup-parent">
         <div class="item-editor-sidebar" id="item-editor-item-widget-bar">
             <div class="item-editor-item-related sidebar-right-section-box" id="item-style-editor-bar">
                 <section class="tool-group clearfix" id="sidebar-right-css-manager">


### PR DESCRIPTION
## Summary
Related to [AUT-2812](https://oat-sa.atlassian.net/browse/AUT-2812)

### Description
 User is not able neither to change Identifier of modal feedback nor to interact with hints. The problem is that when opening a modal, overlay is added to the background. The class that is not subject to overlay was only select for Feedback Style
 
### Solution
- I added the css class to the Properties Panel

### Steps to reproduce
1. Go to "Items" page, create an Item, and go to "Authoring" tab
2. Create Interaction
3. Click the "Response" button
4. Click "Add a modal feedback" button
5. Click "Feedback" button
6. Change the Identifier

### Expected
User is able to change the Feedback identifier and while hovering the question marks user is able to see hints. All properties of Modal feedback are active
![fb](https://github.com/oat-sa/extension-tao-itemqti/assets/10648378/c1621acb-e338-4910-a6ec-8f529e633750)
![fb 2](https://github.com/oat-sa/extension-tao-itemqti/assets/10648378/d2c09dd5-cddf-4d8d-8bea-8029521dbc93)

### Result Demo

https://github.com/oat-sa/extension-tao-itemqti/assets/10648378/03d44915-8690-4d79-a8d8-333a1604932c





[AUT-2812]: https://oat-sa.atlassian.net/browse/AUT-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ