### PR TITLE
[AUT-3559] Text for error messages after trying to save item with Text Entry with invalid response

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
+++ b/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
@@ -90,7 +90,7 @@ define([
                     responseValue = isNaN(value) ? '' : value;
                     // check for parsing and integer
                     if (responseValue === '' || !/^[+-]?[0-9]+(e-?\d*)?$/.test(convertedValue)) {
-                        widget.isValid(widget.serial, false);
+                        widget.isValid(widget.serial, false, __('Invalid value in correct response. Expected integer value.'));
                         return setErrorNotification($submitButton, element, attributes.baseType)
                     }
                     break;
@@ -99,7 +99,7 @@ define([
                     responseValue = isNaN(value) ? '' : value;
                     const regex = new RegExp(`^[+-]?[0-9]+\\${decimalSeparator}[0-9]+(e-?\\d*)?$`);
                     if (responseValue === '' || !regex.test(convertedValue)) { // check for parsing and float
-                        widget.isValid(widget.serial, false);
+                        widget.isValid(widget.serial, false, __('Invalid value in correct response. Expected decimal value.'));
                         return setErrorNotification(
                             $submitButton,
                             element,
@@ -110,7 +110,7 @@ define([
                 case 'string':
                     responseValue = convertedValue;
                     if (responseValue === '') {
-                        widget.isValid(widget.serial, false);
+                        widget.isValid(widget.serial, false, __('Empty value in correct response.'));
                         return setErrorNotification($submitButton, element, attributes.baseType);
                     }
                     break;

--- a/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
+++ b/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
@@ -90,7 +90,7 @@ define([
                     responseValue = isNaN(value) ? '' : value;
                     // check for parsing and integer
                     if (responseValue === '' || !/^[+-]?[0-9]+(e-?\d*)?$/.test(convertedValue)) {
-                        widget.isValid(widget.serial, false, __('Invalid value in correct response. Expected integer value.'));
+                        widget.isValid(widget.serial, false, __('Invalid value in correct response property.'));
                         return setErrorNotification($submitButton, element, attributes.baseType)
                     }
                     break;
@@ -99,7 +99,7 @@ define([
                     responseValue = isNaN(value) ? '' : value;
                     const regex = new RegExp(`^[+-]?[0-9]+\\${decimalSeparator}[0-9]+(e-?\\d*)?$`);
                     if (responseValue === '' || !regex.test(convertedValue)) { // check for parsing and float
-                        widget.isValid(widget.serial, false, __('Invalid value in correct response. Expected decimal value.'));
+                        widget.isValid(widget.serial, false, __('Invalid value in correct response property.'));
                         return setErrorNotification(
                             $submitButton,
                             element,
@@ -110,7 +110,7 @@ define([
                 case 'string':
                     responseValue = convertedValue;
                     if (responseValue === '') {
-                        widget.isValid(widget.serial, false, __('Empty value in correct response.'));
+                        widget.isValid(widget.serial, false, __('Invalid value in correct response property.'));
                         return setErrorNotification($submitButton, element, attributes.baseType);
                     }
                     break;


### PR DESCRIPTION
Ticket: [AUT-3559](https://oat-sa.atlassian.net/browse/AUT-3559)

## What's Changed

- Additional error description for validations error on item save

## Demo
![image](https://i.imgur.com/efhxHef.gif)

## How to test
- Open an item from Preconditions in “Authoring“ mode
- Drag and drop an A-Block
- Drag and drop Text Entry interaction
- Click “Response“ button
- Enter invalid value
- Click “Save“ button

[AUT-3559]: https://oat-sa.atlassian.net/browse/AUT-3559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ