### PR TITLE
[AUT-1966] Fix for Prompt field if it is not displayed when Interaction added via "+" plus button

### DIFF
--- a/views/js/qtiCreator/editor/blockAdder/blockAdder.js
+++ b/views/js/qtiCreator/editor/blockAdder/blockAdder.js
@@ -140,7 +140,7 @@ define([
             //activate the new widget:
             _.defer(function () {
                 if (widget) {
-                    if (widget.elemen && widget.element.is('interaction')) {
+                    if (widget.element && widget.element.is('interaction')) {
                         widget.changeState('question');
                     } else {
                         widget.changeState('active');


### PR DESCRIPTION
Ticket: <a class="link" href='https://oat-sa.atlassian.net/browse/AUT-1966'>AUT-1966</a>

## What's Changed

- Fixed the issue when added by + interaction was have no prompt section on initial rendering

## Demo
![image](https://i.imgur.com/moBIMZY.gif)

## How to test
- Open Item in authoring mod
- Click "+" button and add "Choice interaction"