### PR TITLE
feat: handle translatable status with empty content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=15.39.0",
-        "oat-sa/tao-core": ">=54.23.0",
+        "oat-sa/tao-core": "dev-feat/ADF-1826/avoid-empty-translation as 99.99",
         "oat-sa/extension-tao-item": ">=12.4.0",
         "oat-sa/extension-tao-test": ">=16.3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "naneau/semver": "~0.0.7",
         "oat-sa/generis": ">=15.39.0",
-        "oat-sa/tao-core": "dev-feat/ADF-1826/avoid-empty-translation as 99.99",
+        "oat-sa/tao-core": "dev-feat/HKD-6/integration as 99.99",
         "oat-sa/extension-tao-item": ">=12.4.0",
         "oat-sa/extension-tao-test": ">=16.3.0"
     },

--- a/model/Translation/Service/ResourceTranslatableStatusHandler.php
+++ b/model/Translation/Service/ResourceTranslatableStatusHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\Translation\Service;
+
+use oat\generis\model\data\Ontology;
+use oat\tao\model\Translation\Entity\ResourceTranslatableStatus;
+use oat\taoQtiItem\model\qti\Item;
+use oat\taoQtiItem\model\qti\Service;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class ResourceTranslatableStatusHandler
+{
+    private Service $qtiItemService;
+    private LoggerInterface $logger;
+    private Ontology $ontology;
+
+    public function __construct(Service $qtiItemService, LoggerInterface $logger, Ontology $ontology)
+    {
+        $this->qtiItemService = $qtiItemService;
+        $this->logger = $logger;
+        $this->ontology = $ontology;
+    }
+
+    public function __invoke(ResourceTranslatableStatus $status): void
+    {
+        try {
+            $item = $this->ontology->getResource($status->getUri());
+
+            $itemData = $this->qtiItemService->getDataItemByRdfItem($item);
+
+            $status->setEmpty(!$itemData || $itemData->isEmpty());
+        } catch (Throwable $exception) {
+            $this->logger->error(
+                sprintf(
+                    'An error occurred while retrieving item data: %s. Trace: %s',
+                    $exception->getMessage(),
+                    $exception->getTraceAsString()
+                )
+            );
+
+            throw $exception;
+        }
+    }
+}

--- a/model/Translation/ServiceProvider/TranslationServiceProvider.php
+++ b/model/Translation/ServiceProvider/TranslationServiceProvider.php
@@ -27,12 +27,14 @@ use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\log\LoggerService;
 use oat\tao\model\TaoOntology;
 use oat\tao\model\Translation\Service\ResourceLanguageRetriever;
+use oat\tao\model\Translation\Service\ResourceTranslatableStatusRetriever;
 use oat\tao\model\Translation\Service\TranslationCreationService;
 use oat\tao\model\Translation\Service\TranslationUniqueIdSetter;
 use oat\taoQtiItem\model\qti\Identifier\Service\QtiIdentifierSetter;
 use oat\taoQtiItem\model\qti\Service;
 use oat\taoQtiItem\model\Translation\Service\QtiLanguageRetriever;
 use oat\taoQtiItem\model\Translation\Service\QtiLanguageSetter;
+use oat\taoQtiItem\model\Translation\Service\ResourceTranslatableStatusHandler;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use tao_models_classes_LanguageService;
 
@@ -71,6 +73,14 @@ class TranslationServiceProvider implements ContainerServiceProviderInterface
             ]);
 
         $services
+            ->set(ResourceTranslatableStatusHandler::class, ResourceTranslatableStatusHandler::class)
+            ->args([
+                service(Service::class),
+                service(LoggerService::SERVICE_ID),
+                service(Ontology::SERVICE_ID),
+            ]);
+
+        $services
             ->get(TranslationUniqueIdSetter::class)
             ->call(
                 'addQtiIdentifierSetter',
@@ -94,6 +104,16 @@ class TranslationServiceProvider implements ContainerServiceProviderInterface
                 [
                     TaoOntology::CLASS_URI_ITEM,
                     service(TranslationUniqueIdSetter::class),
+                ]
+            );
+
+        $services
+            ->get(ResourceTranslatableStatusRetriever::class)
+            ->call(
+                'addCallable',
+                [
+                    TaoOntology::CLASS_URI_ITEM,
+                    service(ResourceTranslatableStatusHandler::class),
                 ]
             );
     }

--- a/model/qti/Item.php
+++ b/model/qti/Item.php
@@ -759,4 +759,9 @@ class Item extends IdentifiedElement implements FlowContainer, IdentifiedElement
             throw new \Exception('ExternalScored attribute is not allowed for multiple outcomes in item');
         }
     }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->getBody()) || strpos((string)$this->getBody(), '<div class="empty"') !== false;
+    }
 }

--- a/test/unit/model/Translation/Service/ResourceTranslatableStatusHandlerTest.php
+++ b/test/unit/model/Translation/Service/ResourceTranslatableStatusHandlerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\Translation\Service;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\tao\model\TaoOntology;
+use oat\tao\model\Translation\Entity\ResourceTranslatableStatus;
+use oat\taoQtiItem\model\qti\Item;
+use oat\taoQtiItem\model\qti\Service;
+use oat\taoQtiItem\model\Translation\Service\ResourceTranslatableStatusHandler;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ResourceTranslatableStatusHandlerTest extends TestCase
+{
+    /** @var core_kernel_classes_Resource|MockObject */
+    private core_kernel_classes_Resource $item;
+
+    /** @var Service|MockObject */
+    private Service $qtiItemService;
+
+    /** @var LoggerInterface|MockObject */
+    private LoggerInterface $logger;
+
+    /** @var Ontology|MockObject */
+    private Ontology $ontology;
+
+    private ResourceTranslatableStatus $status;
+    private ResourceTranslatableStatusHandler $sut;
+
+    protected function setUp(): void
+    {
+        $this->item = $this->createMock(core_kernel_classes_Resource::class);
+        $this->item
+            ->method('getUri')
+            ->willReturn('itemUri');
+
+        $this->qtiItemService = $this->createMock(Service::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->ontology = $this->createMock(Ontology::class);
+
+        $this->status = new ResourceTranslatableStatus(
+            'itemUri',
+            TaoOntology::CLASS_URI_ITEM,
+            true,
+            true
+        );
+
+        $this->sut = new ResourceTranslatableStatusHandler(
+            $this->qtiItemService,
+            $this->logger,
+            $this->ontology
+        );
+    }
+
+    public function testWillSetEmptyToFalseIfItemHasContent(): void
+    {
+        $itemData = $this->createMock(Item::class);
+        $itemData
+            ->expects($this->once())
+            ->method('isEmpty')
+            ->willReturn(false);
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
+            ->with('itemUri')
+            ->willReturn($this->item);
+
+        $this->qtiItemService
+            ->expects($this->once())
+            ->method('getDataItemByRdfItem')
+            ->with($this->item)
+            ->willReturn($itemData);
+
+        $this->assertTrue($this->status->isEmpty());
+
+        $this->sut->__invoke($this->status);
+
+        $this->assertFalse($this->status->isEmpty());
+    }
+
+    public function testWillSetEmptyToTrueIfItemHasEmptyContentSaved(): void
+    {
+        $itemData = $this->createMock(Item::class);
+        $itemData
+            ->expects($this->once())
+            ->method('isEmpty')
+            ->willReturn(true);
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
+            ->with('itemUri')
+            ->willReturn($this->item);
+
+        $this->qtiItemService
+            ->expects($this->once())
+            ->method('getDataItemByRdfItem')
+            ->with($this->item)
+            ->willReturn($itemData);
+
+        $this->sut->__invoke($this->status);
+
+        $this->assertTrue($this->status->isEmpty());
+    }
+
+    public function testWillSetEmptyToTrueIfItemHasNoContent(): void
+    {
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
+            ->with('itemUri')
+            ->willReturn($this->item);
+
+        $this->qtiItemService
+            ->expects($this->once())
+            ->method('getDataItemByRdfItem')
+            ->with($this->item)
+            ->willReturn(null);
+
+        $this->sut->__invoke($this->status);
+
+        $this->assertTrue($this->status->isEmpty());
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1826

# Goal 

- Feed translation status based on item content

# Related PRs

- https://github.com/oat-sa/tao-core/pull/4134
- https://github.com/oat-sa/extension-tao-testqti/pull/2530

# TODO 

- [ ] Update composer with tao-core version 