### PR TITLE
fix: escape special chars in imsmanifest.xml

### DIFF
--- a/model/qti/metadata/imsManifest/ImsManifestMetadataInjector.php
+++ b/model/qti/metadata/imsManifest/ImsManifestMetadataInjector.php
@@ -270,7 +270,7 @@ class ImsManifestMetadataInjector implements MetadataInjector
                     }
                 }
             } else {
-                $node->nodeValue = $metadata->getValue();
+                $node->nodeValue = htmlspecialchars($metadata->getValue());
             }
             $oldChildNode = $node;
         }

--- a/test/unit/metadata/ImsManifestMetadataInjectorTest.php
+++ b/test/unit/metadata/ImsManifestMetadataInjectorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoQtiItem\test\unit\metadata;
+
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+use oat\taoQtiItem\model\qti\metadata\imsManifest\ImsManifestMapping;
+use oat\taoQtiItem\model\qti\metadata\imsManifest\ImsManifestMetadataInjector;
+use oat\taoQtiItem\model\qti\metadata\imsManifest\classificationMetadata\ClassificationSourceMetadataValue;
+
+final class ImsManifestMetadataInjectorTest extends TestCase
+{
+    protected ImsManifestMetadataInjector $imsManifestInjector;
+
+    public function setUp(): void
+    {
+        $mappings = [
+            new ImsManifestMapping(
+                'http://ltsc.ieee.org/xsd/LOM',
+                'imsmd',
+                'http://www.imsglobal.org/xsd/imsmd_loose_v1p3p2.xsd'
+            )
+        ];
+
+        $this->imsManifestInjector = new ImsManifestMetadataInjector($mappings);
+    }
+
+    private function createXmlTemplate(string $resourceId): string
+    {
+        return sprintf(
+            '<manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <resources>
+                    <resource identifier="%s"/>
+                </resources>
+            </manifest>',
+            $resourceId
+        );
+    }
+
+    /**
+     * Test that special characters like & < > are encoded as &amp; &lt; &gt; in xml output
+     */
+    public function testInjectMetadata(): void
+    {
+        $resourceId = 'i65dd88260e386150d3bf822a1dace381';
+
+        $metaValue1 = new ClassificationSourceMetadataValue(
+            $resourceId,
+            'http://www.w3.org/2000/01/rdf-schema#label'
+        );
+
+        $metaValue2 = new ClassificationSourceMetadataValue($resourceId, 'Amp &');
+        $metaValue3 = new ClassificationSourceMetadataValue($resourceId, 'Gt >');
+        $metaValue4 = new ClassificationSourceMetadataValue($resourceId, 'Lt <');
+
+        $metaValues = [
+            $resourceId => [
+                $metaValue1,
+                $metaValue2,
+                $metaValue3,
+                $metaValue4,
+            ],
+        ];
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML($this->createXmlTemplate($resourceId));
+
+        $this->imsManifestInjector->inject($dom, $metaValues);
+
+        $xml = $dom->saveXML();
+
+        $this->assertMatchesRegularExpression('/Amp &amp;/', $xml);
+        $this->assertMatchesRegularExpression('/Gt &gt;/', $xml);
+        $this->assertMatchesRegularExpression('/Lt &lt;/', $xml);
+    }
+}

--- a/test/unit/metadata/ImsManifestMetadataInjectorTest.php
+++ b/test/unit/metadata/ImsManifestMetadataInjectorTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -19,6 +17,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
  */
+
+declare(strict_types=1);
 
 namespace oat\taoQtiItem\test\unit\metadata;
 
@@ -48,7 +48,8 @@ final class ImsManifestMetadataInjectorTest extends TestCase
     private function createXmlTemplate(string $resourceId): string
     {
         return sprintf(
-            '<manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            '<manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <resources>
                     <resource identifier="%s"/>
                 </resources>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/ADF-1639

This PR fixes special characters not being encoded in exported imsmanifest.xml file which breaks xml

- [X] New code is covered by tests (if applicable)
- [X] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [X] New code is respecting code style rules
- [X] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [X] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [X] Pull request title and description are meaningful
