### PR TITLE
fix: disable metadata export for APIP

### DIFF
--- a/model/Export/QTIPackedItemExporter.php
+++ b/model/Export/QTIPackedItemExporter.php
@@ -199,11 +199,14 @@ class QTIPackedItemExporter extends AbstractQTIItemExporter
             }
 
             $manifest = $this->getManifest();
-            $this->getMetadataExporter()->export($this->getItem(), $manifest);
-            $this->injectMetadataToManifest($manifest, $this->getItem());
+
+            //APIP does not support metadata at this moment
+            if(!isset($options['apip']) && $options['apip'] !== true){
+                $this->getMetadataExporter()->export($this->getItem(), $manifest);
+                $this->injectMetadataToManifest($manifest, $this->getItem());
+            }
+
             $this->setManifest($manifest);
-
-
             // -- Overwrite manifest in the current ZIP archive.
             $zipArchive->addFromString('imsmanifest.xml', $this->getManifest()->saveXML());
         } else {

--- a/model/Export/QTIPackedItemExporter.php
+++ b/model/Export/QTIPackedItemExporter.php
@@ -201,7 +201,7 @@ class QTIPackedItemExporter extends AbstractQTIItemExporter
             $manifest = $this->getManifest();
 
             //APIP does not support metadata at this moment
-            if(!isset($options['apip']) && $options['apip'] !== true){
+            if(!isset($options['apip']) || (isset($options['apip']) && $options['apip'] !== true)){
                 $this->getMetadataExporter()->export($this->getItem(), $manifest);
                 $this->injectMetadataToManifest($manifest, $this->getItem());
             }

--- a/model/Export/QTIPackedItemExporter.php
+++ b/model/Export/QTIPackedItemExporter.php
@@ -201,7 +201,7 @@ class QTIPackedItemExporter extends AbstractQTIItemExporter
             $manifest = $this->getManifest();
 
             //APIP does not support metadata at this moment
-            if(!isset($options['apip']) || (isset($options['apip']) && $options['apip'] !== true)){
+            if (!isset($options['apip']) || (isset($options['apip']) && $options['apip'] !== true)) {
                 $this->getMetadataExporter()->export($this->getItem(), $manifest);
                 $this->injectMetadataToManifest($manifest, $this->getItem());
             }


### PR DESCRIPTION
When exporting APIP package, disable metadata export. 

Metadata export for APIP will be developed soon so it will be enabled. 


How to test:
1. Export Package with APIP Content Package
2. Unzip and open file. Make sure metadata has not been included. 
3. Import APIP package

Expected behavior
Item APIP package does not contain metadata. 
Importing APIP Package is successful.  