### PR TITLE
fix: improve external scoring

### DIFF
--- a/views/js/qtiCreator/plugins/panel/outcomeEditor.js
+++ b/views/js/qtiCreator/plugins/panel/outcomeEditor.js
@@ -93,7 +93,7 @@ define([
      * @param {Object} item
      * @param {JQuery} $outcomeEditorPanel
      */
-    function renderListing(item, $outcomeEditorPanel) {
+    function renderListing(item, $outcomeEditorPanel, isNewItem = false) {
         const readOnlyRpVariables = getRpUsedVariables(item);
         const scoreMaxScoreVisible = features.isVisible('taoQtiItem/creator/interaction/response/outcomeDeclarations/scoreMaxScore');
         const scoreExternalScored = _.get(_.find(item.outcomes, function (outcome) {
@@ -154,7 +154,7 @@ define([
                     : __('Delete'),
                 titleEdit: readonly ? __('Cannot edit a variable currently used in response processing') : __('Edit'),
                 readonly: readonly,
-                externalScoredDisabled: externalScoredDisabled || 0
+                externalScoredDisabled: isNewItem ? (externalScoredDisabled || 0) : 0
             };
         });
 
@@ -199,7 +199,7 @@ define([
         }
     };
 
-    function hasAllNotExternalScored(outcomes) {
+    function hasAnyNotExternalScored(outcomes) {
         return _.every(outcomes, function (outcome) {
             return outcome.attributes &&
             outcome.attributes.externalScored === externalScoredOptions.none
@@ -241,9 +241,10 @@ define([
         // Iterate over each element in responsePanel and check if any value != none
         responsePanel.find('.outcome-container').each(function () {
             const currentSerial = $(this).data('serial');
+            const id = $(this).find(".identifier").val();
 
             // Skip the element with the same serial, as we're focusing on other elements
-            if (currentSerial === serial) {
+            if (currentSerial === serial || id === 'SCORE') {
                 return;
             }
 
@@ -339,10 +340,6 @@ define([
 
                             // shows tooltips in case of invalid value
                             showScoringTraitWarningOnInvalidValue();
-                        }
-
-                        if (hasAllNotExternalScored(item.outcome)) {
-                            $outcomeContainer.find("select[name='externalScored']").attr('disabled', false);
                         }
 
                         //attach form change callbacks
@@ -503,7 +500,7 @@ define([
                         newOutcome.buildIdentifier('OUTCOME');
 
                         //refresh the list
-                        renderListing(item, $outcomeEditorPanel);
+                        renderListing(item, $outcomeEditorPanel, true);
                     });
 
                 //attach to response form side panel


### PR DESCRIPTION
The main issue:

https://github.com/user-attachments/assets/203a8d23-5566-400b-9079-10a1dde79dc4

How to test:
1. import the item where we have SCORE and Outcome with external scoring [000000000_qa_14_2_1730288277.zip](https://github.com/user-attachments/files/17647511/000000000_qa_14_2_1730288277.zip)
2. Try to open it and check that all external scoring options were set to none automatically
3. Check that disabling works as expected, and you can have only one external SCORE or only custom outcomes setted with external 

Demo:
https://github.com/user-attachments/assets/16876028-5019-4bbc-b189-2f054308bbd9

