### PR TITLE
Backport fix/AUT-3833/backport-import-metadata-fix

### DIFF
--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -330,7 +330,7 @@ class ImportService extends ConfigurableService
             /** @var Resource[] $qtiItemResources */
             $qtiItemResources = $this->createQtiManifest($folder . 'imsmanifest.xml');
 
-            if($importMetadataEnabled) {
+            if ($importMetadataEnabled) {
                 $metadataValues = $this->getMetadataImporter()->extract($domManifest);
                 $metaMetadataValues = $this->getMetaMetadataExtractor()->extract($domManifest);
                 $mappedMetadataValues = $this->getMetaMetadataImportMapper()->mapMetaMetadataToProperties(

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -330,12 +330,14 @@ class ImportService extends ConfigurableService
             /** @var Resource[] $qtiItemResources */
             $qtiItemResources = $this->createQtiManifest($folder . 'imsmanifest.xml');
 
-            $metadataValues = $this->getMetadataImporter()->extract($domManifest);
-            $metaMetadataValues = $this->getMetaMetadataExtractor()->extract($domManifest);
-            $mappedMetadataValues = $this->getMetaMetadataImportMapper()->mapMetaMetadataToProperties(
-                $metaMetadataValues,
-                $itemClass
-            );
+            if($importMetadataEnabled) {
+                $metadataValues = $this->getMetadataImporter()->extract($domManifest);
+                $metaMetadataValues = $this->getMetaMetadataExtractor()->extract($domManifest);
+                $mappedMetadataValues = $this->getMetaMetadataImportMapper()->mapMetaMetadataToProperties(
+                    $metaMetadataValues,
+                    $itemClass
+                );
+            }
 
             $sharedFiles = [];
             $createdClasses = [];
@@ -347,14 +349,14 @@ class ImportService extends ConfigurableService
                     $itemClass,
                     $sharedFiles,
                     [],
-                    $metadataValues,
+                    $metadataValues ?? [],
                     $createdClasses,
                     $enableMetadataGuardians,
                     $enableMetadataValidators,
                     $itemMustExist,
                     $itemMustBeOverwritten,
                     $overwrittenItems,
-                    $mappedMetadataValues['itemProperties'],
+                    isset($mappedMetadataValues['itemProperties']) ? $mappedMetadataValues['itemProperties'] : [],
                     $importMetadataEnabled
                 );
 


### PR DESCRIPTION
This will fix issue where user does not check QTI metadata as properties but metadata property is still imported and may fail when property does not exist.

Backport: https://github.com/oat-sa/extension-tao-itemqti/pull/2570