### PR TITLE
[AUT-2856] fix when item can be saved with empty Mapping default field

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/helpers/answerState.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/answerState.js
@@ -43,16 +43,6 @@ define([
 
     const modalFeedbackConfigKey = 'taoQtiItem/creator/interaction/property/modalFeedback';
 
-    const _saveCallbacks = {
-        mappingAttr: function mappingAttr(response, value, key) {
-            if (value === '') {
-                response.removeMappingAttribute(key);
-            } else {
-                response.setMappingAttribute(key, value);
-            }
-        }
-    };
-
     /**
      * Get the list of all available response processing templates available in the platform
      * @returns {Object}
@@ -302,7 +292,9 @@ define([
                         answerStateHelper.initResponseForm(widget);
                     }
                 },
-                defaultValue: _saveCallbacks.mappingAttr,
+                defaultValue: function (response, value, key) {
+                    response.setMappingAttribute(key, value);
+                },
                 template: function (res, value) {
                     rp.setProcessingType(value === 'CUSTOM' ? 'custom' : 'templateDriven');
                     response.setTemplate(value);


### PR DESCRIPTION
Ticket: <a class="link" href='https://oat-sa.atlassian.net/browse/AUT-2856'>AUT-2856</a>

## What's Changed

- Removed check for empty string on default mapping field, now this validation is going on BE side.

## Demo
![image](https://i.imgur.com/rSVwfJT.gif)

## How to test
- Go to "Items" page, create Item, and click on "Authoring" tab
- Add Interaction and click "Response"
- Choose "map response" in drop-down list in "Response processing" section
- Enter value in the field "Score range" at list for one choice (for example '10')
- Remove the value from "Mapping default" field and click “Save“

[Kitchen](http://test-kiril.playground.kitchen.it.taocloud.org:40351/tao/Main)