### PR TITLE
fix: update @oat-sa/tao-item-runner-qti to v2.2.1 for lodash 4 compatibility

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@oat-sa/tao-item-runner": "^1.0.0",
-                "@oat-sa/tao-item-runner-qti": "^2.2.0"
+                "@oat-sa/tao-item-runner-qti": "^2.2.1"
             }
         },
         "node_modules/@oat-sa/tao-item-runner": {
@@ -19,9 +19,9 @@
             "integrity": "sha512-wSDlxrzIceNdss6STX0e9Lpz095NuoqaluqOQ/r/CpNLo+6K9HgvWSDNLgjFsgb96FdyCiGDeUz7OaMgg3gakQ=="
         },
         "node_modules/@oat-sa/tao-item-runner-qti": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-2.2.0.tgz",
-            "integrity": "sha512-8zIaX7xihE0QxgMZU/BcRXQ5LOaUOQeJukYCbapB+aH/Ozxk0Uuh3FDD6XheDSEhInFwjFL1S52K2xBlhs4j4Q=="
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-2.2.1.tgz",
+            "integrity": "sha512-ZoSRzd5VKpixJLRxMKNi4Bd69vMs6MYcV7Ovs+5cVsPO8x+AFv/LVSIftTotMDB+BpEBtB0CIO9KkLf2DNpM+A=="
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "^1.0.0",
-        "@oat-sa/tao-item-runner-qti": "^2.2.0"
+        "@oat-sa/tao-item-runner-qti": "^2.2.1"
     }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/oat-sa/tao-item-runner-qti-fe/pull/378