### PR TITLE
Fix/ADF-1801/broken unit test

### DIFF
--- a/views/js/test/qtiCreator/component/itemAuthoring/test.js
+++ b/views/js/test/qtiCreator/component/itemAuthoring/test.js
@@ -46,6 +46,7 @@ define([
             responseText: {
                 itemIdentifier: 'item-1',
                 itemData: {
+                    identifier: 'item-1',
                     content: {
                         type: 'qti',
                         data: itemData


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1801

### Summary

The unit tests failed because now the item identifier needs to be supplied by the server.