### PR TITLE
fix: handle import of props without metadata

### DIFF
--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -337,6 +337,12 @@ class ImportService extends ConfigurableService
                     $metaMetadataValues,
                     $itemClass
                 );
+                if (empty($mappedMetadataValues)) {
+                    $mappedMetadataValues = $this->getMetaMetadataImportMapper()->mapMetadataToProperties(
+                        $metadataValues,
+                        $itemClass
+                    );
+                }
             }
 
             $sharedFiles = [];

--- a/model/qti/metadata/importer/MetaMetadataImportMapper.php
+++ b/model/qti/metadata/importer/MetaMetadataImportMapper.php
@@ -63,8 +63,7 @@ class MetaMetadataImportMapper
         array $metadataProperties,
         kernelClass $itemClass,
         kernelClass $testClass = null
-    ): array
-    {
+    ): array {
         $parsedMetadataProperties = [];
         foreach ($metadataProperties as $metadataProperty) {
             foreach ($metadataProperty as $property) {

--- a/model/qti/metadata/importer/MetaMetadataImportMapper.php
+++ b/model/qti/metadata/importer/MetaMetadataImportMapper.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\model\qti\metadata\importer;
 
-use core_kernel_classes_Class;
+use core_kernel_classes_Class as kernelClass;
 use core_kernel_classes_Property as Property;
 use core_kernel_classes_Resource;
 use InvalidArgumentException;
@@ -40,8 +40,8 @@ class MetaMetadataImportMapper
 
     public function mapMetaMetadataToProperties(
         array $metaMetadataProperties,
-        core_kernel_classes_Class $itemClass,
-        core_kernel_classes_Class $testClass = null
+        kernelClass $itemClass,
+        kernelClass $testClass = null
     ): array {
         $matchedProperties = [];
         foreach ($metaMetadataProperties as $metaMetadataProperty) {
@@ -49,14 +49,21 @@ class MetaMetadataImportMapper
                 $matchedProperties['itemProperties'][$metaMetadataProperty['uri']] = $match;
             }
 
-            if ($testClass && $match = $this->matchProperty($metaMetadataProperty, $testClass->getProperties(true))) {
+            if (
+                $testClass &&
+                $match = $this->matchProperty($metaMetadataProperty, $testClass->getProperties(true))
+            ) {
                 $matchedProperties['testProperties'][$metaMetadataProperty['uri']] = $match;
             }
         }
         return $matchedProperties;
     }
 
-    public function mapMetadataToProperties(array $metadataProperties, core_kernel_classes_Class $itemClass, core_kernel_classes_Class $testClass = null): array
+    public function mapMetadataToProperties(
+        array $metadataProperties,
+        kernelClass $itemClass,
+        kernelClass $testClass = null
+    ): array
     {
         $parsedMetadataProperties = [];
         foreach ($metadataProperties as $metadataProperty) {

--- a/model/qti/metadata/importer/MetaMetadataImportMapper.php
+++ b/model/qti/metadata/importer/MetaMetadataImportMapper.php
@@ -25,6 +25,7 @@ namespace oat\taoQtiItem\model\qti\metadata\importer;
 use core_kernel_classes_Class;
 use core_kernel_classes_Property as Property;
 use core_kernel_classes_Resource;
+use InvalidArgumentException;
 use oat\generis\model\GenerisRdf;
 use oat\taoQtiItem\model\import\ChecksumGenerator;
 
@@ -94,7 +95,7 @@ class MetaMetadataImportMapper
         $multiple = $classProperty->getOnePropertyValue(new Property(GenerisRdf::PROPERTY_MULTIPLE));
         try {
             $checksum = $this->checksumGenerator->getRangeChecksum($classProperty);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             return false;
         }
         $metaMetadataProperty['checksum_result'] = $checksum === $metaMetadataProperty['checksum'];

--- a/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
+++ b/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
@@ -143,7 +143,10 @@ class MetaMetadataImportMapperTest extends TestCase
         $result = $this->subject->mapMetadataToProperties($metadataProperties, $itemClass);
 
         $this->assertArrayHasKey('itemProperties', $result);
-        $this->assertInstanceOf(core_kernel_classes_Property::class, $result['itemProperties']['http://example.com/uri1']);
+        $this->assertInstanceOf(
+            core_kernel_classes_Property::class,
+            $result['itemProperties']['http://example.com/uri1']
+        );
     }
 
     public function testHandlesInvalidArgumentExceptionInIsSynced(): void

--- a/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
+++ b/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
@@ -27,11 +27,13 @@ use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use oat\taoQtiItem\model\import\ChecksumGenerator;
 use oat\taoQtiItem\model\qti\metadata\importer\MetaMetadataImportMapper;
-use oat\taoQtiItem\model\qti\metadata\importer\PropertyDoesNotExistException;
 use PHPUnit\Framework\TestCase;
 
 class MetaMetadataImportMapperTest extends TestCase
 {
+    private ChecksumGenerator $checksumGeneratorMock;
+    private MetaMetadataImportMapper $subject;
+
     public function setUp(): void
     {
         $this->checksumGeneratorMock = $this->createMock(ChecksumGenerator::class);
@@ -113,5 +115,60 @@ class MetaMetadataImportMapperTest extends TestCase
         $result = $this->subject->mapMetaMetadataToProperties($metaMetadataProperties, $itemClass, $testClass);
         self::assertNotNull($result);
         self::assertEquals(1, count($result['itemProperties']));
+    }
+
+    public function testMapMetadataToProperties(): void
+    {
+        $metadataProperty = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getPath'])
+            ->getMock();
+        $metadataProperty->method('getPath')->willReturn(['somePath', 'http://example.com/uri1']);
+
+        $metadataProperties = [[$metadataProperty]];
+
+        $itemClass = $this->createMock(core_kernel_classes_Class::class);
+        $propertyMock = $this->createMock(core_kernel_classes_Property::class);
+        $resourceMock = $this->createMock(core_kernel_classes_Resource::class);
+
+        $itemClass->method('getProperties')->willReturn([$propertyMock]);
+        $propertyMock->method('getUri')->willReturn('http://example.com/uri1');
+        $propertyMock->method('getOnePropertyValue')->willReturn($resourceMock);
+        $propertyMock->method('getWidget')->willReturn($propertyMock);
+
+        $resourceMock->method('getUri')->willReturn('http://resource.uri/false');
+
+        $this->checksumGeneratorMock->method('getRangeChecksum')->willReturn('qwerty1234');
+
+        $result = $this->subject->mapMetadataToProperties($metadataProperties, $itemClass);
+
+        $this->assertArrayHasKey('itemProperties', $result);
+        $this->assertInstanceOf(core_kernel_classes_Property::class, $result['itemProperties']['http://example.com/uri1']);
+    }
+
+    public function testHandlesInvalidArgumentExceptionInIsSynced(): void
+    {
+        $metaMetadataProperties = [
+            [
+                'uri' => 'http://example.com/uri1',
+                'label' => 'label1',
+                'alias' => 'alias1',
+                'checksum' => 'qwerty1234',
+                'multiple' => 'http://resource.uri/false',
+                'widget' => 'http://widget.uri'
+            ]
+        ];
+
+        $itemClass = $this->createMock(core_kernel_classes_Class::class);
+        $propertyMock = $this->createMock(core_kernel_classes_Property::class);
+
+        $itemClass->method('getProperties')->willReturn([$propertyMock]);
+        $propertyMock->method('getLabel')->willReturn('label1');
+
+        $this->checksumGeneratorMock->method('getRangeChecksum')
+            ->willThrowException(new \InvalidArgumentException());
+
+        $result = $this->subject->mapMetaMetadataToProperties($metaMetadataProperties, $itemClass);
+
+        $this->assertEmpty($result);
     }
 }

--- a/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
+++ b/test/unit/model/qti/metadata/importer/MetaMetadataImportMapperTest.php
@@ -25,6 +25,7 @@ namespace oat\taoQtiItem\test\unit\model\qti\metadata\importer;
 use core_kernel_classes_Class;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
+use InvalidArgumentException;
 use oat\taoQtiItem\model\import\ChecksumGenerator;
 use oat\taoQtiItem\model\qti\metadata\importer\MetaMetadataImportMapper;
 use PHPUnit\Framework\TestCase;
@@ -165,7 +166,7 @@ class MetaMetadataImportMapperTest extends TestCase
         $propertyMock->method('getLabel')->willReturn('label1');
 
         $this->checksumGeneratorMock->method('getRangeChecksum')
-            ->willThrowException(new \InvalidArgumentException());
+            ->willThrowException(new InvalidArgumentException());
 
         $result = $this->subject->mapMetaMetadataToProperties($metaMetadataProperties, $itemClass);
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3992

## What's Changed

- handle import of props without metadata


## Dependencies PRs

- https://github.com/oat-sa/extension-tao-testqti/pull/2541


## How to test
- Have a import package without metadata section
- Import it
## Video

https://github.com/user-attachments/assets/fdc2f054-5a15-4903-b5cc-4dd664f1b934

