### PR TITLE
Allow Exporting items with Textbox property equal 0

### DIFF
--- a/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
+++ b/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
@@ -100,6 +100,7 @@ class LabelBasedLomOntologyClassificationExtractor implements MetadataExtractor
     private function getResourceValue(Triple $triple): string
     {
         if (
+            !empty($triple->object) &&
             $this->getResource($triple->object)->exists()
             && $this->getResource($triple->object)->getLabel() !== ''
         ) {

--- a/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
+++ b/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
@@ -99,6 +99,10 @@ class LabelBasedLomOntologyClassificationExtractor implements MetadataExtractor
 
     private function getResourceValue(Triple $triple): string
     {
+        if ($triple->object === null) {
+            return '';
+        }
+
         if (
             !empty($triple->object) &&
             $this->getResource($triple->object)->exists()

--- a/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
+++ b/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
@@ -105,8 +105,8 @@ class LabelBasedLomOntologyClassificationExtractor implements MetadataExtractor
 
         if (
             !empty($triple->object) &&
-            $this->getResource($triple->object)->exists()
-            && $this->getResource($triple->object)->getLabel() !== ''
+            $this->getResource($triple->object)->exists() &&
+            $this->getResource($triple->object)->getLabel() !== ''
         ) {
             return $this->getResource($triple->object)->getLabel();
         }

--- a/test/unit/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractorTest.php
+++ b/test/unit/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractorTest.php
@@ -47,15 +47,27 @@ class LabelBasedLomOntologyClassificationExtractorTest extends TestCase
     {
         $resourceMock = $this->createMock(Resource::class);
         $resourceMock->method('getUri')->willReturn('uri#identifier');
-        $rdfTriple = $this->createMock(Triple::class);
+
+        //Should be exported
+        $rdfTripleUri = $this->createMock(Triple::class);
+        $rdfTripleUri->object = 'ResourceUri';
+
+        //Should be iported
+        $rdfTriple0 = $this->createMock(Triple::class);
+        $rdfTriple0->object = '0';
+
+        //Should be ignored
+        $rdfTripleNull = $this->createMock(Triple::class);
+        $rdfTripleNull->object = null;
+
         $propertyMock = $this->createMock(Property::class);
 
         $resourceMock
             ->method('getRdfTriples')
             ->willReturn([
-                $rdfTriple,
-                $rdfTriple,
-                $rdfTriple
+                $rdfTripleUri,
+                $rdfTriple0,
+                $rdfTripleNull
             ]);
         $this->ontologyMock
             ->method('getProperty')
@@ -83,7 +95,7 @@ class LabelBasedLomOntologyClassificationExtractorTest extends TestCase
         $result = $this->subject->extract($resourceMock);
         self::assertIsArray($result);
         self::assertArrayHasKey('identifier', $result);
-        self::assertEquals(3, count($result['identifier']));
+        self::assertEquals(2, count($result['identifier']));
         foreach ($result['identifier'] as $classificationMetadataValue) {
             self::assertInstanceOf(ClassificationMetadataValue::class, $classificationMetadataValue);
             self::assertEquals(5, count($classificationMetadataValue->getPath()));


### PR DESCRIPTION
When Item has a text property equal 0 when exporting it will cause error and Package cannot be exported