### PR TITLE
Implement UniqueNumeric identifier regeneration for imported items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=15.36.4",
-        "oat-sa/tao-core": ">=54.14.7",
+        "oat-sa/tao-core": "dev-feat/AUT-3705/uuid-qti-identifier as 54.14.7",
         "oat-sa/extension-tao-item": ">=12.0.0",
         "oat-sa/extension-tao-test": ">=16.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=15.36.4",
-        "oat-sa/tao-core": "dev-feat/AUT-3705/uuid-qti-identifier as 54.14.7",
+        "oat-sa/tao-core": ">=54.14.7",
         "oat-sa/extension-tao-item": ">=12.0.0",
         "oat-sa/extension-tao-test": ">=16.0.0"
     },

--- a/helpers/QtiXmlLoader.php
+++ b/helpers/QtiXmlLoader.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\helpers;
+
+use common_ext_ExtensionsManager as ExtensionsManager;
+use DOMDocument;
+use Exception;
+use oat\taoQtiItem\model\qti\exception\QtiModelException;
+
+class QtiXmlLoader
+{
+    private ExtensionsManager $extensionsManager;
+
+    /**
+     * @param ExtensionsManager $extensionsManager
+     */
+    public function __construct(ExtensionsManager $extensionsManager)
+    {
+        $this->extensionsManager = $extensionsManager;
+    }
+
+    /**
+     * Load QTI xml and return DOMDocument instance.
+     * This is service implementation of oat\taoQtiItem\helpers\Authoring::loadQtiXml
+     * @throws QtiModelException
+     */
+    public function load(string $xml): DOMDocument
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $this->configDomParser($dom);
+        try {
+            $dom->loadXML($xml);
+        } catch (Exception $e) {
+            throw new QtiModelException('Invalid QTI XML', 0, $e);
+        }
+
+        return $dom;
+    }
+
+    private function getQtiParserConfig(): array
+    {
+        return $this->extensionsManager->getExtensionById('taoQtiItem')
+            ->getConfig('XMLParser');
+    }
+
+    private function configDomParser(DOMDocument $dom): void
+    {
+        $parserConfig = $this->getQtiParserConfig();
+        if ($this->parserConfigValid($parserConfig)) {
+            $dom->formatOutput = $parserConfig['formatOutput'];
+            $dom->preserveWhiteSpace = $parserConfig['preserveWhiteSpace'];
+            $dom->validateOnParse = $parserConfig['validateOnParse'];
+
+            return;
+        }
+
+        $dom->formatOutput = true;
+        $dom->preserveWhiteSpace = false;
+        $dom->validateOnParse = false;
+    }
+
+    private function parserConfigValid(array $parserConfig): bool
+    {
+        return !empty($parserConfig) &&
+            isset($parserConfig['formatOutput'], $parserConfig['preserveWhiteSpace'], $parserConfig['validateOnParse']);
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -206,7 +206,6 @@ return [
         MetadataServiceProvider::class,
         MetaMetadataServiceProvider::class,
         IdentifierGenerationStrategyServiceProvider::class,
-        MetaMetadataServiceProvider::class,
         FeatureFlagQtiIdentifierServiceProvider::class,
     ],
 ];

--- a/manifest.php
+++ b/manifest.php
@@ -33,6 +33,7 @@ use oat\taoQtiItem\model\qti\CustomInteractionAsset\ServiceProvider\{
 use oat\taoQtiItem\model\FeatureFlag\ServiceProvider\FeatureFlagFlaServiceProvider;
 use oat\taoQtiItem\model\FeatureFlag\ServiceProvider\FeatureFlagQtiIdentifierServiceProvider;
 use oat\taoQtiItem\model\qti\metadata\importer\MetaMetadataServiceProvider;
+use oat\taoQtiItem\model\qti\ServiceProvider\IdentifierGenerationStrategyServiceProvider;
 use oat\taoQtiItem\model\qti\ServiceProvider\ItemIdentifierValidatorServiceProvider;
 use oat\taoQtiItem\model\qti\ServiceProvider\MetadataServiceProvider;
 use oat\taoQtiItem\scripts\install\InitMetadataService;
@@ -203,6 +204,8 @@ return [
         FeatureFlagFlaServiceProvider::class,
         ItemIdentifierValidatorServiceProvider::class,
         MetadataServiceProvider::class,
+        MetaMetadataServiceProvider::class,
+        IdentifierGenerationStrategyServiceProvider::class,
         MetaMetadataServiceProvider::class,
         FeatureFlagQtiIdentifierServiceProvider::class,
     ],

--- a/model/FeatureFlag/UniqueNumericQtiIdentifierClientConfig.php
+++ b/model/FeatureFlag/UniqueNumericQtiIdentifierClientConfig.php
@@ -37,6 +37,7 @@ class UniqueNumericQtiIdentifierClientConfig implements FeatureFlagConfigHandler
             $configs['taoQtiItem/qtiCreator/widgets/helpers/qtiIdentifier']['qtiIdPattern'] = '/^\\d{9}$/';
             $configs['taoQtiItem/qtiCreator/widgets/helpers/qtiIdentifier']['invalidQtiIdMessage'] =
                 'The QTI identifier must be a 9-digit number.';
+            $configs['taoQtiItem/qtiCreator/widgets/helpers/qtiIdentifier']['isDisabled'] = true;
         }
 
         return $configs;

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -54,6 +54,7 @@ use oat\taoQtiItem\model\qti\metadata\imsManifest\MetaMetadataExtractor;
 use oat\taoQtiItem\model\qti\metadata\MetadataGuardianResource;
 use oat\taoQtiItem\model\qti\metadata\MetadataService;
 use oat\taoQtiItem\model\qti\metadata\ontology\MappedMetadataInjector;
+use oat\taoQtiItem\model\qti\parser\UniqueNumericQtiIdentifierReplacer;
 use oat\taoQtiItem\model\qti\parser\ValidationException;
 use oat\taoQtiItem\model\event\ItemImported;
 use qtism\data\QtiComponentCollection;
@@ -187,6 +188,7 @@ class ImportService extends ConfigurableService
     protected function createQtiItemModel($qtiFile, $validate = true)
     {
         $qtiXml = Authoring::sanitizeQtiXml($qtiFile);
+        $qtiXml = $this->replaceUniqueNumericQtiIdentifier($qtiXml);
         //validate the file to import
         $qtiParser = new Parser($qtiXml);
 
@@ -951,5 +953,15 @@ class ImportService extends ConfigurableService
     private function getMetaMetadataImportMapper(): MetaMetadataImportMapper
     {
         return $this->getServiceManager()->getContainer()->get(MetaMetadataImportMapper::class);
+    }
+
+    private function getUniqueNumericQtiIdentifierReplacer(): UniqueNumericQtiIdentifierReplacer
+    {
+        return $this->getServiceManager()->getContainer()->get(UniqueNumericQtiIdentifierReplacer::class);
+    }
+
+    private function replaceUniqueNumericQtiIdentifier(string $qtiXml)
+    {
+        return $this->getUniqueNumericQtiIdentifierReplacer()->replace($qtiXml);
     }
 }

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -960,7 +960,7 @@ class ImportService extends ConfigurableService
         return $this->getServiceManager()->getContainer()->get(UniqueNumericQtiIdentifierReplacer::class);
     }
 
-    private function replaceUniqueNumericQtiIdentifier(string $qtiXml)
+    private function replaceUniqueNumericQtiIdentifier(string $qtiXml): string
     {
         return $this->getUniqueNumericQtiIdentifierReplacer()->replace($qtiXml);
     }

--- a/model/qti/ServiceProvider/IdentifierGenerationStrategyServiceProvider.php
+++ b/model/qti/ServiceProvider/IdentifierGenerationStrategyServiceProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\ServiceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use common_ext_ExtensionsManager as ExtensionsManager;
+use oat\taoQtiItem\helpers\QtiXmlLoader;
+use oat\taoQtiItem\model\qti\parser\UniqueNumericQtiIdentifierReplacer;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class IdentifierGenerationStrategyServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services->set(QtiXmlLoader::class, QtiXmlLoader::class)
+            ->args([
+                service(ExtensionsManager::SERVICE_ID)
+            ]);
+
+        $services->set(UniqueNumericQtiIdentifierReplacer::class, UniqueNumericQtiIdentifierReplacer::class)
+            ->args([
+                service(FeatureFlagChecker::class),
+                service(QtiXmlLoader::class)
+            ])
+            ->public();
+    }
+}

--- a/model/qti/parser/UniqueNumericQtiIdentifierReplacer.php
+++ b/model/qti/parser/UniqueNumericQtiIdentifierReplacer.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\parser;
+
+use DOMXPath;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\taoQtiItem\helpers\QtiXmlLoader;
+
+class UniqueNumericQtiIdentifierReplacer
+{
+    private FeatureFlagChecker $featureFlagChecker;
+    private QtiXmlLoader $qtiXmlLoader;
+
+    public function __construct(FeatureFlagChecker $featureFlagChecker, QtiXmlLoader $qtiXmlLoader)
+    {
+        $this->featureFlagChecker = $featureFlagChecker;
+        $this->qtiXmlLoader = $qtiXmlLoader;
+    }
+    public function replace(string $qti): string
+    {
+        if (!$this->featureFlagChecker->isEnabled(FeatureFlagChecker::FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER)) {
+            return $qti;
+        }
+        $doc = $this->qtiXmlLoader->load($qti);
+
+        $xpath = new DOMXpath($doc);
+        $xpath->registerNamespace('qti', 'http://www.imsglobal.org/xsd/imsqti_v2p2');
+        $identifierNodes = $xpath->query('//qti:assessmentItem/@identifier');
+
+        foreach ($identifierNodes as $identifierNode) {
+            $identifierNode->nodeValue = $this->getNumericIdentifier();
+        }
+
+        return $doc->saveXML();
+    }
+
+    private function getNumericIdentifier(): string
+    {
+        return substr((string)floor(time() / 1000), 0, 7)
+            . substr((string)floor(mt_rand(10, 100)), 0, 2);
+    }
+}

--- a/model/qti/parser/UniqueNumericQtiIdentifierReplacer.php
+++ b/model/qti/parser/UniqueNumericQtiIdentifierReplacer.php
@@ -54,6 +54,10 @@ class UniqueNumericQtiIdentifierReplacer
         return $doc->saveXML();
     }
 
+    /**
+     * This will return 9 digits unique numeric identifier base on time and random number
+     * i.e: 123456789
+     */
     private function getNumericIdentifier(): string
     {
         return substr((string)floor(time() / 1000), 0, 7)

--- a/test/unit/helpers/QtiXmlLoaderTest.php
+++ b/test/unit/helpers/QtiXmlLoaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\helpers;
+
+use common_ext_Extension as Extension;
+use DOMDocument;
+use oat\taoQtiItem\helpers\QtiXmlLoader;
+use PHPUnit\Framework\TestCase;
+use common_ext_ExtensionsManager as ExtensionsManager;
+use oat\taoQtiItem\model\qti\exception\QtiModelException;
+
+class QtiXmlLoaderTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->extensionsManagerMock = $this->createMock(ExtensionsManager::class);
+        $this->extensionMock = $this->createMock(Extension::class);
+        $this->extensionsManagerMock->method('getExtensionById')->willReturn($this->extensionMock);
+        $this->extensionMock->method('getConfig')->willReturn([
+            'formatOutput' => true,
+            'preserveWhiteSpace' => false,
+            'validateOnParse' => false,
+        ]);
+        $this->subject = new QtiXmlLoader($this->extensionsManagerMock);
+    }
+
+    public function testLoad()
+    {
+        $qti = file_get_contents(__DIR__ . '/qtiExamples/qti.xml');
+        $sub = $this->subject->load($qti);
+
+        $this->assertInstanceOf(DOMDocument::class, $sub);
+    }
+
+    public function testInvalidLoad()
+    {
+        $this->expectException(QtiModelException::class);
+        $qti = file_get_contents(__DIR__ . '/qtiExamples/invalidQti.xml');
+        $this->subject->load($qti);
+    }
+}

--- a/test/unit/helpers/qtiExamples/invalidQti.xml
+++ b/test/unit/helpers/qtiExamples/invalidQti.xml
@@ -1,0 +1,1 @@
+This cannot be loaded

--- a/test/unit/helpers/qtiExamples/qti.xml
+++ b/test/unit/helpers/qtiExamples/qti.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd" identifier="171930798" title="Item_2 1" label="Item_2 1" xml:lang="en-US" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2024.07">
+    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="identifier"/>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="0" normalMinimum="0"/>
+    <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+        <defaultValue>
+            <value>0</value>
+        </defaultValue>
+    </outcomeDeclaration>
+    <itemBody>
+        <div class="grid-row">
+            <div class="col-12">
+                <choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="0" minChoices="0" orientation="vertical">
+                    <simpleChoice identifier="choice_1" fixed="false" showHide="show">choice #1</simpleChoice>
+                    <simpleChoice identifier="choice_2" fixed="false" showHide="show">choice #2</simpleChoice>
+                    <simpleChoice identifier="choice_3" fixed="false" showHide="show">choice #3</simpleChoice>
+                </choiceInteraction>
+            </div>
+        </div>
+    </itemBody>
+    <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
+</assessmentItem>

--- a/test/unit/model/qti/parser/UniqueNumericQtiIdentifierReplacerTest.php
+++ b/test/unit/model/qti/parser/UniqueNumericQtiIdentifierReplacerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti\parser;
+
+use DOMAttr;
+use DOMDocument;
+use DOMXPath;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\taoQtiItem\helpers\QtiXmlLoader;
+use oat\taoQtiItem\model\qti\parser\UniqueNumericQtiIdentifierReplacer;
+use PHPUnit\Framework\TestCase;
+
+class UniqueNumericQtiIdentifierReplacerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->featureFlagCheckerMock = $this->createMock(FeatureFlagChecker::class);
+        $this->qtiXmlLoaderMock = $this->createMock(QtiXmlLoader::class);
+
+        $this->subject = new UniqueNumericQtiIdentifierReplacer(
+            $this->featureFlagCheckerMock,
+            $this->qtiXmlLoaderMock
+        );
+    }
+
+    public function testReplace(): void
+    {
+
+        $qti = file_get_contents(__DIR__ . '/qti.xml');
+        $this->featureFlagCheckerMock->method('isEnabled')
+            ->willReturn(true);
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML($qti);
+
+        $xpath = new DOMXpath($dom);
+        $xpath->registerNamespace('qti', 'http://www.imsglobal.org/xsd/imsqti_v2p2');
+        $identifierNodes = $xpath->query('//qti:assessmentItem/@identifier');
+        $initialValue = $identifierNodes->item(0)->nodeValue;
+
+        $this->qtiXmlLoaderMock->method('load')
+            ->willReturn($dom);
+
+        $this->subject->replace($qti);
+
+        $xpath = new DOMXpath($dom);
+        $xpath->registerNamespace('qti', 'http://www.imsglobal.org/xsd/imsqti_v2p2');
+        $identifierNodes = $xpath->query('//qti:assessmentItem/@identifier');
+        $this->assertRegExp('/\d{9}/', $identifierNodes->item(0)->nodeValue);
+        $this->assertNotEquals($initialValue, $identifierNodes->item(0)->nodeValue);
+    }
+
+    public function testReplaceWhenFeatureFlagDisabled(): void
+    {
+
+        $qti = file_get_contents(__DIR__ . '/qti.xml');
+        $this->featureFlagCheckerMock->method('isEnabled')
+            ->willReturn(false);
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML($qti);
+
+        $xpath = new DOMXpath($dom);
+        $xpath->registerNamespace('qti', 'http://www.imsglobal.org/xsd/imsqti_v2p2');
+        $identifierNodes = $xpath->query('//qti:assessmentItem/@identifier');
+        $initialValue = $identifierNodes->item(0)->nodeValue;
+
+        $this->qtiXmlLoaderMock->method('load')
+            ->willReturn($dom);
+
+        $this->subject->replace($qti);
+
+        $xpath = new DOMXpath($dom);
+        $xpath->registerNamespace('qti', 'http://www.imsglobal.org/xsd/imsqti_v2p2');
+        $identifierNodes = $xpath->query('//qti:assessmentItem/@identifier');
+        $this->assertEquals($initialValue, $identifierNodes->item(0)->nodeValue);
+    }
+}

--- a/test/unit/model/qti/parser/qti.xml
+++ b/test/unit/model/qti/parser/qti.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd" identifier="171930798" title="Item_2 1" label="Item_2 1" xml:lang="en-US" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2024.07">
+    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="identifier"/>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="0" normalMinimum="0"/>
+    <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+        <defaultValue>
+            <value>0</value>
+        </defaultValue>
+    </outcomeDeclaration>
+    <itemBody>
+        <div class="grid-row">
+            <div class="col-12">
+                <choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="0" minChoices="0" orientation="vertical">
+                    <simpleChoice identifier="choice_1" fixed="false" showHide="show">choice #1</simpleChoice>
+                    <simpleChoice identifier="choice_2" fixed="false" showHide="show">choice #2</simpleChoice>
+                    <simpleChoice identifier="choice_3" fixed="false" showHide="show">choice #3</simpleChoice>
+                </choiceInteraction>
+            </div>
+        </div>
+    </itemBody>
+    <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
+</assessmentItem>

--- a/views/js/qtiCreator/tpl/forms/item.tpl
+++ b/views/js/qtiCreator/tpl/forms/item.tpl
@@ -7,6 +7,7 @@
     <input type="text"
            name="identifier"
            value="{{identifier}}"
+           {{#if disableIdentifier}} disabled {{/if}}
            placeholder="e.g. my-item_123456"
            data-validate="$notEmpty; $qtiIdentifier(serial={{serial}}); $availableIdentifier(serial={{serial}});">
 

--- a/views/js/qtiCreator/widgets/helpers/qtiIdentifier.js
+++ b/views/js/qtiCreator/widgets/helpers/qtiIdentifier.js
@@ -24,10 +24,12 @@ define(['module', 'i18n'], function (module, __) {
     const defaultInvalidQtiIdMessage = 'Identifiers must start with a letter or an underscore and contain only letters, numbers, dots, underscores ( _ ), or hyphens ( - ).';
     const message = module.config().invalidQtiIdMessage || defaultInvalidQtiIdMessage;
     const invalidQtiIdMessage = __(message);
+    const isDisabled = module.config().isDisabled || false;
 
     return {
         pattern: new RegExp(patternContent, flags),
         invalidQtiIdMessage,
-        maxQtiIdLength: 32
+        maxQtiIdLength: 32,
+        isDisabled
     };
 });

--- a/views/js/qtiCreator/widgets/item/states/Active.js
+++ b/views/js/qtiCreator/widgets/item/states/Active.js
@@ -24,8 +24,9 @@ define([
     'taoQtiItem/qtiCreator/widgets/states/Active',
     'tpl!taoQtiItem/qtiCreator/tpl/forms/item',
     'taoQtiItem/qtiCreator/widgets/helpers/formElement',
+    'taoQtiItem/qtiCreator/widgets/helpers/qtiIdentifier',
     'select2'
-], function (_, features, languages, stateFactory, Active, formTpl, formElement ) {
+], function (_, features, languages, stateFactory, Active, formTpl, formElement, qtiIdentifier) {
     'use strict';
 
     const ItemStateActive = stateFactory.create(
@@ -38,6 +39,7 @@ define([
             const $itemBody = _widget.$container.find('.qti-itemBody');
 
             const showIdentifier = features.isVisible('taoQtiItem/creator/item/property/identifier');
+            const disableIdentifier = qtiIdentifier.isDisabled
 
             //build form:
             $form.html(
@@ -49,7 +51,8 @@ define([
                     timeDependent: !!item.attr('timeDependent'),
                     showTimeDependent: features.isVisible('taoQtiItem/creator/item/property/timeDependant'),
                     'xml:lang': item.attr('xml:lang'),
-                    languagesList: item.data('languagesList')
+                    languagesList: item.data('languagesList'),
+                    disableIdentifier
                 })
             );
 


### PR DESCRIPTION
**Description:**
  - Added a new feature where when importing an item with UniqueNumeric, the identifier will be regenerated.
  - Added a new class `QtiXmlLoader` in the `helpers` namespace to handle loading QTI XML and return DOMDocument instance.
  - Added a new service provider `IdentifierGenerationStrategyServiceProvider` to configure the generation of unique numeric identifiers.
  - Added a new class `UniqueNumericQtiIdentifierReplacer` in the `parser` namespace to replace numeric identifiers in QTI XML.
  
**Checklist:**
  - [x] Tested the `QtiXmlLoader` class using unit tests.
  - [x] Tested the `UniqueNumericQtiIdentifierReplacer` class using unit tests.
  - [x] Verified the functionality works as expected.
  - [x] Updated documentation to reflect the changes made.
  - [x] Ensured all existing tests pass.

**How to test**
1. Create item
2. Open authoring and add interaction. Check identifier value
3. Save and close item
4. Export Item
5. Import Item
6. Open Item in Authoring. 
Confirm that identifier value is different from exported item
Confirm that identifier value is 9 digits

https://github.com/oat-sa/extension-tao-itemqti/assets/16231681/b42193c1-ed29-4133-8b2f-b0b98386c1fb


