### PR TITLE
[AUT-3588] Fix for Item which cannot be saved when response processing is set to none for Text Entry Interaction

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
+++ b/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
@@ -125,9 +125,13 @@ define([
         // Make sure to adjust the response when exiting the state even if not modified
         const widget = this.widget;
         const response = widget.element.getResponseDeclaration();
+        if(response.template === "no_response_processing") {
+            widget.$container.find('button.widget-ok').attr('disabled', false);
+            widget.isValid(widget.serial, true);
+        }
         stringResponseHelper.rewriteCorrectResponse(response, { trim: true });
 
-        this.widget.$container.off('.correct');
+        widget.$container.off('.correct');
         instructionMgr.removeInstructions(widget.element);
     }
 


### PR DESCRIPTION
Ticket: [AUT-3588](https://oat-sa.atlassian.net/browse/AUT-3588)

## What's Changed

- Fixed validation of items with disabled response processing

## Demo

![image](https://i.imgur.com/v8yCLwl.gif)

## How to test

- Create an item and open it in “Authoring“ mode
- Drag and drop an A-Block
- Drag and drop Text Entry interaction
- Click “Response“ button
- Choose "none" in drop-down list in "Response processing" section
- Click Save button

[Kitchen](http://test-kiril.playground.kitchen.it.taocloud.org:40351/tao/Main/login)

[AUT-3588]: https://oat-sa.atlassian.net/browse/AUT-3588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ