### PR TITLE
Fix null deprecated message for trim 

### DIFF
--- a/model/qti/OutcomeDeclaration.php
+++ b/model/qti/OutcomeDeclaration.php
@@ -69,7 +69,7 @@ class OutcomeDeclaration extends VariableDeclaration
         $variables = parent::getTemplateQtiVariables();
         $variables['defaultValue'] = null;
         $defaultValue = $this->getDefaultValue();
-        if (!is_null($defaultValue) || trim($defaultValue) != '') {
+        if (!is_null($defaultValue) && trim($defaultValue) != '') {
             $variables['defaultValue'] = $defaultValue;
         }
         return $variables;

--- a/model/qti/templates/qti.object.tpl.php
+++ b/model/qti/templates/qti.object.tpl.php
@@ -19,7 +19,7 @@
  *
  */
 ?>
-<?php if (trim(get_data('_alt')) == '') :?>
+<?php if (has_data('_alt') && trim(get_data('_alt')) == '') :?>
     <object <?=get_data('attributes')?>/>
 <?php else :?>
     <object <?=get_data('attributes')?>><?=get_data('_alt')?></object>


### PR DESCRIPTION
When installing TAO on PHP 8.1 stack We get lot of [passing null deprecation](https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation) message

This PR aims to fix it to make TAO installation a better 

![2024-03-25_12-57](https://github.com/oat-sa/extension-tao-itemqti/assets/11832872/d37e77f0-a529-41d5-be9e-6a8de12a086e)
