### PR TITLE
feat: add form fields

### DIFF
--- a/model/import/QtiPackageImport.php
+++ b/model/import/QtiPackageImport.php
@@ -25,12 +25,14 @@ namespace oat\taoQtiItem\model\import;
 use oat\oatbox\event\EventManagerAwareTrait;
 use oat\oatbox\PhpSerializable;
 use oat\oatbox\PhpSerializeStateless;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\import\ImportHandlerHelperTrait;
 use oat\tao\model\import\TaskParameterProviderInterface;
 use oat\taoQtiItem\model\event\QtiItemImportEvent;
 use oat\taoQtiItem\model\qti\ImportService;
 use oat\taoQtiItem\model\qti\exception\ExtractException;
 use oat\taoQtiItem\model\qti\exception\ParsingException;
+use oat\taoQtiTest\models\classes\metadata\GenericLomOntologyExtractor;
 use tao_models_classes_import_ImportHandler;
 use helpers_TimeOutHelper;
 use common_report_Report;
@@ -56,6 +58,9 @@ class QtiPackageImport implements
         getTaskParameters as getDefaultTaskParameters;
     }
 
+    public const METADATA_IMPORT_ELEMENT_NAME = 'metadataImport';
+    public const DISABLED_ELEMENTS = 'disableElements';
+
     /**
      * @see tao_models_classes_import_ImportHandler::getLabel()
      */
@@ -69,7 +74,12 @@ class QtiPackageImport implements
      */
     public function getForm()
     {
-        $form = new QtiPackageImportForm();
+        $form = new QtiPackageImportForm(
+            [],
+            [
+                self::DISABLED_ELEMENTS => $this->getDisabledElements(),
+            ]
+        );
 
         return $form->getForm();
     }
@@ -100,7 +110,12 @@ class QtiPackageImport implements
                 $class,
                 true,
                 in_array('error', $rollbackInfo),
-                in_array('warning', $rollbackInfo)
+                in_array('warning', $rollbackInfo),
+                null,
+                null,
+                null,
+                null,
+                count($form[QtiPackageImportForm::METADATA_FORM_ELEMENT_NAME]) !== 0
             );
 
             helpers_TimeOutHelper::reset();
@@ -140,8 +155,24 @@ class QtiPackageImport implements
         return array_merge(
             [
                 'rollback' => $form->getValue('rollback'),
+                QtiPackageImportForm::METADATA_FORM_ELEMENT_NAME => $form->getValue(
+                    QtiPackageImportForm::METADATA_FORM_ELEMENT_NAME
+                ) ?? null,
             ],
             $this->getDefaultTaskParameters($form)
         );
+    }
+    private function getFeatureFlagChecker(): FeatureFlagChecker
+    {
+        return $this->serviceLocator->getContainer()->get(FeatureFlagChecker::class);
+    }
+
+    private function getDisabledElements(): array
+    {
+        $disabledElements = [];
+        if (!$this->getFeatureFlagChecker()->isEnabled(GenericLomOntologyExtractor::FEATURE_FLAG)) {
+            $disabledElements[] = self::METADATA_IMPORT_ELEMENT_NAME;
+        }
+        return $disabledElements;
     }
 }

--- a/model/import/QtiPackageImportForm.php
+++ b/model/import/QtiPackageImportForm.php
@@ -40,12 +40,8 @@ use tao_helpers_Environment;
  */
 class QtiPackageImportForm extends tao_helpers_form_FormContainer
 {
-    // --- ASSOCIATIONS ---
+    public const METADATA_FORM_ELEMENT_NAME = 'metadata';
 
-
-    // --- ATTRIBUTES ---
-
-    // --- OPERATIONS ---
     /**
      * (non-PHPdoc)
      * @see tao_helpers_form_FormContainer::initForm()
@@ -111,8 +107,26 @@ class QtiPackageImportForm extends tao_helpers_form_FormContainer
         $rollbackElt->setDescription(__('Rollback on...'));
         $this->form->addElement($rollbackElt);
 
-        $this->form->createGroup('file', __('Import a QTI/APIP Content Package'), ['source', 'rollback']);
+        //Check if value is set in array
+        if (!in_array(
+            QtiPackageImport::METADATA_IMPORT_ELEMENT_NAME, $this->options[QtiPackageImport::DISABLED_ELEMENTS])
+        ) {
+            $metadataImport = tao_helpers_form_FormFactory::getElement(self::METADATA_FORM_ELEMENT_NAME, 'Checkbox');
+            $metadataImport->setOptions(['metadata' => __('Import metadata or fail')]);
+            $metadataImport->setDescription(__('Metadata import'));
+            $metadataImport->setLevel(1);
+            $this->form->addElement($metadataImport);
+        }
 
+        $this->form->createGroup(
+            'file',
+            __('Import a QTI/APIP Content Package'),
+            [
+                'source',
+                'rollback',
+                self::METADATA_FORM_ELEMENT_NAME
+            ]
+        );
 
         $qtiSentElt = tao_helpers_form_FormFactory::getElement('import_sent_qti', 'Hidden');
         $qtiSentElt->setValue(1);

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -284,7 +284,8 @@ class ImportService extends ConfigurableService
         $enableMetadataGuardians = true,
         $enableMetadataValidators = true,
         $itemMustExist = false,
-        $itemMustBeOverwritten = false
+        $itemMustBeOverwritten = false,
+        $importMetadataEnabled = false
     ) {
         $initialLogMsg = "Importing QTI Package with the following options:\n";
         $initialLogMsg .= '- Rollback On Warning: ' . json_encode($rollbackOnWarning) . "\n";
@@ -293,6 +294,7 @@ class ImportService extends ConfigurableService
         $initialLogMsg .= '- Enable Metadata Validators: ' . json_encode($enableMetadataValidators) . "\n";
         $initialLogMsg .= '- Item Must Exist: ' . json_encode($itemMustExist) . "\n";
         $initialLogMsg .= '- Item Must Be Overwritten: ' . json_encode($itemMustBeOverwritten) . "\n";
+        $initialLogMsg .= '- Import Metadata Enabled: ' . json_encode($importMetadataEnabled) . "\n";
         \common_Logger::d($initialLogMsg);
 
         //load and validate the package
@@ -345,7 +347,8 @@ class ImportService extends ConfigurableService
                     $itemMustExist,
                     $itemMustBeOverwritten,
                     $overwrittenItems,
-                    $metaMetadataValues
+                    $metaMetadataValues,
+                    $importMetadataEnabled
                 );
 
                 $allCreatedClasses = array_merge($allCreatedClasses, $createdClasses);
@@ -452,7 +455,8 @@ class ImportService extends ConfigurableService
         $itemMustExist = false,
         $itemMustBeOverwritten = false,
         &$overwrittenItems = [],
-        $metaMedataValues = []
+        $metaMedataValues = [],
+        $importMetadataEnabled = false
     ) {
         // if report can't be finished
         $report = common_report_Report::createFailure(
@@ -624,7 +628,7 @@ class ImportService extends ConfigurableService
 
                 $this->getMetadataImporter()->inject($resourceIdentifier, $rdfItem);
 
-                if (isset($metadataValues[$resourceIdentifier])) {
+                if ($importMetadataEnabled && isset($metadataValues[$resourceIdentifier])) {
                     $this->getMappedMetadataInjector()->inject(
                         $metaMedataValues,
                         $metadataValues[$resourceIdentifier],


### PR DESCRIPTION
When importing item user may check metadata import checkbox to allow importing metadata. 
This field will only show when `GenericLomOntologyExtractor::FEATURE_FLAG` is enabled. 

<img width="537" alt="Screenshot 2024-04-29 at 13 31 09" src="https://github.com/oat-sa/extension-tao-itemqti/assets/16231681/a00f4795-136b-402a-955f-4d7a7bf3875e">
