### PR TITLE
Fix/AUT-1141/Unwanted confirm exit dialog

### DIFF
--- a/views/js/qtiCreator/editor/styleEditor/styleSheetToggler.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleSheetToggler.js
@@ -91,7 +91,7 @@ define([
                     uploadUrl: itemConfig.fileUploadUrl,
                     deleteUrl: itemConfig.fileDeleteUrl,
                     downloadUrl: itemConfig.fileDownloadUrl,
-                    fileExistsUrl : itemConfig.fileExistsUrl,
+                    fileExistsUrl: itemConfig.fileExistsUrl,
                     params: {
                         uri: itemConfig.uri,
                         lang: itemConfig.lang,
@@ -103,6 +103,21 @@ define([
                         for (i = 0; i < l; i++) {
                             styleEditor.addStylesheet(files[i].file);
                         }
+                    },
+                    close: function () {
+                        $('#mediaManager').off('filedelete.resourcemgr');
+                    }
+                });
+
+                // watch for file deletion inside the media manager that are related to a linked stylesheet
+                $('#mediaManager').on('filedelete.resourcemgr', function (e, file) {
+                    if (file.startsWith('/')) {
+                        file = file.substring(1);
+                    }
+
+                    const $style = cssToggler.find(`[data-css-res="${file}"]`);
+                    if ($style.length) {
+                        deleteStylesheet($style);
                     }
                 });
             });

--- a/views/js/qtiCreator/editor/styleEditor/styleSheetToggler.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleSheetToggler.js
@@ -98,24 +98,25 @@ define([
                         filters: 'text/css'
                     },
                     pathParam: 'path',
-                    select: function (e, files) {
+                    select(e, files) {
                         var i, l = files.length;
                         for (i = 0; i < l; i++) {
                             styleEditor.addStylesheet(files[i].file);
                         }
                     },
-                    close: function () {
+                    close() {
                         $('#mediaManager').off('filedelete.resourcemgr');
                     }
                 });
 
                 // watch for file deletion inside the media manager that are related to a linked stylesheet
-                $('#mediaManager').on('filedelete.resourcemgr', function (e, file) {
+                $('#mediaManager').on('filedelete.resourcemgr', (e, file) => {
+                    const filePath = [file]
                     if (file.startsWith('/')) {
-                        file = file.substring(1);
+                        filePath.push(file.substring(1));
                     }
 
-                    const $style = cssToggler.find(`[data-css-res="${file}"]`);
+                    const $style = cssToggler.find(filePath.map(path => `[data-css-res="${path}"]`).join(', '));
                     if ($style.length) {
                         deleteStylesheet($style);
                     }

--- a/views/js/qtiCreator/helper/changeTracker.js
+++ b/views/js/qtiCreator/helper/changeTracker.js
@@ -119,6 +119,7 @@ define([
                 // every click outside the authoring (except feedback message)
                 $(wrapperSelector).on(`click${eventNS}`, e => {
                     if (
+                        e.target.isConnected && // check if the target is still in the DOM, if not there is no need to check further since parent will be null
                         !$.contains(container, e.target) &&
                         !$(e.target).parents('#feedback-box').length &&
                         !$(e.target).parents('.outcome-container').length &&


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/AUT-1141

### Summary

Prevent from applying the confirm exit dialog if the click was made inside a detached element.

Also added a fix for removing linked CSS from the resource manager.

### Details

The root cause is the same for several cases when the confirm dialog is shown after a click inside the item authoring. For example when adding/removing a feedback.

When a change is made to the item and a click is detected on the page, the change tracker tries to identify if the clicked element belong to the item creator or is outside. The confirm dialog is shown if the click is considered outside. However, if the clicked element has been detached from the DOM, it becomes impossible to know if it was belonging to the item creator before its removal, and therefore the click is considered as outside…

To fix the issue, we need to discard the detached elements from the check.

### How to test

- checkout the branch: `git checkout -t origin/fix/AUT-1141/unwanted-confirm-exit-dialog`
- author an item and add a stylesheet
- save the item
- remove the stylesheet: no confirm dialog should pop up
- enter in answer mode, then add feedbacks (both if and else): no confirm dialog should pop up
- remove the feedbacks: : no confirm dialog should pop up
- click the add stylesheet button, then delete the stylesheet from the resource manager: it should also remove the stylesheet from the item
