### PR TITLE
fix: expose zero maxscore for upload and endAttempt interactions

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@oat-sa/tao-item-runner": "^1.0.0",
-                "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#fix/AUT-2604/upload-endattempt-interactions-maxscore"
+                "@oat-sa/tao-item-runner-qti": "^2.2.3"
             }
         },
         "node_modules/@oat-sa/tao-item-runner": {
@@ -19,9 +19,9 @@
             "integrity": "sha512-wSDlxrzIceNdss6STX0e9Lpz095NuoqaluqOQ/r/CpNLo+6K9HgvWSDNLgjFsgb96FdyCiGDeUz7OaMgg3gakQ=="
         },
         "node_modules/@oat-sa/tao-item-runner-qti": {
-            "version": "2.2.2",
-            "resolved": "git+ssh://git@github.com/oat-sa/tao-item-runner-qti-fe.git#79839a21507b7d8ea57866ef5b21a4757ec68874",
-            "license": "GPL-2.0"
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-2.2.3.tgz",
+            "integrity": "sha512-jEOFzmYSpfVwFXh2dFGcL5aMxKpGfpoxp6kr3+as2S1/aqTmDuV6/meg3rHRo3eJvVWS5/4JEohd/Y1/M3EvHw=="
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@oat-sa/tao-item-runner": "^1.0.0",
-                "@oat-sa/tao-item-runner-qti": "^2.2.2"
+                "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#fix/AUT-2604/upload-endattempt-interactions-maxscore"
             }
         },
         "node_modules/@oat-sa/tao-item-runner": {
@@ -20,8 +20,8 @@
         },
         "node_modules/@oat-sa/tao-item-runner-qti": {
             "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-2.2.2.tgz",
-            "integrity": "sha512-aCIiMZUQAIXxq2DADrXifua1RbWWmZCFOt3G3qamuyyIBvN9TG1k5WuKFkBubf98bLeWb6dLVlEHRjOA1J7GFg=="
+            "resolved": "git+ssh://git@github.com/oat-sa/tao-item-runner-qti-fe.git#79839a21507b7d8ea57866ef5b21a4757ec68874",
+            "license": "GPL-2.0"
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "^1.0.0",
-        "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#fix/AUT-2604/upload-endattempt-interactions-maxscore"
+        "@oat-sa/tao-item-runner-qti": "^2.2.3"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     },
     "dependencies": {
         "@oat-sa/tao-item-runner": "^1.0.0",
-        "@oat-sa/tao-item-runner-qti": "^2.2.2"
+        "@oat-sa/tao-item-runner-qti": "https://github.com/oat-sa/tao-item-runner-qti-fe#fix/AUT-2604/upload-endattempt-interactions-maxscore"
     }
 }


### PR DESCRIPTION
Tickets:
https://oat-sa.atlassian.net/browse/AUT-2604,
https://oat-sa.atlassian.net/browse/AUT-3593

## What's Changed

- Updated the @oat-sa/tao-item-runner-qti package with exposed normal maximum as zero for the EndAttemptInteraction and UploadInteraction

## How to test
- Create a new item
- DnD a Choice Interaction
- Save the item
- DnD “End attempt“ Interaction
- Save the Item 
- Preview the Item and click "Submit"
- Check both the MAXSCORE and SCORE outcomes are present
- Repeat this flow with "File Upload" interaction

**Available for test on**: http://test-viktar-2.playground.kitchen.it.taocloud.org:42481/