### PR TITLE
REL-1884: Delivery cannot be published when test contains Item with rich passages

### DIFF
--- a/model/Export/Stylesheet/AssetStylesheetLoader.php
+++ b/model/Export/Stylesheet/AssetStylesheetLoader.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\model\Export\Stylesheet;
 
+use League\Flysystem\StorageAttributes;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\filesystem\FilesystemException;
 use oat\oatbox\filesystem\FilesystemInterface;
@@ -52,13 +53,16 @@ class AssetStylesheetLoader extends ConfigurableService
             $stylesheetPath = $this->buildAssetPathFromPropertyName($property);
             try {
                 $cssFiles = $this->getFileSystem()->listContents($stylesheetPath)->toArray();
+                $cssFilesInfo = [];
+
                 foreach ($cssFiles as $key => $file) {
-                    $cssFiles[$key]['stream'] = $this->getFileSystem()->readStream(
+                    $cssFilesInfo[$key] = $file instanceof StorageAttributes ? $file->jsonSerialize() : $file;
+                    $cssFilesInfo[$key]['stream'] = $this->getFileSystem()->readStream(
                         $stylesheetPath . DIRECTORY_SEPARATOR . basename($file['path'])
                     );
                 }
 
-                return $cssFiles;
+                return $cssFilesInfo;
             } catch (FilesystemException $exception) {
                 $this->getLogger()->notice(
                     sprintf(
@@ -80,7 +84,7 @@ class AssetStylesheetLoader extends ConfigurableService
             DIRECTORY_SEPARATOR,
             [
                 dirname($property),
-                self::ASSET_CSS_DIRECTORY_NAME
+                self::ASSET_CSS_DIRECTORY_NAME,
             ]
         );
     }

--- a/test/unit/model/Export/Stylesheet/AssetStylesheetLoaderTest.php
+++ b/test/unit/model/Export/Stylesheet/AssetStylesheetLoaderTest.php
@@ -25,6 +25,7 @@ namespace oat\taoQtiItem\test\unit\model\Export\Stylesheet;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use League\Flysystem\DirectoryListing;
+use League\Flysystem\FileAttributes;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\oatbox\filesystem\FileSystem;
@@ -98,12 +99,11 @@ class AssetStylesheetLoaderTest extends TestCase
         $fileInfo = [
             'type' => 'file',
             'path' => 'dummy/path/file.css',
-            'timestamp' => 1654502842,
-            'size' => 0,
-            'dirname' => 'dummy/path',
-            'basename' => 'file.css',
-            'extension' => 'css',
-            'filename' => 'file',
+            'last_modified' => 1654502842,
+            'file_size' => 0,
+            'mime_type' => 'css',
+            'visibility' => 'public',
+            'extra_metadata' => [],
         ];
 
         $fileStream = "file stream resource";
@@ -111,7 +111,7 @@ class AssetStylesheetLoaderTest extends TestCase
         $this->fileSystemMock
             ->expects($this->once())
             ->method('listContents')
-            ->willReturn(new DirectoryListing([$fileInfo]));
+            ->willReturn(new DirectoryListing([FileAttributes::fromArray($fileInfo)]));
 
         $this->fileSystemMock
             ->expects($this->once())

--- a/test/unit/model/compile/XIncludeAdditionalAssetInjectorTest.php
+++ b/test/unit/model/compile/XIncludeAdditionalAssetInjectorTest.php
@@ -43,7 +43,7 @@ class XIncludeAdditionalAssetInjectorTest extends TestCase
     private const RESOURCE_ID_FIXTURE = 'fixture-id';
 
     private const STYLESHEETS_LOADER_FILE = [
-        'basename' => 'file.css',
+        'path' => 'file.css',
         'stream' => 'dummy resource string'
     ];
 
@@ -113,9 +113,9 @@ class XIncludeAdditionalAssetInjectorTest extends TestCase
                 'href' => implode(DIRECTORY_SEPARATOR, [
                     $this->subject::COMPILED_PASSAGE_STYLESHEET_FILENAME_PREFIX,
                     AssetStylesheetLoader::ASSET_CSS_DIRECTORY_NAME,
-                    self::STYLESHEETS_LOADER_FILE['basename']
+                    self::STYLESHEETS_LOADER_FILE['path']
                 ]),
-                'title' => self::STYLESHEETS_LOADER_FILE['basename'],
+                'title' => self::STYLESHEETS_LOADER_FILE['path'],
                 'type' => 'text/css'
             ],
             null,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/REL-1884

Steps to reproduce:
1. Go to "Deliveries" page
2. Click "New delivery" button below the Deliveries tree
3. Enter the title of Test from preconditions in the "Select the test" field (3 or more characters)
4. Click "Publish" button

The issue was connected to the interface change in the `\League\Flysystem\ProxyArrayAccessToProperties::offsetSet`. In the new version, it doesn't allow you to set new or change an existing property of the object and throws an exception in case you try to do it.