### PR TITLE
fix: _currentChoices change to arrow function

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/graphicInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicInteraction/Widget.js
@@ -106,7 +106,7 @@ define([
          * call render choice for each interaction's choices
          */
         createChoices : function(){
-            _.forEach(this.element.getChoices(), this._currentChoices, this);
+            _.forEach(this.element.getChoices(), _.bind(this._currentChoices, this));
         },
 
         /**
@@ -114,7 +114,7 @@ define([
          * @private
          * @param {Object} choice - the QTI choice
          */
-        _currentChoices : (choice) => {
+        _currentChoices : function(){
             graphic.createElement(this.element.paper, choice.attr('shape'), choice.attr('coords'), {
                 id          : choice.serial,
                 touchEffect : false

--- a/views/js/qtiCreator/widgets/interactions/graphicInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicInteraction/Widget.js
@@ -114,7 +114,7 @@ define([
          * @private
          * @param {Object} choice - the QTI choice
          */
-        _currentChoices : function(){
+        _currentChoices : function(choice){
             graphic.createElement(this.element.paper, choice.attr('shape'), choice.attr('coords'), {
                 id          : choice.serial,
                 touchEffect : false

--- a/views/js/qtiCreator/widgets/interactions/graphicInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/graphicInteraction/Widget.js
@@ -114,7 +114,7 @@ define([
          * @private
          * @param {Object} choice - the QTI choice
          */
-        _currentChoices : function(choice){
+        _currentChoices : (choice) => {
             graphic.createElement(this.element.paper, choice.attr('shape'), choice.attr('coords'), {
                 id          : choice.serial,
                 touchEffect : false


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-3541

**Steps to reproduce:**
1. Open Item in authoring mode
2. D&D  Graphic Hotspot Interaction to the canvas
3. Choose an Image file and click the "Select" button
4. Draw one/more Rectangle/Circle/Ellipsis/Free form on the Image
5. Navigate to "Response" tab and choose the correct Rectangle/Circle/Ellipsis/Free form as the correct answer
6. Click “Done”

**Fix**
In the `_currentChoices` function, the `this` context was undefined, so I changed it to an arrow function. Now, `this` is visible.