### PR TITLE
Properties without range will throw exception

### DIFF
--- a/model/import/ChecksumGenerator.php
+++ b/model/import/ChecksumGenerator.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\taoQtiItem\model\import;
 
 use core_kernel_classes_Property as Property;
+use InvalidArgumentException;
 use oat\taoBackOffice\model\lists\ListService;
 
 class ChecksumGenerator
@@ -36,6 +37,10 @@ class ChecksumGenerator
 
     public function getRangeChecksum(Property $property): string
     {
+        if ($property->getRange() === null) {
+            throw new InvalidArgumentException('Property range is not set');
+        }
+
         $labels = [];
         foreach ($this->listService->getListElements($property->getRange()) as $listEntry) {
             $labels[] = strtolower($listEntry->getLabel());

--- a/model/import/ChecksumGenerator.php
+++ b/model/import/ChecksumGenerator.php
@@ -38,7 +38,12 @@ class ChecksumGenerator
     public function getRangeChecksum(Property $property): string
     {
         if ($property->getRange() === null) {
-            throw new InvalidArgumentException('Property range is not set');
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Property %s does not have range set. Only properties with range can have checksum',
+                    $property->getUri()
+                )
+            );
         }
 
         $labels = [];

--- a/test/unit/model/import/ChecksumGeneratorTest.php
+++ b/test/unit/model/import/ChecksumGeneratorTest.php
@@ -78,7 +78,9 @@ class ChecksumGeneratorTest extends TestCase
     public function testThrowExceptionOnPropertyWithoutRange(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Property propertyUri does not have range set. Only properties with range can have checksum');
+        $this->expectExceptionMessage(
+            'Property propertyUri does not have range set. Only properties with range can have checksum'
+        );
         $this->propertyMock->method('getRange')->willReturn(null);
         $this->propertyMock->method('getUri')->willReturn('propertyUri');
 

--- a/test/unit/model/import/ChecksumGeneratorTest.php
+++ b/test/unit/model/import/ChecksumGeneratorTest.php
@@ -25,7 +25,7 @@ namespace oat\taoQtiItem\test\unit\model\import;
 use core_kernel_classes_Class as ClassResource;
 use core_kernel_classes_Property as Property;
 use core_kernel_classes_Resource as Resource;
-use oat\generis\model\data\Ontology;
+use InvalidArgumentException;
 use oat\taoBackOffice\model\lists\ListService;
 use oat\taoQtiItem\model\import\ChecksumGenerator;
 use PHPUnit\Framework\TestCase;
@@ -73,5 +73,14 @@ class ChecksumGeneratorTest extends TestCase
             'c315a4bd4fa0f4479b1ea4b5998aa548eed3b670',
             $this->checksumGenerator->getRangeChecksum($this->propertyMock)
         );
+    }
+
+    public function testThrowExceptionOnPropertyWithoutRange(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Property range is not set');
+        $this->propertyMock->method('getRange')->willReturn(null);
+
+        $this->checksumGenerator->getRangeChecksum($this->propertyMock);
     }
 }

--- a/test/unit/model/import/ChecksumGeneratorTest.php
+++ b/test/unit/model/import/ChecksumGeneratorTest.php
@@ -78,8 +78,9 @@ class ChecksumGeneratorTest extends TestCase
     public function testThrowExceptionOnPropertyWithoutRange(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Property range is not set');
+        $this->expectExceptionMessage('Property propertyUri does not have range set. Only properties with range can have checksum');
         $this->propertyMock->method('getRange')->willReturn(null);
+        $this->propertyMock->method('getUri')->willReturn('propertyUri');
 
         $this->checksumGenerator->getRangeChecksum($this->propertyMock);
     }


### PR DESCRIPTION
In order to defenese ChecksumGenerator service from passing property without range