### PR TITLE
feature: add xi include loading on authoring initialization

### DIFF
--- a/views/js/qtiCreator/helper/xincludeLoader.js
+++ b/views/js/qtiCreator/helper/xincludeLoader.js
@@ -1,0 +1,82 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+define(
+    ['jquery', 'lodash',],
+    function ($, _) {
+        'use strict';
+
+        const xincludeLoader = {
+            name: 'xincludeLoader',
+            load: function load(xincludeElement, baseUrl) {
+                const self = this;
+                const href = xincludeElement.attr('href');
+
+                // Return a new Promise
+                return new Promise((resolve, reject) => {
+                    if (href && baseUrl) {
+                        const fileUrl = `text!${baseUrl}${href}`;
+                        // reset the previous definition of the XML, to receive updated passage
+                        require.undef(fileUrl);
+                        // require xml
+                        require([fileUrl], function (stimulusXml) {
+                            const data = self.parseXmlToDom(stimulusXml);
+                            resolve({ xinclude: xincludeElement, data }); // Resolve with an object containing xinclude and data
+                        }, function () {
+                            // In case the file does not exist, reject the promise
+                            reject(new Error('File not found'));
+                        });
+                    } else {
+                        reject(new Error('href or baseUrl is missing'));
+                    }
+                });
+            },
+            parseXmlToDom: function parseXmlToDom(xmlString) {
+                // Parse the XML string into a document object
+                const parser = new DOMParser();
+                const xmlDoc = parser.parseFromString(xmlString, "application/xml");
+
+                // Function to recursively convert XML to HTML
+                function convertXMLToHTML(xmlNode) {
+                    // Create a corresponding HTML element for the XML node
+                    const htmlNode = document.createElement(xmlNode.nodeName);
+
+                    // Copy attributes
+                    for (let i = 0; i < xmlNode.attributes.length; i++) {
+                        const attr = xmlNode.attributes[i];
+                        htmlNode.setAttribute(attr.name, attr.value);
+                    }
+
+                    // Recursively convert child nodes
+                    xmlNode.childNodes.forEach(childNode => {
+                        if (childNode.nodeType === Node.ELEMENT_NODE) {
+                            htmlNode.appendChild(convertXMLToHTML(childNode));
+                        } else if (childNode.nodeType === Node.TEXT_NODE) {
+                            htmlNode.appendChild(document.createTextNode(childNode.nodeValue));
+                        }
+                    });
+
+                    return htmlNode;
+                }
+
+                // Convert the XML document to HTML
+                return convertXMLToHTML(xmlDoc.documentElement);
+            }
+        };
+        return xincludeLoader;
+    });

--- a/views/js/qtiCreator/helper/xincludeLoader.js
+++ b/views/js/qtiCreator/helper/xincludeLoader.js
@@ -76,6 +76,29 @@ define(
 
                 // Convert the XML document to HTML
                 return convertXMLToHTML(xmlDoc.documentElement);
+            },
+            loadByElementPages: function loadByElementPages(pages, baseUrl) {
+                return pages.map(page => {
+                    const contentPromises = page.content.map(contentItem => {
+                        const tempDiv = document.createElement('div');
+                        tempDiv.innerHTML = contentItem;
+                        const xiIncludeElements = tempDiv.querySelectorAll('xi\\:include');
+
+                        const xiIncludePromises = Array.from(xiIncludeElements).map(xiIncludeElement => {
+                            const $xiIncludeElement = $(xiIncludeElement);
+                            return xincludeLoader.load($xiIncludeElement, baseUrl).then(newContent => {
+                                $xiIncludeElement.replaceWith(newContent.data);
+                            });
+                        });
+
+                        return Promise.all(xiIncludePromises).then(() => tempDiv.innerHTML);
+                    });
+
+                    return Promise.all(contentPromises).then(updatedContentItems => {
+                        page.content = updatedContentItems;
+                        return page;
+                    });
+                });
             }
         };
         return xincludeLoader;

--- a/views/js/qtiCreator/itemCreator.js
+++ b/views/js/qtiCreator/itemCreator.js
@@ -256,34 +256,10 @@ define([
                             if (element.is('customInteraction')) {
                                 usedCustomInteractionIds.push(element.typeIdentifier);
 
-                                // Directly iterate over element.properties.pages as it's already an array
                                 if (element.properties && Array.isArray(element.properties.pages) && element.typeIdentifier === 'textReaderInteraction') {
-                                    const pages = element.properties.pages;
-
-                                    const pagePromises = pages.map(page => {
-                                        const contentPromises = page.content.map(contentItem => {
-                                            const tempDiv = document.createElement('div');
-                                            tempDiv.innerHTML = contentItem;
-                                            const xiIncludeElements = tempDiv.querySelectorAll('xi\\:include');
-
-                                            const xiIncludePromises = Array.from(xiIncludeElements).map(xiIncludeElement => {
-                                                const $xiIncludeElement = $(xiIncludeElement);
-                                                return xincludeLoader.load($xiIncludeElement, config.properties.baseUrl).then(newContent => {
-                                                    $xiIncludeElement.replaceWith(newContent.data);
-                                                });
-                                            });
-
-                                            return Promise.all(xiIncludePromises).then(() => tempDiv.innerHTML);
-                                        });
-
-                                        return Promise.all(contentPromises).then(updatedContentItems => {
-                                            page.content = updatedContentItems;
-                                            return page;
-                                        });
-                                    });
-
+                                    const pagePromises = xincludeLoader.loadByElementPages(element.properties.pages);
                                     elementPromises.push(Promise.all(pagePromises).then(updatedPages => {
-                                        element.properties.pages = updatedPages; // No need for JSON.stringify
+                                        element.properties.pages = updatedPages;
                                     }));
                                 }
                             }

--- a/views/js/qtiCreator/widgets/interactions/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/states/Question.js
@@ -3,8 +3,9 @@ define([
     'taoQtiItem/qtiCreator/widgets/states/factory',
     'taoQtiItem/qtiCreator/widgets/states/Question',
     'tpl!taoQtiItem/qtiCreator/tpl/toolbars/addChoice',
-    'i18n'
-], function($, stateFactory, Question, addChoiceTpl, __){
+    'i18n',
+    'taoQtiItem/qtiCreator/helper/xincludeLoader',
+], function($, stateFactory, Question, addChoiceTpl, __, xincludeLoader){
 
     var InteractionStateQuestion = stateFactory.create(Question, function(){
 
@@ -23,10 +24,18 @@ define([
 
 
     }, function(){
-
         //destroy and hide it
         this.widget.$form.empty().hide();
-
+        //render textReaderInteraction possible xi:include elements
+        let element = this.widget.element;
+        const baseUrl = this.widget.options.baseUrl;
+        if (element.properties && Array.isArray(element.properties.pages) && element.typeIdentifier === 'textReaderInteraction') {
+            const pagePromises = xincludeLoader.loadByElementPages(element.properties.pages, baseUrl)
+            Promise.all(pagePromises).then(updatedPages => {
+                element.properties.pages = updatedPages;
+                element.widgetRenderer.renderPages(element.properties);
+            });
+        }
         //disable/destroy editor, hide mini-toolbar
     });
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-1647

## What's Changed

- Add loading of shared stimulus in text reader PCI in preview and authoring.

## Dependencies PRs

- https://github.com/oat-sa/extension-tao-test-preview-ui-loader/pull/166


## How to test
- Install & enable PCI Samples extension in Tao 
- Install & enable Tao Asset Manager extension
- Add shared stimulus via Asset Manager
- Go to items, create new item and add Text Reader custom interaction
- Add shared stimulus to text reader, click done.
- Click Preview and see that shared stimulus is visible.

## Video

https://github.com/oat-sa/extension-tao-itemqti/assets/118974926/733898a3-79f3-43f8-859e-4ee7afb1f96a


