### PR TITLE
Fix/aut 3654/prevent property duplication widget added to mapping

### DIFF
--- a/model/qti/metadata/importer/MetaMetadataImportMapper.php
+++ b/model/qti/metadata/importer/MetaMetadataImportMapper.php
@@ -86,7 +86,8 @@ class MetaMetadataImportMapper
         $multiple = $classProperty->getOnePropertyValue(new Property(GenerisRdf::PROPERTY_MULTIPLE));
         $checksum = $this->checksumGenerator->getRangeChecksum($classProperty);
         $metaMetadataProperty['checksum_result'] = $checksum === $metaMetadataProperty['checksum'];
-        $metaMetadataProperty['widget_result'] = $classProperty->getWidget()->getUri() === $metaMetadataProperty['widget'];
+        $metaMetadataProperty['widget_result'] =
+            $classProperty->getWidget()->getUri() === $metaMetadataProperty['widget'];
 
         return $multiple instanceof core_kernel_classes_Resource
             && $multiple->getUri() === $metaMetadataProperty['multiple']

--- a/model/qti/metadata/importer/MetaMetadataImportMapper.php
+++ b/model/qti/metadata/importer/MetaMetadataImportMapper.php
@@ -91,6 +91,6 @@ class MetaMetadataImportMapper
         return $multiple instanceof core_kernel_classes_Resource
             && $multiple->getUri() === $metaMetadataProperty['multiple']
             && $checksum === $metaMetadataProperty['checksum']
-            && $classProperty->getWidget() === $metaMetadataProperty['widget'];
+            && $classProperty->getWidget()->getUri() === $metaMetadataProperty['widget'];
     }
 }

--- a/model/qti/metadata/importer/MetaMetadataImportMapper.php
+++ b/model/qti/metadata/importer/MetaMetadataImportMapper.php
@@ -86,7 +86,7 @@ class MetaMetadataImportMapper
         $multiple = $classProperty->getOnePropertyValue(new Property(GenerisRdf::PROPERTY_MULTIPLE));
         $checksum = $this->checksumGenerator->getRangeChecksum($classProperty);
         $metaMetadataProperty['checksum_result'] = $checksum === $metaMetadataProperty['checksum'];
-        $metaMetadataProperty['widget_result'] = $classProperty->getWidget() === $metaMetadataProperty['widget'];
+        $metaMetadataProperty['widget_result'] = $classProperty->getWidget()->getUri() === $metaMetadataProperty['widget'];
 
         return $multiple instanceof core_kernel_classes_Resource
             && $multiple->getUri() === $metaMetadataProperty['multiple']

--- a/model/qti/metadata/importer/MetaMetadataImportMapper.php
+++ b/model/qti/metadata/importer/MetaMetadataImportMapper.php
@@ -86,9 +86,11 @@ class MetaMetadataImportMapper
         $multiple = $classProperty->getOnePropertyValue(new Property(GenerisRdf::PROPERTY_MULTIPLE));
         $checksum = $this->checksumGenerator->getRangeChecksum($classProperty);
         $metaMetadataProperty['checksum_result'] = $checksum === $metaMetadataProperty['checksum'];
+        $metaMetadataProperty['widget_result'] = $classProperty->getWidget() === $metaMetadataProperty['widget'];
 
         return $multiple instanceof core_kernel_classes_Resource
             && $multiple->getUri() === $metaMetadataProperty['multiple']
-            && $checksum === $metaMetadataProperty['checksum'];
+            && $checksum === $metaMetadataProperty['checksum']
+            && $classProperty->getWidget() === $metaMetadataProperty['widget'];
     }
 }

--- a/model/qti/metadata/importer/PropertyDoesNotExistException.php
+++ b/model/qti/metadata/importer/PropertyDoesNotExistException.php
@@ -38,6 +38,16 @@ class PropertyDoesNotExistException extends Exception
             return;
         }
 
+        if (isset($message['widget_result']) && $message['widget_result'] === false) {
+            parent::__construct(
+                sprintf(
+                    'The property %s selected widget is not defined as expected by the imported package',
+                    $message['label'] ?? 'unknown label',
+                )
+            );
+            return;
+        }
+
         parent::__construct(
             sprintf(
                 'Property with label %s and alias %s does not exist.',

--- a/model/qti/metadata/imsManifest/MetaMetadataExtractor.php
+++ b/model/qti/metadata/imsManifest/MetaMetadataExtractor.php
@@ -55,6 +55,7 @@ class MetaMetadataExtractor
             $label = $xpath->evaluate('string(default:label)', $property);
             $multiple = $xpath->evaluate('string(default:multiple)', $property);
             $checksum = $xpath->evaluate('string(default:checksum)', $property);
+            $widget = $xpath->evaluate('string(default:widget)', $property);
 
             if (strlen($uri) === 0 || strlen($label) === 0) {
                 continue;
@@ -66,6 +67,7 @@ class MetaMetadataExtractor
                 'label' => trim($label),
                 'multiple' => trim($multiple),
                 'checksum' => trim($checksum),
+                'widget' => trim($widget),
             ];
         }
 

--- a/model/qti/metadata/ontology/MappedMetadataInjector.php
+++ b/model/qti/metadata/ontology/MappedMetadataInjector.php
@@ -44,7 +44,9 @@ class MappedMetadataInjector
         /** @var SimpleMetadataValue $metadataValue */
         foreach ($metadataValues as $metadataValue) {
             foreach ($metadataValue->getPath() as $mappedPath) {
-                if (isset($mappedProperties[$mappedPath]) && $mappedProperties[$mappedPath] instanceof Property) {
+                if ($this->isInjectableProperty($mappedProperties, $mappedPath)
+                    && !$this->isPropertyDefined($resource, $mappedProperties[$mappedPath])
+                ) {
                     if ($mappedProperties[$mappedPath]->getRange()->getUri() === RDFS_LITERAL) {
                         $resource->setPropertyValue($mappedProperties[$mappedPath], $metadataValue->getValue());
                         break;
@@ -66,5 +68,16 @@ class MappedMetadataInjector
                 }
             }
         }
+    }
+
+    private function isInjectableProperty(array $mappedProperties, string $mappedPath): bool
+    {
+        return isset($mappedProperties[$mappedPath])
+            && $mappedProperties[$mappedPath] instanceof Property;
+    }
+
+    private function isPropertyDefined(Resource $resource, Property $property): bool
+    {
+        return count($resource->getPropertyValues($property)) !== 0;
     }
 }

--- a/model/qti/metadata/ontology/MappedMetadataInjector.php
+++ b/model/qti/metadata/ontology/MappedMetadataInjector.php
@@ -44,7 +44,8 @@ class MappedMetadataInjector
         /** @var SimpleMetadataValue $metadataValue */
         foreach ($metadataValues as $metadataValue) {
             foreach ($metadataValue->getPath() as $mappedPath) {
-                if ($this->isInjectableProperty($mappedProperties, $mappedPath)
+                if (
+                    $this->isInjectableProperty($mappedProperties, $mappedPath)
                     && !$this->isPropertyDefined($resource, $mappedProperties[$mappedPath])
                 ) {
                     if ($mappedProperties[$mappedPath]->getRange()->getUri() === RDFS_LITERAL) {

--- a/model/qti/metadata/ontology/MappedMetadataInjector.php
+++ b/model/qti/metadata/ontology/MappedMetadataInjector.php
@@ -63,7 +63,10 @@ class MappedMetadataInjector
                                 $mappedProperties[$mappedPath],
                                 $this->getResource($listElement->getUri())
                             );
-                            break;
+
+                            if ($mappedProperties[$mappedPath]->isMultiple() === false) {
+                                break;
+                            }
                         }
                     }
                 }

--- a/test/unit/metadata/MetaMetadataExtractorTest.php
+++ b/test/unit/metadata/MetaMetadataExtractorTest.php
@@ -50,6 +50,7 @@ final class MetaMetadataExtractorTest extends TestCase
                             <def:label>Example</def:label>
                             <def:multiple>1</def:multiple>
                             <def:checksum>123</def:checksum>
+                            <def:widget>Password</def:widget>
                         </def:property>
                     </def:customProperties>
                 </def:extension>
@@ -61,7 +62,8 @@ final class MetaMetadataExtractorTest extends TestCase
                 'alias' => 'example',
                 'label' => 'Example',
                 'multiple' => '1',
-                'checksum' => '123'
+                'checksum' => '123',
+                'widget' => 'Password'
             ]
         ], $result);
     }

--- a/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
+++ b/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
@@ -46,21 +46,24 @@ class MetaMetadataImportMapperTest extends TestCase
                 'label' => 'label1',
                 'alias' => 'alias1',
                 'checksum' => 'qwerty1234',
-                'multiple' => 'http://resource.uri/false'
+                'multiple' => 'http://resource.uri/false',
+                'widget' => 'http://widget.uri'
             ],
             [
                 'uri' => 'http://example.com/uri2',
                 'label' => 'label2',
                 'alias' => 'alias2',
                 'checksum' => '4321qwerty',
-                'multiple' => 'http://resource.uri/false'
+                'multiple' => 'http://resource.uri/false',
+                'widget' => 'http://widget.uri'
             ],
             [
                 'uri' => 'http://example.com/uri3',
                 'label' => 'label3',
                 'alias' => 'alias3',
                 'checksum' => '4321qwerty',
-                'multiple' => 'http://resource.uri/false'
+                'multiple' => 'http://resource.uri/false',
+                'widget' => 'http://widget.uri'
             ],
         ];
 
@@ -69,6 +72,7 @@ class MetaMetadataImportMapperTest extends TestCase
         $propertyMock = $this->createMock(core_kernel_classes_Property::class);
         $resourceMock = $this->createMock(core_kernel_classes_Resource::class);
 
+
         $itemClass->method('getProperties')
             ->willReturn([$propertyMock, $propertyMock, $propertyMock]);
         $testClass->method('getProperties')
@@ -76,9 +80,13 @@ class MetaMetadataImportMapperTest extends TestCase
         $propertyMock->method('getUri')
             ->willReturn(
                 'http://example.com/uri1',
+                'http://widget.uri',
                 'http://some-other-uri',
+                'http://widget.uri',
                 'http://some-other-uri',
-                'http://some-other-uri'
+                'http://widget.uri',
+                'http://some-other-uri',
+                'http://widget.uri'
             );
         $propertyMock->method('getLabel')
             ->willReturn('label2', 'some-other-label', 'some-other-other-label');
@@ -86,6 +94,8 @@ class MetaMetadataImportMapperTest extends TestCase
             ->willReturn('alias2', 'alias3', 'some-other-other-alias');
         $propertyMock->method('getOnePropertyValue')
             ->willReturn($resourceMock);
+        $propertyMock->method('getWidget')
+            ->willReturn($propertyMock);
         $this->checksumGeneratorMock->method('getRangeChecksum')
             ->willReturn('4321qwerty');
 

--- a/test/unit/model/qti/metadata/ontology/MappedMetadataInjectorTest.php
+++ b/test/unit/model/qti/metadata/ontology/MappedMetadataInjectorTest.php
@@ -98,6 +98,8 @@ class MappedMetadataInjectorTest extends TestCase
             ->method('setPropertyValue')
             ->with($propertyMock, $resourceMock);
 
+        $resourceMock->method('getPropertyValues')->willReturn([]);
+
         $this->subject->inject($mappedProperties, $metadataValues, $resourceMock);
     }
 }


### PR DESCRIPTION
Guard property import with widget type used for input value for property.

Prevent from property value duplication for resource that was causing resource to be displayed multiple times in tree view.

How to test:
1. Create property with i.e password type on one instance
2. Create resource with new property defined
3. Export resource
4. On another instance create class with property with equal type (i.e password)
5. On another instance create class with property with different type (i.e text field)
6. Import resource on different instance to class with equal property type (i.e password) 
**Expected Behaviour:** Resource will be imported
7. Import resource on different instance to class with different property type (i.e text field)
**Expected Behaviour:** Import will fail