### PR TITLE
Feature/ADF-1695/Show multiple preview buttons

### DIFF
--- a/views/js/qtiCreator/plugins/menu/preview.js
+++ b/views/js/qtiCreator/plugins/menu/preview.js
@@ -123,11 +123,14 @@ define([
 
             itemCreator.on('saved', () => enablePreviewIfNotEmpty(this));
 
-            const createButton = ({id, label, title} = {}) => {
+            const createButton = ({ id, label, title } = {}) => {
+                // configured labels will need to to be registered elsewhere for the translations
+                const translate = text => text && __(text);
+
                 return $(buttonTpl({
                     icon: 'preview',
-                    title: title || __('Preview the item'),
-                    text : label || __('Preview'),
+                    title: translate(title) || __('Preview the item'),
+                    text : translate(label) || __('Preview'),
                     cssClass: 'preview-trigger',
                     testId: 'preview-the-item'
                 })).on('click', e => previewHandler(e, this, id))

--- a/views/js/qtiCreator/plugins/menu/preview.js
+++ b/views/js/qtiCreator/plugins/menu/preview.js
@@ -55,9 +55,9 @@ define([
      * Handler for preview
      * @param {Object} e - Preview event fired
      * @param {Object} plugin - Context of preview
+     * @param {string} provider - The identifier of the preview provider to use
      */
     function previewHandler(e, plugin, provider) {
-        console.log(e, plugin, provider);
         if (!$(e.currentTarget).hasClass('disabled')) {
             const itemCreator = plugin.getHost();
             $(document).trigger('open-preview.qti-item');

--- a/views/js/qtiCreator/plugins/menu/preview.js
+++ b/views/js/qtiCreator/plugins/menu/preview.js
@@ -1,4 +1,3 @@
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -31,8 +30,8 @@ define([
     'core/plugin',
     'ui/hider',
     'taoItems/previewer/factory',
-    'tpl!taoQtiItem/qtiCreator/plugins/button',
-], function(module, $, __, pluginFactory, hider, previewerFactory, buttonTpl){
+    'tpl!taoQtiItem/qtiCreator/plugins/button'
+], function (module, $, __, pluginFactory, hider, previewerFactory, buttonTpl) {
     'use strict';
 
     /**
@@ -58,7 +57,7 @@ define([
      * @param {Object} plugin - Context of preview
      */
     function previewHandler(e, plugin, provider) {
-        console.log(e, plugin, provider)
+        console.log(e, plugin, provider);
         if (!$(e.currentTarget).hasClass('disabled')) {
             const itemCreator = plugin.getHost();
             $(document).trigger('open-preview.qti-item');
@@ -93,14 +92,13 @@ define([
      * @returns {Function} the plugin
      */
     return pluginFactory({
-
-        name : 'preview',
+        name: 'preview',
 
         /**
          * Initialize the plugin (called during itemCreator's init)
          * @fires {itemCreator#preview}
          */
-        init(){
+        init() {
             const itemCreator = this.getHost();
             const config = module.config();
 
@@ -109,15 +107,20 @@ define([
              * @event itemCreator#preview
              * @param {String} uri - the uri of this item to preview
              */
-            itemCreator.on('preview', function(uri, provider) {
+            itemCreator.on('preview', function (uri, provider) {
                 const type = provider || config.provider || 'qtiItem';
 
                 if (!this.isEmpty()) {
-                    previewerFactory(type, uri, {}, {
-                        readOnly: false,
-                        fullPage: true,
-                        pluginsOptions: config.pluginsOptions
-                    });
+                    previewerFactory(
+                        type,
+                        uri,
+                        {},
+                        {
+                            readOnly: false,
+                            fullPage: true,
+                            pluginsOptions: config.pluginsOptions
+                        }
+                    );
                 }
             });
 
@@ -127,14 +130,16 @@ define([
                 // configured labels will need to to be registered elsewhere for the translations
                 const translate = text => text && __(text);
 
-                return $(buttonTpl({
-                    icon: 'preview',
-                    title: translate(title) || __('Preview the item'),
-                    text : translate(label) || __('Preview'),
-                    cssClass: 'preview-trigger',
-                    testId: 'preview-the-item'
-                })).on('click', e => previewHandler(e, this, id))
-            }
+                return $(
+                    buttonTpl({
+                        icon: 'preview',
+                        title: translate(title) || __('Preview the item'),
+                        text: translate(label) || __('Preview'),
+                        cssClass: 'preview-trigger',
+                        testId: 'preview-the-item'
+                    })
+                ).on('click', e => previewHandler(e, this, id));
+            };
 
             //creates the preview button
             this.elements = config.providers ? config.providers.map(createButton) : [createButton()];
@@ -147,7 +152,7 @@ define([
         /**
          * Initialize the plugin (called during itemCreator's render)
          */
-        render(){
+        render() {
             //attach the element to the menu area
             const $container = this.getAreaBroker().getMenuArea();
             if (this.getHost().isEmpty()) {
@@ -180,7 +185,7 @@ define([
         /**
          * Show the button
          */
-        show(){
+        show() {
             this.elements.forEach($element => hider.show($element));
         },
 

--- a/views/js/qtiCreator/plugins/menu/preview.js
+++ b/views/js/qtiCreator/plugins/menu/preview.js
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2024 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -36,20 +36,37 @@ define([
     'use strict';
 
     /**
+     * We assume the ClientLibConfigRegistry is filled up with something like this:
+     * 'taoQtiItem/qtiCreator/plugins/menu/preview' => [
+     *     'provider' => 'qtiItem',
+     * ],
+     *
+     * Or, with something like this for allowing multiple buttons in case of several providers are available:
+     * 'taoQtiItem/qtiCreator/plugins/menu/preview' => [
+     *     'provider' => 'qtiItem',
+     *     'providers' => [
+     *         ['id' => 'qtiItem', 'label' => 'Preview'],
+     *         ['id' => 'xxxx', 'label' => 'xxxx'],
+     *         ...
+     *     ],
+     * ],
+     */
+
+    /**
      * Handler for preview
      * @param {Object} e - Preview event fired
      * @param {Object} plugin - Context of preview
      */
-    function previewHandler(e, plugin) {
-        if (!plugin.$element.hasClass('disabled')) {
+    function previewHandler(e, plugin, provider) {
+        console.log(e, plugin, provider)
+        if (!$(e.currentTarget).hasClass('disabled')) {
             const itemCreator = plugin.getHost();
             $(document).trigger('open-preview.qti-item');
             e.preventDefault();
             plugin.disable();
-            itemCreator.trigger('preview', itemCreator.getItem().data('uri'));
+            itemCreator.trigger('preview', itemCreator.getItem().data('uri'), provider);
             plugin.enable();
         }
-
     }
 
     /**
@@ -83,17 +100,17 @@ define([
          * Initialize the plugin (called during itemCreator's init)
          * @fires {itemCreator#preview}
          */
-        init : function init(){
+        init(){
             const itemCreator = this.getHost();
+            const config = module.config();
 
             /**
              * Preview an item
              * @event itemCreator#preview
              * @param {String} uri - the uri of this item to preview
              */
-            itemCreator.on('preview', function(uri) {
-                const config = module.config();
-                const type = config.provider || 'qtiItem';
+            itemCreator.on('preview', function(uri, provider) {
+                const type = provider || config.provider || 'qtiItem';
 
                 if (!this.isEmpty()) {
                     previewerFactory(type, uri, {}, {
@@ -106,14 +123,18 @@ define([
 
             itemCreator.on('saved', () => enablePreviewIfNotEmpty(this));
 
+            const createButton = ({id, label, title} = {}) => {
+                return $(buttonTpl({
+                    icon: 'preview',
+                    title: title || __('Preview the item'),
+                    text : label || __('Preview'),
+                    cssClass: 'preview-trigger',
+                    testId: 'preview-the-item'
+                })).on('click', e => previewHandler(e, this, id))
+            }
+
             //creates the preview button
-            this.$element = $(buttonTpl({
-                icon: 'preview',
-                title: __('Preview the item'),
-                text : __('Preview'),
-                cssClass: 'preview-trigger',
-                testId: 'preview-the-item'
-            })).on('click', e => previewHandler(e, this));
+            this.elements = config.providers ? config.providers.map(createButton) : [createButton()];
 
             this.getAreaBroker()
                 .getItemPanelArea()
@@ -123,51 +144,48 @@ define([
         /**
          * Initialize the plugin (called during itemCreator's render)
          */
-        render : function render(){
-
+        render(){
             //attach the element to the menu area
             const $container = this.getAreaBroker().getMenuArea();
             if (this.getHost().isEmpty()) {
                 this.disable();
             }
-            $container.append(this.$element);
+            this.elements.forEach($element => $container.append($element));
         },
 
         /**
          * Called during the itemCreator's destroy phase
          */
-        destroy : function destroy (){
-            this.$element.remove();
+        destroy() {
+            this.elements.forEach($element => $element.remove());
         },
 
         /**
          * Enable the button
          */
-        enable : function enable (){
-            this.$element.removeProp('disabled')
-                         .removeClass('disabled');
+        enable() {
+            this.elements.forEach($element => $element.removeProp('disabled').removeClass('disabled'));
         },
 
         /**
          * Disable the button
          */
-        disable : function disable (){
-            this.$element.prop('disabled', true)
-                         .addClass('disabled');
+        disable() {
+            this.elements.forEach($element => $element.prop('disabled', true).addClass('disabled'));
         },
 
         /**
          * Show the button
          */
-        show: function show(){
-            hider.show(this.$element);
+        show(){
+            this.elements.forEach($element => hider.show($element));
         },
 
         /**
          * Hide the button
          */
-        hide: function hide(){
-            hider.hide(this.$element);
+        hide() {
+            this.elements.forEach($element => hider.hide($element));
         }
     });
 });


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1695

Requires: 
 - [x] https://github.com/oat-sa/extension-tao-item/pull/656

### Summary

Add the possibility of having more than one item previewer.

### Details

It supports multiple preview buttons from the item's property page.

This is made thanks to a configuration applied in `config/tao/client_lib_config_registry.conf.php`, and a change applied to the `structures.xml` file.

- **structures.xml**
Each button must be declared with an identifier starting with `item-preview`. The first button must be `item-preview`, the second `item-preview-1`, etc. The suffix number refers to a position in the configuration (see `client_lib_config_registry.conf.php`).
Example:
```xml
    <structure id="items" name="Items" level="0" group="main">
        <sections>
            <section id="manage_items" name="Manage items" url="/taoItems/Items/index">
                <actions>
                    <action id="item-preview" name="Preview" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview">
                        <icon id="icon-preview"/>
                    </action>
                    <action id="item-preview-1" name="Preview (legacy)" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview">
                        <icon id="icon-preview"/>
                    </action>
                </actions>
            </section>
        </sections>
    </structure>
```

- **client_lib_config_registry.conf.php**
The configuration can be extended with a list of possible providers, aside from the default one. This is done in `config/tao/client_lib_config_registry.conf.php`.
Example:
```php
        'taoItems/controller/items/action' => array(
            'provider' => 'qtiItemNUI',
            'providers' => array(
                array(
                    'id' => 'qtiItemNUI',
                    'label' => 'Preview'
                ),
                array(
                    'id' => 'qtiItem',
                    'label' => 'Preview (legacy)'
                )
            )
        ),
```

### How to test

- checkout the branch: `git checkout -t origin/feature/ADF-1695/multiple-preview-buttons`
- also checkout the branches from the companion PR
- make sure to have set the appropriate configuration (check the details in the ticket)