### PR TITLE
[AUT-3641] CORE: Free form choice is not resizable in Graphic Interactions during Item Authoring

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/helpers/shapeEditor.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/shapeEditor.js
@@ -192,15 +192,13 @@ define([
                         content : parseInt(bbox.width, 10) + ' x ' + parseInt(bbox.height, 10)
                     });
 
-                    function setPointIndex(point, index){
-                        if(point.length === 3 && point[1] === this.attr('cx') && point[2] === this.attr('cy')){
-                            this.pointIndex = index;
-                            return false;
-                        }
-                    }
-
                     if(self.shape.type === 'path'){
-                        self.shape.attr('path').forEach(setPointIndex.bind(handler));
+                        self.shape.attr('path').forEach(function(point, index){
+                            if(point.length === 3 && point[1] === this.attr('cx') && point[2] === this.attr('cy')){
+                                this.pointIndex = index;
+                                return false;
+                            }
+                        }, handler);
                     }
 
                     //hide others

--- a/views/js/qtiCreator/widgets/interactions/helpers/shapeEditor.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/shapeEditor.js
@@ -181,7 +181,7 @@ define([
                     self.setState('resizing', true)
                         .trigger('shapechanging.qti-widget');
 
-                    //create a layer to be reiszed
+                    //create a layer to be resized
                     self.layer = self.shape.clone();
                     self.layer.attr(graphicHelper._style.basic);
                     self.layer.attr('cursor', handler.attrs.cursor);
@@ -192,13 +192,15 @@ define([
                         content : parseInt(bbox.width, 10) + ' x ' + parseInt(bbox.height, 10)
                     });
 
+                    function setPointIndex(point, index){
+                        if(point.length === 3 && point[1] === this.attr('cx') && point[2] === this.attr('cy')){
+                            this.pointIndex = index;
+                            return false;
+                        }
+                    }
+
                     if(self.shape.type === 'path'){
-                       _.forEach(self.shape.attr('path'), function(point, index){
-                           if(point.length === 3 && point[1] === this.attr('cx') && point[2] === this.attr('cy')){
-                                this.pointIndex = index;
-                                return false;
-                           }
-                       }, handler);
+                        self.shape.attr('path').forEach(setPointIndex.bind(handler));
                     }
 
                     //hide others


### PR DESCRIPTION
Ticket: [AUT-3641](https://oat-sa.atlassian.net/browse/AUT-3641)


## What's Changed

- Fixed error on free form points drugging, error was related missing scope after lodash migration

## Demo
![image](https://i.imgur.com/uwXYpUn.gif)

## How to test
- Launch the authoring with HotSpot interaction
- Create free form zone
- Edit it by drugging any point

[Env](http://test-kiril.playground.kitchen.it.taocloud.org:40351/) admin/admin

[AUT-3641]: https://oat-sa.atlassian.net/browse/AUT-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ