### PR TITLE
fix: pass contentEditable flag value to newly rebuild widget object f…

### DIFF
--- a/views/js/portableLib/OAT/xincludeLoader.js
+++ b/views/js/portableLib/OAT/xincludeLoader.js
@@ -1,3 +1,24 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+/**
+ * Helper for loading xinclude elements for PCI
+ */
 define(function () {
     'use strict';
 

--- a/views/js/qtiCreator/helper/xincludeRenderer.js
+++ b/views/js/qtiCreator/helper/xincludeRenderer.js
@@ -47,11 +47,11 @@ define([
          * @returns {undefined}
          */
         render: function render(xincludeWidget, baseUrl, newHref) {
+            xincludeWidget.$container.attr('contenteditable', false);
             const xinclude = xincludeWidget.element;
             if (newHref) {
                 xinclude.attr('href', newHref);
             }
-
             xincludeLoader.load(xinclude, baseUrl, function (xi, data, loadedClasses) {
                 if (data) {
                     const dataBody = data.body.body;
@@ -61,7 +61,6 @@ define([
                     if (hasClass && hasClass.groups && hasClass.groups.className) {
                         className = hasClass.groups.className;
                     }
-
                     //loading success :
                     commonRenderer.get().load(function () {
                         //set commonRenderer to the composing elements only (because xinclude is "read-only")

--- a/views/js/qtiCreator/renderers/Include.js
+++ b/views/js/qtiCreator/renderers/Include.js
@@ -40,12 +40,21 @@ define([
         options.mediaManager = this.getOption('mediaManager');
         options.assetManager = this.getAssetManager();
 
-        Widget.build(
+        let widget = Widget.build(
             include,
             containerHelper.get(include),
             this.getOption('bodyElementOptionForm'),
             options
         );
+
+        if (widget && widget.$container) {
+            widget.$container.attr('contenteditable', 'false');
+            widget.$container.css({
+                'user-select': 'none',
+                'pointer-events': 'none'
+            });
+        }
+
     };
 
     return CreatorXInclude;

--- a/views/js/qtiCreator/widgets/Widget.js
+++ b/views/js/qtiCreator/widgets/Widget.js
@@ -296,6 +296,7 @@ define([
                 //otherwise use less performance efficient selector
                 $container = $(`.widget-box[data-serial=${element.serial}]`);
             }
+            let contentEditableState = $container.attr('contenteditable');
 
             //once required data ref has been set, destroy it:
             this.destroy();
@@ -307,6 +308,7 @@ define([
                 if (renderer.name === 'creatorRenderer') {
                     element.render($container);
                     element.postRender(postRenderOpts);
+                    element.data('widget').$container.attr('contenteditable', contentEditableState);
                     return element.data('widget');
                 } else {
                     throw new Error('The renderer is no longer the creatorRenderer');


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3594
Disable xi include edition in Text reader interaction

## What's Changed
- pass contentEditable flag value to newly rebuild widget object from old one
- set xi include element editable to false

## Video

https://github.com/oat-sa/extension-tao-itemqti/assets/118974926/65c6bea3-8f45-44d5-99ae-69e0d1b6a278

