### PR TITLE
feat: add item and manifest conversion service

### DIFF
--- a/model/ValidationService.php
+++ b/model/ValidationService.php
@@ -41,6 +41,12 @@ class ValidationService extends ConfigurableService
         'http://www.imsglobal.org/xsd/imsqti_v2p2' => [
             '/qti/data/qtiv2p2p4/imsqti_v2p2p4.xsd'
         ],
+        'http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1' => [
+            '/qti/data/qtiv3/imsqtiv3p0_imscpv1p2_v1p0.xsd'
+        ],
+        'http://www.imsglobal.org/xsd/imscp_v1p1' => [
+            '/qti/data/imscp_v1p1.xsd'
+        ],
         'default' => [
             '/qti/data/qtiv2p1p1/imsqti_v2p1p1.xsd'
         ]
@@ -52,7 +58,11 @@ class ValidationService extends ConfigurableService
             '/qti/data/qtiv2p2/qtiv2p2_imscpv1p2_v1p0.xsd',
             '/qti/data/apipv1p0/Core_Level/Package/apipv1p0_imscpv1p2_v1p0.xsd',
             '/qti/data/apipv1p0final/Core_Level/Package/apipv1p0_imscpv1p2_v1p0.xsd',
-        ]
+            '/qti/data/qtiv3/imsqtiv3p0_imscpv1p2_v1p0.xsd'
+        ],
+        'http://www.imsglobal.org/xsd/imscp_v1p1' => [
+            '/qti/data/imscp_v1p1.xsd'
+        ],
     ];
 
     public function __construct(array $options = [])

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -971,7 +971,7 @@ class ImportService extends ConfigurableService
 
     private function convertItem(string $tmpQtiFile): void
     {
-        $this->getItemConverter()->convert($tmpQtiFile);
+        $this->getItemConverter()->convertToQti2($tmpQtiFile);
     }
 
     private function getItemConverter(): ItemConverter

--- a/model/qti/Resource.php
+++ b/model/qti/Resource.php
@@ -50,7 +50,8 @@ class Resource
         'imsqti_apiptestroot_xmlv2p1',
         'imsqti_test_xmlv2p1',
         'imsqti_test_xmlv2p2',
-        'imsqti_assessment_xmlv2p1'
+        'imsqti_assessment_xmlv2p1',
+        'imsqti_test_xmlv3p0'
     ];
 
     /**

--- a/model/qti/ServiceProvider/QtiServiceProvider.php
+++ b/model/qti/ServiceProvider/QtiServiceProvider.php
@@ -24,6 +24,9 @@ namespace oat\taoQtiItem\model\qti\ServiceProvider;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\log\LoggerService;
+use oat\taoQtiItem\model\qti\converter\CaseConversionService;
+use oat\taoQtiItem\model\qti\converter\ItemConverter;
+use oat\taoQtiItem\model\qti\converter\ManifestConverter;
 use oat\taoQtiItem\model\qti\Identifier\Service\QtiIdentifierSetter;
 use oat\taoQtiItem\model\qti\Service;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -42,5 +45,17 @@ class QtiServiceProvider implements ContainerServiceProviderInterface
                 service(Service::class),
                 service(LoggerService::SERVICE_ID),
             ]);
+
+        $services->set(CaseConversionService::class);
+
+        $services
+            ->set(ManifestConverter::class, ManifestConverter::class)
+            ->public();
+
+        $services->set(ItemConverter::class)
+            ->args([
+                service(CaseConversionService::class),
+            ])
+            ->public();
     }
 }

--- a/model/qti/ServiceProvider/QtiServiceProvider.php
+++ b/model/qti/ServiceProvider/QtiServiceProvider.php
@@ -29,6 +29,7 @@ use oat\taoQtiItem\model\qti\converter\ItemConverter;
 use oat\taoQtiItem\model\qti\converter\ManifestConverter;
 use oat\taoQtiItem\model\qti\Identifier\Service\QtiIdentifierSetter;
 use oat\taoQtiItem\model\qti\Service;
+use oat\taoQtiItem\model\ValidationService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -55,6 +56,7 @@ class QtiServiceProvider implements ContainerServiceProviderInterface
         $services->set(ItemConverter::class)
             ->args([
                 service(CaseConversionService::class),
+                service(ValidationService::SERVICE_ID)
             ])
             ->public();
     }

--- a/model/qti/converter/AbstractQtiConverter.php
+++ b/model/qti/converter/AbstractQtiConverter.php
@@ -33,6 +33,7 @@ use oat\taoQtiItem\model\ValidationService;
 abstract class AbstractQtiConverter
 {
     private const QTI_22_NS = 'http://www.imsglobal.org/xsd/imsqti_v2p2';
+    private const QTI_3_NS = 'http://www.imsglobal.org/xsd/imsqtiasi_v3p0';
     private const XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
     private const XSI_SCHEMA_LOCATION = 'xsi:schemaLocation';
     private const SCHEMA_LOCATION = 'http://www.imsglobal.org/xsd/imsqti_v2p2 ' .
@@ -58,7 +59,7 @@ abstract class AbstractQtiConverter
         $dom->formatOutput = true;
         $dom->load($filename);
         foreach (iterator_to_array($dom->childNodes) as $child) {
-            if ($child instanceof DOMElement && $child->tagName === $this->getRootElement()) {
+            if ($this->canBeConverted($child)) {
                 $this->convertRootElementsRecursively(iterator_to_array($child->childNodes));
                 $this->convertRootElement($child);
                 $dom->save($filename);
@@ -189,5 +190,18 @@ abstract class AbstractQtiConverter
         }
 
         return false;
+    }
+
+    /**
+     * We can only apply conversion into root element equal to defined root element const
+     * We should ignore other dom object other DOMElement
+     * We should only apply if the namespace is equal to QTI 3.0
+     */
+    private function canBeConverted(mixed $child): bool
+    {
+        return $child instanceof DOMElement
+            && $child->tagName === $this->getRootElement()
+            && $child->getAttributeNode('xmlns') !== null
+            && $child->getAttributeNode('xmlns')->nodeValue === self::QTI_3_NS;
     }
 }

--- a/model/qti/converter/AbstractQtiConverter.php
+++ b/model/qti/converter/AbstractQtiConverter.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\taoQtiItem\model\qti\converter;
 
 use common_Logger;
+use DOMComment;
 use DOMDocument;
 use DOMElement;
 use DOMText;
@@ -68,7 +69,7 @@ abstract class AbstractQtiConverter
     private function convertRootElementsRecursively(array $children): void
     {
         foreach ($children as $child) {
-            if ($child instanceof DOMText) {
+            if ($child instanceof DOMText || $child instanceof DOMComment) {
                 continue;
             }
 

--- a/model/qti/converter/AbstractQtiConverter.php
+++ b/model/qti/converter/AbstractQtiConverter.php
@@ -44,7 +44,7 @@ abstract class AbstractQtiConverter
         $this->caseConversionService = $caseConversionService;
     }
 
-    public function convert(string $filename): void
+    public function convertToQti2(string $filename): void
     {
         // Load the QTI XML document
         $dom = new DOMDocument();

--- a/model/qti/converter/AbstractQtiConverter.php
+++ b/model/qti/converter/AbstractQtiConverter.php
@@ -75,7 +75,7 @@ abstract class AbstractQtiConverter
             if ($child instanceof DOMElement) {
                 $childNodes = null;
                 if ($child->hasChildNodes()) {
-                    $this->convertRootElementsRecursively(iterator_to_array($child->childNodes), $report);
+                    $this->convertRootElementsRecursively(iterator_to_array($child->childNodes));
                     $childNodes = $child->childNodes;
                 }
             }

--- a/model/qti/converter/AbstractQtiConverter.php
+++ b/model/qti/converter/AbstractQtiConverter.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\converter;
+
+use DOMDocument;
+use DOMElement;
+use DOMText;
+
+abstract class AbstractQtiConverter
+{
+    private const QTI_22_NS = 'http://www.imsglobal.org/xsd/imsqti_v2p2';
+    private const XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
+    private const XSI_SCHEMA_LOCATION = 'xsi:schemaLocation';
+    private const SCHEMA_LOCATION = 'http://www.imsglobal.org/xsd/imsqti_v2p2 ' .
+    'http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p1.xsd';
+    private const XML_NS_NAMESPACE = 'http://www.w3.org/2000/xmlns/';
+    private const QUALIFIED_NAME_NS = 'xmlns';
+    private const QUALIFIED_NAME_XSI = self::QUALIFIED_NAME_NS . ':xsi';
+
+    private CaseConversionService $caseConversionService;
+
+    public function __construct(CaseConversionService $caseConversionService)
+    {
+        $this->caseConversionService = $caseConversionService;
+    }
+
+    public function convert(string $filename): void
+    {
+        // Load the QTI XML document
+        $dom = new DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->load($filename);
+        $rootElement = $dom->firstChild;
+        if ($rootElement instanceof DOMElement) {
+            $this->convertRootElementsRecursively(iterator_to_array($rootElement->childNodes));
+            $this->convertRootElement($rootElement);
+            $dom->save($filename);
+        }
+    }
+
+    private function convertRootElementsRecursively(array $children): void
+    {
+        foreach ($children as $child) {
+            if ($child instanceof DOMText) {
+                continue;
+            }
+
+            if ($child instanceof DOMElement) {
+                $childNodes = null;
+                if ($child->hasChildNodes()) {
+                    $this->convertRootElementsRecursively(iterator_to_array($child->childNodes));
+                    $childNodes = $child->childNodes;
+                }
+            }
+
+            $tagName = $child->tagName;
+            // When elements has child we do not want to create literal value
+            $nodeValue = $child->childElementCount === 0 ? $child->nodeValue : '';
+
+            $newElement = $child->ownerDocument->createElement(
+                $this->caseConversionService->kebabToCamelCase($tagName),
+                $nodeValue
+            );
+
+            if ($childNodes) {
+                foreach (iterator_to_array($childNodes) as $childNode) {
+                    if ($childNode instanceof DOMElement) {
+                        $newElement->appendChild($childNode);
+                    }
+                }
+            }
+
+            $this->adjustAttributes($newElement, $child);
+            $child->parentNode->replaceChild($newElement, $child);
+        }
+    }
+
+    private function adjustAttributes(DOMElement $newElement, DOMElement $childNode)
+    {
+        foreach (iterator_to_array($childNode->attributes) as $attribute) {
+            //If attribute name is not equal to nodeName it's most probably namespace attribute
+            //This will be hardcoded below therefore we wish to ignore it.
+            if ($attribute->name !== $attribute->nodeName) {
+                continue;
+            }
+
+            // Only replace attribute names from map
+            if ($attrReplacement = $this->caseConversionService->kebabToCamelCase($attribute->name)) {
+                $newElement->setAttribute($attrReplacement, $attribute->value);
+                continue;
+            }
+
+            $newElement->setAttribute($attribute->name, $attribute->value);
+        }
+    }
+
+    private function convertRootElement(DOMElement $rootElement): void
+    {
+        $newElement = $rootElement->ownerDocument->createElementNS(
+            self::QTI_22_NS,
+            $this->caseConversionService->kebabToCamelCase($this->getRootElement())
+        );
+
+        $newElement->setAttributeNS(
+            self::XSI_NAMESPACE,
+            self::XSI_SCHEMA_LOCATION,
+            self::XSI_NAMESPACE
+        );
+
+        $newElement->setAttributeNS(
+            self::XSI_NAMESPACE,
+            self::XSI_SCHEMA_LOCATION,
+            self::SCHEMA_LOCATION
+        );
+
+        $newElement->setAttributeNS(
+            self::XSI_NAMESPACE,
+            self::XSI_SCHEMA_LOCATION,
+            self::SCHEMA_LOCATION
+        );
+
+        $newElement->setAttributeNS(
+            self::XML_NS_NAMESPACE,
+            self::QUALIFIED_NAME_XSI,
+            self::XSI_NAMESPACE
+        );
+
+        foreach (iterator_to_array($rootElement->childNodes) as $childNode) {
+            $newElement->appendChild($childNode);
+        }
+
+        $this->adjustAttributes($newElement, $rootElement);
+        $rootElement->parentNode->replaceChild($newElement, $rootElement);
+    }
+
+    abstract protected function getRootElement(): string;
+}

--- a/model/qti/converter/CaseConversionService.php
+++ b/model/qti/converter/CaseConversionService.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\converter;
+
+class CaseConversionService
+{
+    public function kebabToCamelCase(string $kebab): string
+    {
+        // Remove qti prefix if it exists
+        if (strpos($kebab, 'qti-') === 0) {
+            $kebab = substr($kebab, 4);
+        }
+
+        return preg_replace_callback('/-(.?)/', function ($matches) {
+            return strtoupper($matches[1]);
+        }, $kebab);
+    }
+}

--- a/model/qti/converter/ItemConverter.php
+++ b/model/qti/converter/ItemConverter.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\converter;
+
+class ItemConverter extends AbstractQtiConverter
+{
+    private const ROOT_ELEMENT = 'qti-assessment-item';
+
+    protected function getRootElement(): string
+    {
+        return self::ROOT_ELEMENT;
+    }
+}

--- a/model/qti/converter/ManifestConverter.php
+++ b/model/qti/converter/ManifestConverter.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\converter;
+
+use DOMDocument;
+use oat\oatbox\extension\exception\ManifestNotFoundException;
+use taoQtiTest_models_classes_ManifestParser as ManifestParser;
+
+class ManifestConverter
+{
+    private const XML_NS_NAMESPACE = 'http://www.w3.org/2000/xmlns/';
+    private const NEW_MAIN_NAMESPACE = 'http://www.imsglobal.org/xsd/imscp_v1p1';
+    private const XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
+    private const IMS_MD_NAMESPACE = 'http://ltsc.ieee.org/xsd/LOM';
+    private const SCHEMA_LOCATION = 'http://www.imsglobal.org/xsd/imscp_v1p1 ' .
+    'http://www.imsglobal.org/xsd/qti/qtiv2p2/qtiv2p2_imscpv1p2_v1p0.xsd ' .
+    'http://ltsc.ieee.org/xsd/LOM http://www.imsglobal.org/xsd/imsmd_loose_v1p3p2.xsd';
+    private const QUALIFIED_NAME_NS = 'xmlns';
+    private const QUALIFIED_NAME_XSI = self::QUALIFIED_NAME_NS . ':xsi';
+    private const QUALIFIED_NAME_IMSMD = self::QUALIFIED_NAME_NS . ':imsmd';
+    private const XSI_SCHEMA_LOCATION = 'xsi:schemaLocation';
+    private const QTI3_XSD = 'http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1';
+    private const TEST_RESOURCE_TYPE = 'imsqti_test_xmlv3p0';
+    private const ITEM_RESOURCE_TYPE = 'imsqti_item_xmlv3p0';
+    private const RESOURCE_TYPE_REPLACEMENTS = [
+        self::ITEM_RESOURCE_TYPE => 'imsqti_item_xmlv2p2',
+        self::TEST_RESOURCE_TYPE => 'imsqti_test_xmlv2p2',
+    ];
+
+    public function convert(string $manifestFile, ManifestParser $manifestParser): void
+    {
+        //Check if folder exist and contains QTI 3.0 files
+        if (!is_readable($manifestFile)) {
+            throw new ManifestNotFoundException('Manifest not found!');
+        }
+
+        $dom = new DOMDocument();
+        $dom->load($manifestFile);
+
+        //Check if the file is QTI 3.0 using schemaversion
+        if ($dom->getElementsByTagName('schemaversion')->item(0)->nodeValue !== '3.0.0') {
+            return;
+        }
+        // Get the manifest element
+        $manifestElement = $dom->getElementsByTagName('manifest')->item(0);
+        if (!$manifestElement) {
+            return;
+        }
+
+        // Remove existing namespace attributes
+        $manifestElement->removeAttributeNS(
+            self::QTI3_XSD,
+            ''
+        );
+
+        // Set new main namespace
+        $manifestElement->setAttributeNS(
+            self::XML_NS_NAMESPACE,
+            self::QUALIFIED_NAME_NS,
+            self::NEW_MAIN_NAMESPACE
+        );
+
+        // Ensure xsi namespace
+        $manifestElement->setAttributeNS(
+            self::XML_NS_NAMESPACE,
+            self::QUALIFIED_NAME_XSI,
+            self::XSI_NAMESPACE
+        );
+
+        // Ensure imsmd namespace
+        $manifestElement->setAttributeNS(
+            self::XML_NS_NAMESPACE,
+            self::QUALIFIED_NAME_IMSMD,
+            self::IMS_MD_NAMESPACE
+        );
+
+        $manifestElement->setAttributeNS(
+            self::XSI_NAMESPACE,
+            self::XSI_SCHEMA_LOCATION,
+            self::SCHEMA_LOCATION
+        );
+
+        $dom->getElementsByTagName('schemaversion')->item(0)->nodeValue = '2.2.0';
+        $resources = $dom->getElementsByTagName('resource');
+
+        foreach ($resources as $resource) {
+            //Each resource type will be handle by different converter
+            $resourceHrefs[$resource->getAttribute('type')][] = $resource->getAttribute('href');
+            $resource->setAttribute(
+                'type',
+                self::RESOURCE_TYPE_REPLACEMENTS[$resource->getAttribute('type')]
+            );
+        }
+
+        // Save the modified XML
+        $dom->save($manifestFile);
+        $manifestParser->validate();
+    }
+}

--- a/model/qti/converter/ManifestConverter.php
+++ b/model/qti/converter/ManifestConverter.php
@@ -47,7 +47,7 @@ class ManifestConverter
         self::TEST_RESOURCE_TYPE => 'imsqti_test_xmlv2p2',
     ];
 
-    public function convert(string $manifestFile, ManifestParser $manifestParser): void
+    public function convertToQti2(string $manifestFile, ManifestParser $manifestParser): void
     {
         //Check if folder exist and contains QTI 3.0 files
         if (!is_readable($manifestFile)) {

--- a/model/qti/converter/ManifestConverter.php
+++ b/model/qti/converter/ManifestConverter.php
@@ -104,12 +104,14 @@ class ManifestConverter
         $resources = $dom->getElementsByTagName('resource');
 
         foreach ($resources as $resource) {
-            //Each resource type will be handle by different converter
-            $resourceHrefs[$resource->getAttribute('type')][] = $resource->getAttribute('href');
-            $resource->setAttribute(
-                'type',
-                self::RESOURCE_TYPE_REPLACEMENTS[$resource->getAttribute('type')]
-            );
+            // If resource type is mapped replace it with mapped value
+            if (isset(self::RESOURCE_TYPE_REPLACEMENTS[$resource->getAttribute('type')])) {
+                $resource->setAttribute(
+                    'type',
+                    self::RESOURCE_TYPE_REPLACEMENTS[$resource->getAttribute('type')]
+                );
+            }
+
         }
 
         // Save the modified XML

--- a/model/qti/data/qtiv3/imsqti_metadatav3p0_v1p0.xsd
+++ b/model/qti/data/qtiv3/imsqti_metadatav3p0_v1p0.xsd
@@ -1,0 +1,254 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xs:schema xmlns="http://www.imsglobal.org/xsd/imsqti_metadata_v3p0"
+     targetNamespace="http://www.imsglobal.org/xsd/imsqti_metadata_v3p0"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+     version="IMS QTI MD 3.0.0"
+     elementFormDefault="qualified"
+     attributeFormDefault="unqualified">
+
+    <xs:annotation>
+        <xs:documentation>
+            XSD Data File Information
+            =========================
+            Author:         Colin Smythe (IMS Global), Tom Hoffman (IMS Global) and Susan Haught (IMS Global)
+            Date:           1st May 2022
+            Version:        1.0
+            Status:         IMS Final Release
+            Description:    This is the Platform Specific Model of the Metadata object in the IMS QTIv3.0 Specification Information Model. It is this representation that is used to produce the XSD binding for the IMS QTI Metadata v3.0.
+
+            History:        This version supercedes the full IMS QTIv2.2 Metadata specification.
+            
+            License:        IPR and Distribution Notices
+            
+                            This machine readable file is derived from the IMS Question and Test Interoperability (QTI) Metadata Specification Version 3.0
+                            found at http://www.imsglobal.org/question and the original IMS Global schema binding or code base
+                            http://www.imsglobal.org/question.
+            
+                            Recipients of this document are requested to submit, with their comments, notification of any relevant 
+                            patent claims or other intellectual property rights of which they may be aware that might be infringed by
+                            any implementation of the specification set forth in this document, and to provide supporting documentation.
+            
+                            IMS takes no position regarding the validity or scope of any intellectual property or other rights that might
+                            be claimed to pertain to the implementation or use of the technology described in this document or the extent 
+                            to which any license under such rights might or might not be available; neither does it represent that it has 
+                            made any effort to identify any such rights. Information on IMS procedures with respect to rights in IMS 
+                            specifications can be found at the IMS Global Intellectual Property Rights web page: http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf.
+            
+                            Copyright (c) IMS Global Learning Consortium 1999-2022. All Rights Reserved.
+            
+                            Use of this specification to develop products or services is governed by the license with IMS found on the IMS website: http://www.imsglobal.org/license.html.
+            
+                            Permission is granted to all parties to use excerpts from this document as needed in producing requests for proposals.
+            
+                            The limited permissions granted above are perpetual and will not be revoked by IMS or its successors or assigns.
+            
+                            THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS
+                            EXPRESSLY DISCLAIMED. ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTERS OWN RISK, AND NEITHER THE CONSORTIUM
+                            NOR ANY OF ITS MEMBERS OR SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR THIRD PARTY FOR ANY DAMAGES OF
+                            ANY NATURE WHATSOEVER, DIRECTLY OR INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
+            
+            Source UML File Information
+            ===========================
+            The source file information must be supplied as an XMI file (without diagram layout information).
+            The supported UML authoring tools are:
+            (a) Poseidon - v6 (and later)
+            (b) Papyrus - v1.1.3 (and later)
+            
+            Source XSLT File Information
+            ============================
+            XSL Generator:    Specificationv1p0_GenerationToolv1.xsl
+            XSLT Processor:   Saxon
+            Release:          1.0
+            Date:             31st January, 2021
+            Autogen Engineer: Colin Smythe (IMS Global, UK)
+            Autogen Date:     2022-03-30
+            
+            IMS Global Auto-generation Binding Tool-kit (I-BAT)
+            ===================================================
+            This file was auto-generated using the IMS Global Binding Auto-generation Tool-kit (I-BAT).  While every
+            attempt has been made to ensure that this tool auto-generates the files correctly, users should be aware
+            that this is an experimental tool.  Permission is given to make use of this tool.  IMS Global makes no
+            claim on the materials created by third party users of this tool.  Details on how to use this tool
+            are contained in the IMS Global "I-BAT" documentation available at the IMS Global web-site:
+            http://www.imsglobal.org.
+            
+            Tool Copyright:  2012-2022  (c) IMS Global Learning Consortium Inc.  All Rights Reserved.
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Generate Global Attributes (non-assigned) ******************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global Attributes *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global List Types *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Namespaced extension Group  ************************************************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Special DataTypes  ********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the enumerated simpleType declarations ************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Parameter) ***************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Derived) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Union) ********************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Complex) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon simpleType ************************************ -->
+
+    <xs:simpleType name="String256DType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="256" />
+            <xs:whiteSpace value="preserve" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon derived simpleType **************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the ComplexTypes ************************************************************************ -->
+
+    <xs:complexType name="PCIContextDType" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                This is the container for the contextual information that can be supplied for a PCI used  
+                within an Item. The contained information is only relevant when there is an 'interactionT-
+                ype' of 'portableCustomInteraction'.                                                      
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="customTypeIdentifier" type="xs:normalizedString" minOccurs="0" maxOccurs="1" />
+            <xs:element name="interactionKind" type="xs:normalizedString" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="QTIMetadataDType" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                This contains the new category of metadata for the recording of QTI specific information. 
+                It is designed to be treated as an additional top-level category to augment the IEEE LOM. 
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="itemTemplate" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+            <xs:element name="timeDependent" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+            <xs:element name="composite" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+            <xs:element name="interactionType" minOccurs="0" maxOccurs="unbounded">
+                <xs:simpleType>
+                    <xs:annotation>
+                        <xs:documentation source="documentation">
+                            The set of enumerations for the type of interaction in the QTI Metadata.                  
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="associateInteraction" />
+                        <xs:enumeration value="choiceInteraction" />
+                        <xs:enumeration value="customInteraction" />
+                        <xs:enumeration value="drawingInteraction" />
+                        <xs:enumeration value="endAttemptInteraction" />
+                        <xs:enumeration value="extendedTextInteraction" />
+                        <xs:enumeration value="gapMatchInteraction" />
+                        <xs:enumeration value="graphicAssociateInteraction" />
+                        <xs:enumeration value="graphicGapMatchInteraction" />
+                        <xs:enumeration value="graphicOrderInteraction" />
+                        <xs:enumeration value="hotspotInteraction" />
+                        <xs:enumeration value="hottextInteraction" />
+                        <xs:enumeration value="inlineChoiceInteraction" />
+                        <xs:enumeration value="matchInteraction" />
+                        <xs:enumeration value="mediaInteraction" />
+                        <xs:enumeration value="orderInteraction" />
+                        <xs:enumeration value="portableCustomInteraction" />
+                        <xs:enumeration value="positionObjectInteraction" />
+                        <xs:enumeration value="selectPointInteraction" />
+                        <xs:enumeration value="sliderInteraction" />
+                        <xs:enumeration value="textEntryInteraction" />
+                        <xs:enumeration value="uploadInteraction" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="portableCustomInteractionContext" type="PCIContextDType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="feedbackType" minOccurs="0" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:annotation>
+                        <xs:documentation source="documentation">
+                            The set of enumerations for the type of feedback in QTI Metadata.                         
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="adaptive" />
+                        <xs:enumeration value="nonadaptive" />
+                        <xs:enumeration value="none" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="solutionAvailable" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+            <xs:element name="scoringMode" minOccurs="0" maxOccurs="unbounded">
+                <xs:simpleType>
+                    <xs:annotation>
+                        <xs:documentation source="documentation">
+                            The set of enumerations for the scoring mode in the QTI Metadata.                         
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="human" />
+                        <xs:enumeration value="externalmachine" />
+                        <xs:enumeration value="responseprocessing" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="toolName" type="String256DType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="toolVersion" type="String256DType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="toolVendor" type="String256DType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the SOAP Binding ComplexTypes *********************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived ComplexTypes **************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Complex) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Derived) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the root element(s) *************************************************************** -->
+
+    <xs:element name="qtiMetadata" type="QTIMetadataDType" />
+
+    <!-- ================================================================================================== -->
+
+</xs:schema>

--- a/model/qti/data/qtiv3/imsqtiv3p0_afa3p0drd_v1p0.xsd
+++ b/model/qti/data/qtiv3/imsqtiv3p0_afa3p0drd_v1p0.xsd
@@ -1,0 +1,437 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xs:schema xmlns="http://www.imsglobal.org/xsd/qti/qtiv3p0/imsafa3p0drd_v1p0"
+     targetNamespace="http://www.imsglobal.org/xsd/qti/qtiv3p0/imsafa3p0drd_v1p0"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+     version="IMS AFA DRD 3.0 QTI 3.0"
+     elementFormDefault="qualified"
+     attributeFormDefault="unqualified">
+
+    <xs:annotation>
+        <xs:documentation>
+            XSD Data File Information
+            =========================
+            Author:         Colin Smythe (IMS Global, UK)
+            Date:           2nd April, 2019
+            Version:        1.0
+            Status:         IMS Candidate Final
+            Description:    This is the PSM for the QTI 3.0 Profile for the Access For All Digital Resource Description (DRD) data model.
+
+            History:        The original Final Release.
+
+            PROFILE:        This is the "QTIv3p0-AFADRD". THIS IS A PROFILE OF THE BASE SPECIFICATION.
+                            The changes to the base specification are:
+                            * The schema namespace has been changed to "http://www.imsglobal.org/xsd/qti/qtiv3p0/imsafa3p0drd_v1p0".
+                            * The schema version has been changed to "IMS AFA DRD 3.0 QTI 3.0".
+
+            License:        IPR and Distribution Notices
+
+                            This machine readable file is derived from IMS Global specification IMS Question and Test Interoperability 3.0 Access for All (AfA) Digital Resource Description (DRD) Profile Version 1.0
+                            found at http://www.imsglobal.org/afa and the original IMS Global schema binding or code base
+                            http://www.imsglobal.org/afa.
+
+                            Recipients of this document are requested to submit, with their comments, notification of any relevant 
+                            patent claims or other intellectual property rights of which they may be aware that might be infringed by
+                            any implementation of the specification set forth in this document, and to provide supporting documentation.
+
+                            IMS takes no position regarding the validity or scope of any intellectual property or other rights that might
+                            be claimed to pertain to the implementation or use of the technology described in this document or the extent 
+                            to which any license under such rights might or might not be available; neither does it represent that it has 
+                            made any effort to identify any such rights. Information on IMS procedures with respect to rights in IMS 
+                            specifications can be found at the IMS Global Intellectual Property Rights web page: http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf.
+
+                            Copyright (c) IMS Global Learning Consortium 1999-2019. All Rights Reserved.
+
+                            Use of this specification to develop products or services is governed by the license with IMS found on the IMS website: http://www.imsglobal.org/license.html.
+
+                            Permission is granted to all parties to use excerpts from this document as needed in producing requests for proposals.
+
+                            The limited permissions granted above are perpetual and will not be revoked by IMS or its successors or assigns.
+
+                            THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS
+                            EXPRESSLY DISCLAIMED. ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTERS OWN RISK, AND NEITHER THE CONSORTIUM
+                            NOR ANY OF ITS MEMBERS OR SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR THIRD PARTY FOR ANY DAMAGES OF
+                            ANY NATURE WHATSOEVER, DIRECTLY OR INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
+
+            Source UML File Information
+            ===========================
+            The source file information must be supplied as an XMI file (without diagram layout information).
+            The supported UML authoring tools are:
+            (a) Poseidon - v6 (and later)
+            (b) Papyrus - v1.1.3 (and later)
+
+            Source XSLT File Information
+            ============================
+            XSL Generator:    Specificationv1p0_GenerationToolv1.xsl
+            XSLT Processor:   Saxon
+            Release:          1.0
+            Date:             31st July, 2017
+            Autogen Engineer: Colin Smythe (IMS Global, UK)
+            Autogen Date:     2019-04-01
+
+            IMS Global Auto-generation Binding Tool-kit (I-BAT)
+            ===================================================
+            This file was auto-generated using the IMS Global Binding Auto-generation Tool-kit (I-BAT).  While every
+            attempt has been made to ensure that this tool auto-generates the files correctly, users should be aware
+            that this is an experimental tool.  Permission is given to make use of this tool.  IMS Global makes no
+            claim on the materials created by third party users of this tool.  Details on how to use this tool
+            are contained in the IMS Global "I-BAT" documentation available at the IMS Global web-site:
+            http://www.imsglobal.org.
+
+            Tool Copyright:  2012-2019  (c) IMS Global Learning Consortium Inc.  All Rights Reserved.
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Generate Global Attributes (non-assigned) ******************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global Attributes *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global List Types *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Namespaced extension Group  ************************************************************* -->
+
+    <xs:group name="grpStrict.any">
+        <xs:annotation>
+            <xs:documentation>
+                Any namespaced element from any namespace, other than the target namespace, may be included within an "any" element.
+                The namespace for the imported element must be defined in the instance, and the schema must be imported.
+                The extension has a definition of "strict" i.e. they must have their own namespace.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:any namespace = "##other" processContents = "strict" minOccurs = "0" maxOccurs = "unbounded" />
+        </xs:sequence>
+    </xs:group>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Special DataTypes  ********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the enumerated simpleType declarations ************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Parameter) ***************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Derived) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Union) ********************************* -->
+
+    <xs:element name="accessMode">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="auditory" />
+                        <xs:enumeration value="colour" />
+                        <xs:enumeration value="itemSize" />
+                        <xs:enumeration value="olfactory" />
+                        <xs:enumeration value="orientation" />
+                        <xs:enumeration value="position" />
+                        <xs:enumeration value="tactile" />
+                        <xs:enumeration value="textOnImage" />
+                        <xs:enumeration value="textual" />
+                        <xs:enumeration value="visual" />
+                    </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="accessModeAdapted">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="auditory" />
+                        <xs:enumeration value="colour" />
+                        <xs:enumeration value="itemSize" />
+                        <xs:enumeration value="olfactory" />
+                        <xs:enumeration value="orientation" />
+                        <xs:enumeration value="position" />
+                        <xs:enumeration value="tactile" />
+                        <xs:enumeration value="textOnImage" />
+                        <xs:enumeration value="textual" />
+                        <xs:enumeration value="visual" />
+                    </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="adaptationDetail">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="enhanced" />
+                        <xs:enumeration value="verbatim" />
+                        <xs:enumeration value="realTime" />
+                        <xs:enumeration value="symbolic" />
+                        <xs:enumeration value="recorded" />
+                        <xs:enumeration value="synthesized" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="adaptationMediaType">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="Daisy" />
+                        <xs:enumeration value="braille" />
+                        <xs:enumeration value="NIMAS" />
+                        <xs:enumeration value="MathML" />
+                        <xs:enumeration value="ChemML" />
+                        <xs:enumeration value="LaTeX" />
+                        <xs:enumeration value="OEBPS" />
+                        <xs:enumeration value="PDF" />
+                        <xs:enumeration value="LIT" />
+                        <xs:enumeration value="Nemeth" />
+                        <xs:enumeration value="EPUB3" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="adaptationType">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="alternativeText" />
+                        <xs:enumeration value="audioDescription" />
+                        <xs:enumeration value="captions" />
+                        <xs:enumeration value="e-book" />
+                        <xs:enumeration value="haptic" />
+                        <xs:enumeration value="highContrast" />
+                        <xs:enumeration value="longDescription" />
+                        <xs:enumeration value="signLanguage" />
+                        <xs:enumeration value="transcript" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="apiInteroperable">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="AndroidAccessibility" />
+                        <xs:enumeration value="ARIA" />
+                        <xs:enumeration value="ATK" />
+                        <xs:enumeration value="AT-SPI" />
+                        <xs:enumeration value="BlackberryAccessibility" />
+                        <xs:enumeration value="iAccessible2" />
+                        <xs:enumeration value="JavaAccessibility" />
+                        <xs:enumeration value="MacOSXAccessibility" />
+                        <xs:enumeration value="MSAA" />
+                        <xs:enumeration value="UIAutomation" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="controlFlexibility">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="fullKeyboardControl" />
+                        <xs:enumeration value="fullMouseControl" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="displayTransformability">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="backgroundColour" />
+                        <xs:enumeration value="cursorPresentation" />
+                        <xs:enumeration value="fontFace" />
+                        <xs:enumeration value="fontSize" />
+                        <xs:enumeration value="fontWeight" />
+                        <xs:enumeration value="foregroundColour" />
+                        <xs:enumeration value="highlightPresentation" />
+                        <xs:enumeration value="layout" />
+                        <xs:enumeration value="letterSpacing" />
+                        <xs:enumeration value="lineHeight" />
+                        <xs:enumeration value="structurePresentation" />
+                        <xs:enumeration value="wordSpacing" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="educationalComplexityOfAdaptation">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="enriched" />
+                        <xs:enumeration value="simplified" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="hazard">
+        <xs:simpleType>
+            <xs:union>
+                <xs:simpleType>
+                    <xs:restriction base="ExtensionString.Type" />
+                </xs:simpleType>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="flashing" />
+                        <xs:enumeration value="sound" />
+                        <xs:enumeration value="olfactoryHazard" />
+                        <xs:enumeration value="motionSimulation" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:element>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Complex) ******************************* -->
+
+    <xs:element name="atInteroperable" type="xs:boolean" />
+
+    <xs:element name="educationalLevelOfAdaptation" type="xs:normalizedString" />
+
+    <xs:element name="hasAdaptation" type="xs:anyURI" />
+
+    <xs:element name="isAdaptationOf" type="xs:anyURI" />
+
+    <xs:element name="isFullAdaptationOf" type="xs:anyURI" />
+
+    <xs:element name="isPartialAdaptationOf" type="xs:anyURI" />
+
+    <xs:element name="languageOfAdaptation" type="xs:normalizedString" />
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon simpleType ************************************ -->
+
+    <xs:simpleType name="ExtensionString.Type">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(ext:)[ a-z | A-Z | 0-9 | . | _ ]+" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon derived simpleType **************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the ComplexTypes ************************************************************************ -->
+
+    <xs:complexType name="Access_For_All_Resource.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The Access_for_All_Resource complexType is the container for a collection of information  
+                that states how a digital learning resource can be perceived, understood or interacted wi-
+                th by users.                                                                              
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="accessMode" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="accessModeAdapted" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="adaptationType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="atInteroperable" minOccurs="0" maxOccurs="1" />
+            <xs:element ref="controlFlexibility" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="displayTransformability" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="educationalComplexityOfAdaptation" minOccurs="0" maxOccurs="1" />
+            <xs:element ref="hasAdaptation" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="hazard" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="isAdaptationOf" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="languageOfAdaptation" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="adaptationDetail" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="adaptationMediaType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="apiInteroperable" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="educationalLevelOfAdaptation" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="isFullAdaptationOf" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="isPartialAdaptationOf" minOccurs="0" maxOccurs="unbounded" />
+            <xs:group ref="grpStrict.any" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the SOAP Binding ComplexTypes *********************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived ComplexTypes **************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Complex) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Derived) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the root element(s) *************************************************************** -->
+
+    <xs:element name="accessForAllResource" type="Access_For_All_Resource.Type" />
+
+    <!-- ================================================================================================== -->
+
+</xs:schema>

--- a/model/qti/data/qtiv3/imsqtiv3p0_cpextv1p2_v1p0.xsd
+++ b/model/qti/data/qtiv3/imsqtiv3p0_cpextv1p2_v1p0.xsd
@@ -1,0 +1,212 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xs:schema xmlns="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_extensionv1p2"
+     targetNamespace="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_extensionv1p2"
+     xmlns:drd="http://www.imsglobal.org/xsd/qti/qtiv3p0/imsafa3p0drd_v1p0"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     version="IMS CPX 1.2 QTI 3.0"
+     elementFormDefault="qualified"
+     attributeFormDefault="unqualified">
+    <xs:import namespace = "http://www.w3.org/1999/xlink" schemaLocation = "../w3/xlink.xsd" />
+    <xs:import namespace="http://www.imsglobal.org/xsd/qti/qtiv3p0/imsafa3p0drd_v1p0" schemaLocation="./imsqtiv3p0_afa3p0drd_v1p0.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+            XSD Data File Information
+            =========================
+            Author:         Colin Smythe (IMS Global, UK)
+            Date:           2nd April, 2019
+            Version:        1.0
+            Status:         IMS Candidate Final
+            Description:    This is the PSM for the QTI 3.0 profile of the IMS Content Packaging Extension v1.0 specification.
+
+            History:        The original Final Release.
+
+            PROFILE:        This is the "QTIv3p0-CP-Extensions". THIS IS A PROFILE OF THE BASE SPECIFICATION.
+                            The changes to the base specification are:
+                            * The schema namespace has been changed to "http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_extensionv1p2".
+                            * The schema version has been changed to "IMS CPX 1.2 QTI 3.0".
+                            * The "IPointer" class/complexType and set of XML attributes have been deleted;
+                            * The "LingualTitle" class/complexType and set of XML attributes have been deleted;
+                            * The "Metadata" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                              - The "accessForAllResource" attribute has been added using Import;
+
+            License:        IPR and Distribution Notices
+
+                            This machine readable file is derived from IMS Global specification IMS Question and Test Interoperability 3.0 Content Packaging Extension (CPX) v1.0 Profile Version 1.0
+                            found at http://www.imsglobal.org/qti and the original IMS Global schema binding or code base
+                            http://www.imsglobal.org/qti.
+
+                            Recipients of this document are requested to submit, with their comments, notification of any relevant
+                            patent claims or other intellectual property rights of which they may be aware that might be infringed by
+                            any implementation of the specification set forth in this document, and to provide supporting documentation.
+
+                            IMS takes no position regarding the validity or scope of any intellectual property or other rights that might
+                            be claimed to pertain to the implementation or use of the technology described in this document or the extent
+                            to which any license under such rights might or might not be available; neither does it represent that it has
+                            made any effort to identify any such rights. Information on IMS procedures with respect to rights in IMS
+                            specifications can be found at the IMS Global Intellectual Property Rights web page: http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf.
+
+                            Copyright (c) IMS Global Learning Consortium 1999-2019. All Rights Reserved.
+
+                            Use of this specification to develop products or services is governed by the license with IMS found on the IMS website: http://www.imsglobal.org/license.html.
+
+                            Permission is granted to all parties to use excerpts from this document as needed in producing requests for proposals.
+
+                            The limited permissions granted above are perpetual and will not be revoked by IMS or its successors or assigns.
+
+                            THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS
+                            EXPRESSLY DISCLAIMED. ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTERS OWN RISK, AND NEITHER THE CONSORTIUM
+                            NOR ANY OF ITS MEMBERS OR SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR THIRD PARTY FOR ANY DAMAGES OF
+                            ANY NATURE WHATSOEVER, DIRECTLY OR INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
+
+            Source UML File Information
+            ===========================
+            The source file information must be supplied as an XMI file (without diagram layout information).
+            The supported UML authoring tools are:
+            (a) Poseidon - v6 (and later)
+            (b) Papyrus - v1.1.3 (and later)
+
+            Source XSLT File Information
+            ============================
+            XSL Generator:    Specificationv1p0_GenerationToolv1.xsl
+            XSLT Processor:   Saxon
+            Release:          1.0
+            Date:             31st July, 2017
+            Autogen Engineer: Colin Smythe (IMS Global, UK)
+            Autogen Date:     2019-04-01
+
+            IMS Global Auto-generation Binding Tool-kit (I-BAT)
+            ===================================================
+            This file was auto-generated using the IMS Global Binding Auto-generation Tool-kit (I-BAT).  While every
+            attempt has been made to ensure that this tool auto-generates the files correctly, users should be aware
+            that this is an experimental tool.  Permission is given to make use of this tool.  IMS Global makes no
+            claim on the materials created by third party users of this tool.  Details on how to use this tool
+            are contained in the IMS Global "I-BAT" documentation available at the IMS Global web-site:
+            http://www.imsglobal.org.
+
+            Tool Copyright:  2012-2019  (c) IMS Global Learning Consortium Inc.  All Rights Reserved.
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Generate Global Attributes (non-assigned) ******************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global Attributes *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global List Types *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Namespaced extension Group  ************************************************************* -->
+
+        <!-- The Strict-Namespaced extension Group declaration has been deleted in this profile  ********** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Special DataTypes  ********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the enumerated simpleType declarations ************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Parameter) ***************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Derived) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Union) ********************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Complex) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon simpleType ************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon derived simpleType **************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the ComplexTypes ************************************************************************ -->
+
+    <xs:complexType name="Metadata.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                An instance of the metadata element contains data structures that declare descriptive inf-
+                ormation about a metadata element's parent only. One or more different metadata models may
+                be declared as child extensions of a metadata element.
+Represents a binding of the kinds
+                of child objects defined for ims-cp-imMetadata: Metadata.[ Extension ].
+                [QTIv3p0-CP-Extensions] Profile - the changes to the XML element list are:
+                * The "extension" element has been prohibited;
+                * The "accessForAllResource" element has been added using Import;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="drd:accessForAllResource" minOccurs = "1" maxOccurs = "1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Variant.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                A variant element is closely analogous to a resource element in the IMS CP informaton mod-
+                el. Variant is a container for an alternative resource. A resource many contain references
+                to assets that are all of the same type or different types i.e. file formats. The Variant
+                class points to the alternative resource. Metadata is used to describe the nature of a co-
+                llection of alternative assets and their intended use. Examples include, but are not limi-
+                ted to, use as lingual variants, visual or auditory variants, remediation variants or pla-
+                tform delivery variants. The scope of referenced assts is specific to a Variant object. T-
+                heir use is in the context of the parent object containing a variant instance, typically a
+                bound instance of a Resource object from the IMS CP namespace.
+Represents a binding of the
+                kinds of child objects defined for ims-cp-imResource: Resource.[ Metadata, File, Dependen-
+                cy, Extension ].
+                Represents a binding of the kinds of characteristic objects defined for ims-cp-imResource: Resource{ Identifier, Type, Base, Href, Other }.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="metadata" type="Metadata.Type" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="xs:ID" />
+        <xs:attribute name="identifierref" use="required" type="xs:IDREF" />
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the SOAP Binding ComplexTypes *********************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived ComplexTypes **************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Complex) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Derived) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the root element(s) *************************************************************** -->
+
+    <xs:element name="variant" type="Variant.Type" />
+
+    <!-- ================================================================================================== -->
+
+</xs:schema>

--- a/model/qti/data/qtiv3/imsqtiv3p0_csmv1p1_v1p0.xsd
+++ b/model/qti/data/qtiv3/imsqtiv3p0_csmv1p1_v1p0.xsd
@@ -1,0 +1,221 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xs:schema xmlns="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscsmd_v1p1"
+     targetNamespace="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscsmd_v1p1"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+     version="IMS CSM QTI 3.0"
+     elementFormDefault="qualified"
+     attributeFormDefault="unqualified">
+
+    <xs:annotation>
+        <xs:documentation>
+            XSD Data File Information
+            =========================
+            Author:         Colin Smythe
+            Date:           11th December, 2017
+            Version:        3.0
+            Status:         Final
+            Description:    The data model for metadata used to annotate resources with curriculum standards GUIDs.
+                                            This is the profile for the Question and Test Interoperability (QTI) v3.0.
+
+            History:        Version 1.0: The first formal release of this QTI 3.0 profiled PSM binding.
+
+            PROFILE:        This is the "QTIv3p0". THIS IS A PROFILE OF THE BASE SPECIFICATION.
+                            The changes to the base specification are:
+                            * The schema namespace has been changed to "http://www.imsglobal.org/xsd/qti/qtiv3p0/imscsmd_v1p1".
+                            * The schema version has been changed to "IMS CSM QTI 3.0".
+
+            License:        IPR and Distribution Notices
+
+                            This machine readable file is derived from IMS Global specification IMS Curriculum Standards Metadata (CSM) for QTI Version 1.1
+                            found at http://www.imsglobal.org/csm and the original IMS Global schema binding or code base
+                            http://www.imsglobal.org/csm.
+
+                            Recipients of this document are requested to submit, with their comments, notification of any relevant 
+                            patent claims or other intellectual property rights of which they may be aware that might be infringed by
+                            any implementation of the specification set forth in this document, and to provide supporting documentation.
+
+                            IMS takes no position regarding the validity or scope of any intellectual property or other rights that might
+                            be claimed to pertain to the implementation or use of the technology described in this document or the extent 
+                            to which any license under such rights might or might not be available; neither does it represent that it has 
+                            made any effort to identify any such rights. Information on IMS procedures with respect to rights in IMS 
+                            specifications can be found at the IMS Global Intellectual Property Rights web page: http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf.
+
+                            Copyright (c) IMS Global Learning Consortium 1999-2017. All Rights Reserved.
+
+                            Use of this specification to develop products or services is governed by the license with IMS found on the IMS website: http://www.imsglobal.org/license.html.
+
+                            Permission is granted to all parties to use excerpts from this document as needed in producing requests for proposals.
+
+                            The limited permissions granted above are perpetual and will not be revoked by IMS or its successors or assigns.
+
+                            THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS
+                            EXPRESSLY DISCLAIMED. ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTERS OWN RISK, AND NEITHER THE CONSORTIUM
+                            NOR ANY OF ITS MEMBERS OR SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR THIRD PARTY FOR ANY DAMAGES OF
+                            ANY NATURE WHATSOEVER, DIRECTLY OR INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
+
+            Source UML File Information
+            ===========================
+            The source file information must be supplied as an XMI file (without diagram layout information).
+            The supported UML authoring tools are:
+            (a) Poseidon - v6 (and later)
+            (b) Papyrus - v1.1.3 (and later)
+
+            Source XSLT File Information
+            ============================
+            XSL Generator:    Specificationv1p0_GenerationToolv1.xsl
+            XSLT Processor:   Saxon
+            Release:          1.0
+            Date:             31st July, 2017
+            Autogen Engineer: Colin Smythe (IMS Global, UK)
+            Autogen Date:     2017-12-05
+
+            IMS Global Auto-generation Binding Tool-kit (I-BAT)
+            ===================================================
+            This file was auto-generated using the IMS Global Binding Auto-generation Tool-kit (I-BAT).  While every
+            attempt has been made to ensure that this tool auto-generates the files correctly, users should be aware
+            that this is an experimental tool.  Permission is given to make use of this tool.  IMS Global makes no
+            claim on the materials created by third party users of this tool.  Details on how to use this tool
+            are contained in the IMS Global "I-BAT" documentation available at the IMS Global web-site:
+            http://www.imsglobal.org.
+
+            Tool Copyright:  2012-2017  (c) IMS Global Learning Consortium Inc.  All Rights Reserved.
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Generate Global Attributes (non-assigned) ******************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global Attributes *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global List Types *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Namespaced extension Group  ************************************************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Special DataTypes  ********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the enumerated simpleType declarations ************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Parameter) ***************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Derived) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Union) ********************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Complex) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon simpleType ************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon derived simpleType **************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the ComplexTypes ************************************************************************ -->
+
+    <xs:complexType name="CurriculumStandardsMetadata.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The CurriculumStandardsMetadata data-type is the container for the specicial metadata for 
+                curriculum standards for a particular domain of GUID provider. The 'providerId' attribute 
+                is used to denote the originator of the GUID scheme.                                      
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="setOfGUIDs" type="SetOfGUIDs.Type" minOccurs="1" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="providerId" use="optional" type="xs:normalizedString" />
+    </xs:complexType>
+
+    <xs:complexType name="CurriculumStandardsMetadataSet.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The CurriculumStandardsMetadataSet data-type is the container for the set of curriculum s-
+                tandards metadata. Each member of the set contains the curriculum standards metadata for a
+                specific source of the GUIDs. The 'resourceLabel' attribute is a human readable label used
+                to identify the type of resource, or part of resource, to which the enclosed metadata ref-
+                ers. The 'resourcePartId' is used to contain the appropriate identifier that is used to i-
+                dentify the resource part e.g. a QTI-Item within a QTI-Assessment.                        
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="curriculumStandardsMetadata" type="CurriculumStandardsMetadata.Type" minOccurs="1" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="resourceLabel" use="optional" type="xs:normalizedString" />
+        <xs:attribute name="resourcePartId" use="optional" type="xs:normalizedString" />
+    </xs:complexType>
+
+    <xs:complexType name="LabelledGUID.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The labelled curriculum standard GUID. The optional label provides a human readable string
+                to provide a clue about the nature of the curriculum standard.                            
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="label" type="xs:normalizedString" minOccurs="0" maxOccurs="1" />
+            <xs:element name="caseItemURI" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
+            <xs:element name="GUID" type="xs:normalizedString" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="SetOfGUIDs.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The SetofGUIDs data-type is the container for the set of GUIDs that are to annotate a res-
+                ource for a particular geographical/socio-political/etc. region. The region is denote usi-
+                ng the 'region' attribute. The 'version' attribute is used to denote any relevant version-
+                ing information.                                                                          
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="labelledGUID" type="LabelledGUID.Type" minOccurs="1" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="region" use="optional" type="xs:normalizedString" />
+        <xs:attribute name="version" use="optional" type="xs:normalizedString" />
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the SOAP Binding ComplexTypes *********************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived ComplexTypes **************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Complex) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Derived) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the root element(s) *************************************************************** -->
+
+    <xs:element name="curriculumStandardsMetadataSet" type="CurriculumStandardsMetadataSet.Type" />
+
+    <!-- ================================================================================================== -->
+
+</xs:schema>

--- a/model/qti/data/qtiv3/imsqtiv3p0_imscpv1p2_v1p0.xsd
+++ b/model/qti/data/qtiv3/imsqtiv3p0_imscpv1p2_v1p0.xsd
@@ -1,0 +1,493 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xs:schema xmlns="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1"
+     targetNamespace="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1"
+     xmlns:lom="http://ltsc.ieee.org/xsd/LOM"
+     xmlns:csmd="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscsmd_v1p1"
+     xmlns:qmd="http://www.imsglobal.org/xsd/imsqti_metadata_v3p0"
+     xmlns:cpx="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_extensionv1p2"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+     version="IMS CP 1.2 QTI 3.0"
+     elementFormDefault="qualified"
+     attributeFormDefault="unqualified">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../w3/xml.xsd" />
+    <xs:import namespace="http://ltsc.ieee.org/xsd/LOM" schemaLocation="../lom/imsmd_loose_v1p3p2.xsd" />
+    <xs:import namespace="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscsmd_v1p1" schemaLocation="imsqtiv3p0_csmv1p1_v1p0.xsd" />
+    <xs:import namespace="http://www.imsglobal.org/xsd/imsqti_metadata_v3p0" schemaLocation="imsqti_metadatav3p0_v1p0.xsd" />
+    <xs:import namespace="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_extensionv1p2" schemaLocation="imsqtiv3p0_cpextv1p2_v1p0.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+            XSD Data File Information
+            =========================
+            Author:         Colin Smythe (IMS Global, UK)
+            Date:           14th March, 2019
+            Version:        3.0
+            Status:         Candidate Final
+            Description:    This is the QTIv3.0 profile of the IMS CPv1.2 specification. This is a normative 
+                            representation of the IMS CP 1.2 Information Model for binding purposes.  Read 
+                            the corresponding IMS CP Information Model for the Platform Independent Model 
+                            representation.
+
+            History:        This is version 1 of the IMS CP v1.2 QTI v3.0 XSD.
+
+            PROFILE:        This is the "QTIv3p0". THIS IS A PROFILE OF THE BASE SPECIFICATION.
+                            The changes to the base specification are:
+                            * The schema namespace has been changed to "http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1".
+                            * The schema version has been changed to "IMS CP 1.2 QTI 3.0".
+                            * The "Item" class/complexType and set of XML attributes have been deleted;
+                            * The "ItemMetadata" class/complexType and set of XML attributes have been deleted;
+                            * The "Organization" class/complexType and set of XML attributes have been deleted;
+                            * The "OrganizationMetadata" class/complexType and set of XML attributes have been deleted;
+                            * The "Organizations.Attr" class/complexType and set of XML attributes have been deleted;
+                            * The "Dependency" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                            * The "Dependency.Attr" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                              - The "identifierref" attribute class type has been changed to the class "IDREF";
+                            * The "File" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                            * The "File.Attr" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                            * The "FileMetadata" class/complexType has been modified by:-
+                              - The "schema" attribute has been prohibited;
+                              - The "schemaversion" attribute has been prohibited;
+                            * The "Manifest" class/complexType has been modified by:-
+                              - The "manifest" attribute has been prohibited;
+                              - The "extension" attribute has been prohibited;
+                              - The "metadata" attribute has been made required i.e. multiplicity [1..1];
+                            * The "Manifest.Attr" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                              - The "version" attribute has been prohibited;
+                            * The "ManifestMetadata" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                              - The "schema" attribute has been made required i.e. multiplicity [1..1];
+                              - The "schemaversion" attribute has been made required i.e. multiplicity [1..1];
+                              - The "schema" attribute class type has been changed to the class "Schema";
+                              - The "schemaversion" attribute class type has been changed to the class "SchemaVersion";
+                              - The "curriculumStandardsMetadataSet" attribute has been added using Import;
+                              - The "lom" attribute has been added using Import;
+                            * The "Organizations" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                            * The "Resource" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                              - The "file" attribute has been made required i.e. multiplicity [1..*];
+                              - The "variant" attribute has been added using Import;
+                            * The "Resource.Attr" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                              - The "type" attribute class type has been changed to the class "ResourceType";
+                            * The "ResourceMetadata" class/complexType has been modified by:-
+                              - The "schema" attribute has been prohibited;
+                              - The "schemaversion" attribute has been prohibited;
+                              - The "extension" attribute has been prohibited;
+                              - The "qtiMetadata" attribute has been added using Import;
+                              - The "curriculumStandardsMetadataSet" attribute has been added using Import;
+                              - The "lom" attribute has been added using Import;
+                            * The "Resources" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+                            * The "Resources.Attr" class/complexType has been modified by:-
+                              - The "extension" attribute has been prohibited;
+
+            License:        IPR and Distribution Notices
+
+                            This machine readable file is derived from IMS Global specification IMS Question and Test Interoperability (QTI): Assessment, Section and Item Version 3.0
+                            found at http://www.imsglobal.org/qti and the original IMS Global schema binding or code base
+                            http://www.imsglobal.org/qti.
+
+                            Recipients of this document are requested to submit, with their comments, notification of any relevant 
+                            patent claims or other intellectual property rights of which they may be aware that might be infringed by
+                            any implementation of the specification set forth in this document, and to provide supporting documentation.
+
+                            IMS takes no position regarding the validity or scope of any intellectual property or other rights that might
+                            be claimed to pertain to the implementation or use of the technology described in this document or the extent 
+                            to which any license under such rights might or might not be available; neither does it represent that it has 
+                            made any effort to identify any such rights. Information on IMS procedures with respect to rights in IMS 
+                            specifications can be found at the IMS Global Intellectual Property Rights web page: http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf.
+
+                            Copyright (c) IMS Global Learning Consortium 1999-2019. All Rights Reserved.
+
+                            Use of this specification to develop products or services is governed by the license with IMS found on the IMS website: http://www.imsglobal.org/license.html.
+
+                            Permission is granted to all parties to use excerpts from this document as needed in producing requests for proposals.
+
+                            The limited permissions granted above are perpetual and will not be revoked by IMS or its successors or assigns.
+
+                            THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS
+                            EXPRESSLY DISCLAIMED. ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTERS OWN RISK, AND NEITHER THE CONSORTIUM
+                            NOR ANY OF ITS MEMBERS OR SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR THIRD PARTY FOR ANY DAMAGES OF
+                            ANY NATURE WHATSOEVER, DIRECTLY OR INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
+
+            Source UML File Information
+            ===========================
+            The source file information must be supplied as an XMI file (without diagram layout information).
+            The supported UML authoring tools are:
+            (a) Poseidon - v6 (and later)
+            (b) Papyrus - v1.1.3 (and later)
+
+            Source XSLT File Information
+            ============================
+            XSL Generator:    Specificationv1p0_GenerationToolv1.xsl
+            XSLT Processor:   Saxon
+            Release:          1.0
+            Date:             31st July, 2017
+            Autogen Engineer: Colin Smythe (IMS Global, UK)
+            Autogen Date:     2019-04-01
+
+            IMS Global Auto-generation Binding Tool-kit (I-BAT)
+            ===================================================
+            This file was auto-generated using the IMS Global Binding Auto-generation Tool-kit (I-BAT).  While every
+            attempt has been made to ensure that this tool auto-generates the files correctly, users should be aware
+            that this is an experimental tool.  Permission is given to make use of this tool.  IMS Global makes no
+            claim on the materials created by third party users of this tool.  Details on how to use this tool
+            are contained in the IMS Global "I-BAT" documentation available at the IMS Global web-site:
+            http://www.imsglobal.org.
+
+            Tool Copyright:  2012-2019  (c) IMS Global Learning Consortium Inc.  All Rights Reserved.
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Generate Global Attributes (non-assigned) ******************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global Attributes *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global List Types *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Namespaced extension Group  ************************************************************* -->
+
+    <xs:group name="grpStrict.any">
+        <xs:annotation>
+            <xs:documentation>
+                Any namespaced element from any namespace, other than the target namespace, may be included within an "any" element.
+                The namespace for the imported element must be defined in the instance, and the schema must be imported.
+                The extension has a definition of "strict" i.e. they must have their own namespace.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:any namespace = "##other" processContents = "strict" minOccurs = "0" maxOccurs = "unbounded" />
+        </xs:sequence>
+    </xs:group>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Special DataTypes  ********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the enumerated simpleType declarations ************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Parameter) ***************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Derived) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Union) ********************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Complex) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon simpleType ************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon derived simpleType **************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the ComplexTypes ************************************************************************ -->
+
+    <xs:complexType name="Dependency.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                A Dependency element provides a way to associate another collection of asset references w-
+                ithin the scope of the dependency element's parent resource element. This element allows  
+                the parsimonious declaration of asset refereces. Shared asset references can be declared  
+                once and associated many times through a Dependency element.
+Represents a binding of the  
+                kinds of child objects defined for ims-cp-imDependency: Dependency.[ Extension ].         
+                Represents a binding of the kinds of characteristic objects defined for ims-cp-imDependency: Dependency{ IdentifierRef, Other }.
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "extension" element has been prohibited;
+                [QTIv3p0] Profile - the changes to the XML attribute list are:
+                * The "extension" attribute has been prohibited;
+                * The "identifierref" attribute class type has been changed to the class "IDREF";
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+        </xs:sequence>
+        <xs:attribute name="identifierref" use="required" type="xs:IDREF" />
+    </xs:complexType>
+
+    <xs:complexType name="File.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                A File element declares a reference to a single asset. The reference may be relative to t-
+                he Package containing the file element or absolute (external to the Package). A File elem-
+                ent may contain child extensions declaring alternative references to the same asset as th-
+                at referenced by the file element's 'href' attribute.
+Represents a binding of the kinds of
+                child objects defined for ims-cp-imFile: File.[ Metadata, Extension ].                    
+                Represents a binding of the kinds of characteristic objects defined for ims-cp-imFile: File{ Href, Other }.
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "extension" element has been prohibited;
+                [QTIv3p0] Profile - the changes to the XML attribute list are:
+                * The "extension" attribute has been prohibited;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="metadata" type="FileMetadata.Type" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="href" use="required" type="xs:anyURI" />
+    </xs:complexType>
+
+    <xs:complexType name="FileMetadata.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                An instance of the File metadata element contains data structures that declare descriptive
+                information about the parent File only. One or more different metadata models may be decl-
+                ared as child extensions of a metadata element.
+Represents a binding of the kinds of child
+                objects defined for ims-cp-imMetadata: Metadata.[ Extension ].                            
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "schema" element has been prohibited;
+                * The "schemaversion" element has been prohibited;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:group ref="grpStrict.any" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Manifest.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                A Manifest element is a container for data structures whose contents describe a semantica-
+                lly complete instance of the IMS CP Information model. A Manifest element may contain ref-
+                erence child manifest elements in the same Manifest document. The root manifest element d-
+                efines an entire IMS Package. A child manifest element defines a semantically complete su-
+                bset of that package.
+Represents a binding of the kinds of objects defined as children of 
+                ims-cp-imManifest : Manifest.[ ManifestMetadata, Organizations, Resources, Manifest, Exte-
+                nsion ].                                                                                  
+                Represents a binding of the kinds of characteristic objects defined for ims-cp-imManifest: Manifest{ Identifier, Version, Base, Other }.
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "manifest" element has been prohibited;
+                * The "extension" element has been prohibited;
+                * The "metadata" element has been made required i.e. multiplicity [1..1];
+                [QTIv3p0] Profile - the changes to the XML attribute list are:
+                * The "extension" attribute has been prohibited;
+                * The "version" attribute has been prohibited;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="metadata" type="ManifestMetadata.Type" minOccurs="1" maxOccurs="1" />
+            <xs:element name="organizations" type="Organizations.Type" minOccurs="1" maxOccurs="1" />
+            <xs:element name="resources" type="Resources.Type" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="xs:ID" />
+        <xs:attribute ref="xml:base" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="ManifestMetadata.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                This metadata element contains data structures that declare descriptive information about 
+                an entire Package. One or more different metadata models may be declared as child extensi-
+                ons of a metadata element. The schema and schemaversion children define the kind or colle-
+                ction of metadata models being used.
+Represents a binding of the kinds of child objects d-
+                efined for ims-cp-imManifestMetadata: ManifestMetadata.[ Schema, SchemaVersion, MetadataM-
+                odel ]..                                                                                  
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "extension" element has been prohibited;
+                * The "schema" element has been made required i.e. multiplicity [1..1];
+                * The "schemaversion" element has been made required i.e. multiplicity [1..1];
+                * The "schema" element class type has been changed to the class "Schema";
+                * The "schemaversion" element class type has been changed to the class "SchemaVersion";
+                * The "curriculumStandardsMetadataSet" element has been added using Import;
+                * The "lom" element has been added using Import;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="schema" minOccurs="1" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="QTI Package" />
+                        <xs:enumeration value="QTI Test Bank" />
+                        <xs:enumeration value="QTI Item Bank" />
+                        <xs:enumeration value="QTI Object Bank" />
+                        <xs:enumeration value="QTI Test" />
+                        <xs:enumeration value="QTI Section" />
+                        <xs:enumeration value="QTI Item" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="schemaversion" minOccurs="1" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="3.0.0" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element ref="csmd:curriculumStandardsMetadataSet" minOccurs = "0" maxOccurs = "1" />
+            <xs:element ref="lom:lom" minOccurs = "0" maxOccurs = "1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Organizations.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The organizations element is a container for all data structures that describe the way or 
+                ways that information encapsulated by its parent manifest element is structured.
+Represen-
+                ts of binding of the child objects of ims-cp-imOrganizations: Organizations.[ Organizatio-
+                n, Extension ].                                                                           
+                Represents a binding of the kinds of characteristic objects for ims-cp-imOrganizations: Organizations{ Default, Other }.
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "extension" element has been prohibited;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Resource.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                A Resource element is a container for a particular asset or collection of assets. A Resou-
+                rce may contain references to assets that are all of the same type or different types i.e.
+                file formats. The scope or boundary of an IMS Package is defined by the asset references  
+                collected into all resources containers associated with the root manifest element, whether
+                as a child, directed descendant, or externally linked descendant.
+Represents a binding of 
+                the kinds of child objects defined for ims-cp-imResource: Resource.[ Metadata, File, Depe-
+                ndency, Extension ].                                                                      
+                Represents a binding of the kinds of characteristic objects defined for ims-cp-imResource: Resource{ Identifier, Type, Base, Href, Other }.
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "extension" element has been prohibited;
+                * The "file" element has been made required i.e. multiplicity [1..*];
+                * The "variant" element has been added using Import;
+                [QTIv3p0] Profile - the changes to the XML attribute list are:
+                * The "extension" attribute has been prohibited;
+                * The "type" attribute class type has been changed to the class "ResourceType";
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="metadata" type="ResourceMetadata.Type" minOccurs="0" maxOccurs="1" />
+            <xs:element name="file" type="File.Type" minOccurs="1" maxOccurs="unbounded" />
+            <xs:element name="dependency" type="Dependency.Type" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="cpx:variant" minOccurs = "0" maxOccurs = "unbounded" />
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="xs:ID" />
+        <xs:attribute name="type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="imsqti_test_xmlv3p0" />
+                    <xs:enumeration value="imsqti_section_xmlv3p0" />
+                    <xs:enumeration value="imsqti_item_xmlv3p0" />
+                    <xs:enumeration value="imsqti_resprocessing_xmlv3p0" />
+                    <xs:enumeration value="imsqti_outcomes_xmlv3p0" />
+                    <xs:enumeration value="imsqti_stimulus_xmlv3p0" />
+                    <xs:enumeration value="imsqti_fragment_xmlv3p0" />
+                    <xs:enumeration value="imsqti_rptemplate_xmlv3p0" />
+                    <xs:enumeration value="associatedcontent/learning-application-resource" />
+                    <xs:enumeration value="webcontent" />
+                    <xs:enumeration value="imsbasiclti_xmlv1p3" />
+                    <xs:enumeration value="controlfile" />
+                    <xs:enumeration value="resourcemetadata/xml" />
+                    <xs:enumeration value="resourceextmetadata/xml" />
+                    <xs:enumeration value="qtiusagedata/xml" />
+                    <xs:enumeration value="pls" />
+                    <xs:enumeration value="css2" />
+                    <xs:enumeration value="css3" />
+                    <xs:enumeration value="extension" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute ref="xml:base" use="optional" />
+        <xs:attribute name="href" use="optional" type="xs:anyURI" />
+    </xs:complexType>
+
+    <xs:complexType name="ResourceMetadata.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                An instance of the Resource metadata element contains data structures that declare descri-
+                ptive information about the parent Resource only. One or more different metadata models m-
+                ay be declared as child extensions of a metadata element.
+Represents a binding of the kin-
+                ds of child objects defined for ims-cp-imMetadata: Metadata.[ Extension ].                
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "schema" element has been prohibited;
+                * The "schemaversion" element has been prohibited;
+                * The "extension" element has been prohibited;
+                * The "qtiMetadata" element has been added using Import;
+                * The "curriculumStandardsMetadataSet" element has been added using Import;
+                * The "lom" element has been added using Import;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="qmd:qtiMetadata" minOccurs = "0" maxOccurs = "1" />
+            <xs:element ref="csmd:curriculumStandardsMetadataSet" minOccurs = "0" maxOccurs = "1" />
+            <xs:element ref="lom:lom" minOccurs = "0" maxOccurs = "1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Resources.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The Resources element is a container for data structures containing references to one or  
+                more assets. Asset references may be grouped within a containing resources element in wha-
+                tever manner seems best. The scope of referenced assets is specific to a resource element-
+                's parent manifest element only.
+Represents a binding of the kinds of child objects defin-
+                ed for ims-cp-imResources: Resources.[ Resource, Extension ].                             
+                Represents a binding of the kinds of characteristic objects defined for ims-cp-imResources: Resources{ Base, Other }.
+                [QTIv3p0] Profile - the changes to the XML element list are:
+                * The "extension" element has been prohibited;
+                [QTIv3p0] Profile - the changes to the XML attribute list are:
+                * The "extension" attribute has been prohibited;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="resource" type="Resource.Type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute ref="xml:base" use="optional" />
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the SOAP Binding ComplexTypes *********************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived ComplexTypes **************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Complex) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Derived) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the root element(s) *************************************************************** -->
+
+    <xs:element name="manifest" type="Manifest.Type" />
+
+    <!-- ================================================================================================== -->
+
+</xs:schema>

--- a/model/qti/response/Template.php
+++ b/model/qti/response/Template.php
@@ -103,6 +103,13 @@ class Template extends ResponseProcessing implements Rule
     // phpcs:enable Generic.NamingConventions.UpperCaseConstantName,Generic.Files.LineLength
 
     /**
+     * QTI 3.0
+     */
+    public const MAP_RESPONSE_POINT_qtiv3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/map_response_point';
+    public const MATCH_CORRECT_qtiv3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/match_correct.xml';
+    public const MAP_RESPONSE_qtiv3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates//map_response';
+
+    /**
      * Template to apply when no response processing should take place
      */
     public const NONE = 'no_response_processing';
@@ -194,16 +201,19 @@ class Template extends ResponseProcessing implements Rule
             case self::MATCH_CORRECT:
             case self::MATCH_CORRECT_qtiv2p0:
             case self::MATCH_CORRECT_qtiv2p2:
+            case self::MATCH_CORRECT_qtiv3:
                 $this->uri = self::MATCH_CORRECT;
                 break;
             case self::MAP_RESPONSE:
             case self::MAP_RESPONSE_qtiv2p0:
             case self::MAP_RESPONSE_qtiv2p2:
+            case self::MAP_RESPONSE_qtiv3:
                 $this->uri = self::MAP_RESPONSE;
                 break;
             case self::MAP_RESPONSE_POINT:
             case self::MAP_RESPONSE_POINT_qtiv2p0:
             case self::MAP_RESPONSE_POINT_qtiv2p2:
+            case self::MAP_RESPONSE_POINT_qtiv3:
                 $this->uri = self::MAP_RESPONSE_POINT;
                 break;
             case self::NONE:

--- a/model/qti/response/Template.php
+++ b/model/qti/response/Template.php
@@ -110,6 +110,7 @@ class Template extends ResponseProcessing implements Rule
     public const SPEC_MAP_RESPONSE_POINT_QTI_V3 = 'https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/map_response_point';
     public const SPEC_RESPONSE_QTI_V3 = 'https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/match_correct.xml';
     public const SPEC_MAP_RESPONSE_QTI_V3 = 'https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/map_response.xml';
+    public const SPEC_MATCH_CORRECT_QTI_V3 = 'http://purl.imsglobal.org/spec/qti/v3p0/rptemplates/match_correct.xml';
 
     // phpcs:enable Generic.NamingConventions.UpperCaseConstantName,Generic.Files.LineLength
 
@@ -206,7 +207,7 @@ class Template extends ResponseProcessing implements Rule
             case self::MATCH_CORRECT_qtiv2p0:
             case self::MATCH_CORRECT_qtiv2p2:
             case self::MATCH_CORRECT_QTI_V3:
-            case self::SPEC_RESPONSE_QTI_V3:
+            case self::SPEC_MATCH_CORRECT_QTI_V3:
                 $this->uri = self::MATCH_CORRECT;
                 break;
             case self::MAP_RESPONSE:
@@ -214,6 +215,7 @@ class Template extends ResponseProcessing implements Rule
             case self::MAP_RESPONSE_qtiv2p2:
             case self::MAP_RESPONSE_QTI_V3:
             case self::SPEC_MAP_RESPONSE_QTI_V3:
+            case self::SPEC_RESPONSE_QTI_V3:
                 $this->uri = self::MAP_RESPONSE;
                 break;
             case self::MAP_RESPONSE_POINT:

--- a/model/qti/response/Template.php
+++ b/model/qti/response/Template.php
@@ -107,7 +107,9 @@ class Template extends ResponseProcessing implements Rule
     public const MAP_RESPONSE_POINT_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/map_response_point';
     public const MATCH_CORRECT_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/match_correct.xml';
     public const MAP_RESPONSE_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates//map_response';
+    public const SPEC_MAP_RESPONSE_POINT_QTI_V3 = 'https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/map_response_point';
     public const SPEC_RESPONSE_QTI_V3 = 'https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/match_correct.xml';
+    public const SPEC_MAP_RESPONSE_QTI_V3 = 'https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/map_response.xml';
 
     // phpcs:enable Generic.NamingConventions.UpperCaseConstantName,Generic.Files.LineLength
 
@@ -205,19 +207,20 @@ class Template extends ResponseProcessing implements Rule
             case self::MATCH_CORRECT_qtiv2p2:
             case self::MATCH_CORRECT_QTI_V3:
             case self::SPEC_RESPONSE_QTI_V3:
-
                 $this->uri = self::MATCH_CORRECT;
                 break;
             case self::MAP_RESPONSE:
             case self::MAP_RESPONSE_qtiv2p0:
             case self::MAP_RESPONSE_qtiv2p2:
             case self::MAP_RESPONSE_QTI_V3:
+            case self::SPEC_MAP_RESPONSE_QTI_V3:
                 $this->uri = self::MAP_RESPONSE;
                 break;
             case self::MAP_RESPONSE_POINT:
             case self::MAP_RESPONSE_POINT_qtiv2p0:
             case self::MAP_RESPONSE_POINT_qtiv2p2:
             case self::MAP_RESPONSE_POINT_QTI_V3:
+            case self::SPEC_MAP_RESPONSE_POINT_QTI_V3:
                 $this->uri = self::MAP_RESPONSE_POINT;
                 break;
             case self::NONE:

--- a/model/qti/response/Template.php
+++ b/model/qti/response/Template.php
@@ -107,6 +107,8 @@ class Template extends ResponseProcessing implements Rule
     public const MAP_RESPONSE_POINT_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/map_response_point';
     public const MATCH_CORRECT_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/match_correct.xml';
     public const MAP_RESPONSE_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates//map_response';
+    public const SPEC_RESPONSE_QTI_V3 = 'https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/match_correct.xml';
+
     // phpcs:enable Generic.NamingConventions.UpperCaseConstantName,Generic.Files.LineLength
 
     /**
@@ -202,6 +204,8 @@ class Template extends ResponseProcessing implements Rule
             case self::MATCH_CORRECT_qtiv2p0:
             case self::MATCH_CORRECT_qtiv2p2:
             case self::MATCH_CORRECT_QTI_V3:
+            case self::SPEC_RESPONSE_QTI_V3:
+
                 $this->uri = self::MATCH_CORRECT;
                 break;
             case self::MAP_RESPONSE:

--- a/model/qti/response/Template.php
+++ b/model/qti/response/Template.php
@@ -100,14 +100,14 @@ class Template extends ResponseProcessing implements Rule
      * @var string
      */
     public const MAP_RESPONSE_POINT_qtiv2p2 = 'http://www.imsglobal.org/question/qti_v2p2/rptemplates/map_response_point';
-    // phpcs:enable Generic.NamingConventions.UpperCaseConstantName,Generic.Files.LineLength
 
     /**
      * QTI 3.0
      */
-    public const MAP_RESPONSE_POINT_qtiv3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/map_response_point';
-    public const MATCH_CORRECT_qtiv3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/match_correct.xml';
-    public const MAP_RESPONSE_qtiv3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates//map_response';
+    public const MAP_RESPONSE_POINT_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/map_response_point';
+    public const MATCH_CORRECT_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates/match_correct.xml';
+    public const MAP_RESPONSE_QTI_V3 = 'https://www.imsglobal.org/question/qti_v3p0/rptemplates//map_response';
+    // phpcs:enable Generic.NamingConventions.UpperCaseConstantName,Generic.Files.LineLength
 
     /**
      * Template to apply when no response processing should take place
@@ -201,19 +201,19 @@ class Template extends ResponseProcessing implements Rule
             case self::MATCH_CORRECT:
             case self::MATCH_CORRECT_qtiv2p0:
             case self::MATCH_CORRECT_qtiv2p2:
-            case self::MATCH_CORRECT_qtiv3:
+            case self::MATCH_CORRECT_QTI_V3:
                 $this->uri = self::MATCH_CORRECT;
                 break;
             case self::MAP_RESPONSE:
             case self::MAP_RESPONSE_qtiv2p0:
             case self::MAP_RESPONSE_qtiv2p2:
-            case self::MAP_RESPONSE_qtiv3:
+            case self::MAP_RESPONSE_QTI_V3:
                 $this->uri = self::MAP_RESPONSE;
                 break;
             case self::MAP_RESPONSE_POINT:
             case self::MAP_RESPONSE_POINT_qtiv2p0:
             case self::MAP_RESPONSE_POINT_qtiv2p2:
-            case self::MAP_RESPONSE_POINT_qtiv3:
+            case self::MAP_RESPONSE_POINT_QTI_V3:
                 $this->uri = self::MAP_RESPONSE_POINT;
                 break;
             case self::NONE:

--- a/test/unit/model/qti/converter/CaseConversionServiceTest.php
+++ b/test/unit/model/qti/converter/CaseConversionServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti\converter;
+
+use oat\taoQtiItem\model\qti\converter\CaseConversionService;
+use PHPUnit\Framework\TestCase;
+
+class CaseConversionServiceTest extends TestCase
+{
+    public static function kebabToCamelCaseProvider()
+    {
+        return [
+            'qti prefix present' => [
+                'kebab' => 'qti-assessment-item',
+                'camel' => 'assessmentItem'
+            ],
+            'qti prefix not present' => [
+                'kebab' => 'assessment-item',
+                'camel' => 'assessmentItem'
+            ],
+            'not kebab case' => [
+                'kebab' => 'assessmentItem',
+                'camel' => 'assessmentItem',
+            ],
+        ];
+    }
+
+    public function setUp(): void
+    {
+        $this->subject = new CaseConversionService();
+    }
+
+    /**
+     * @dataProvider kebabToCamelCaseProvider
+     */
+    public function testKebabToCamelCase(string $kebab, string $camel)
+    {
+        $this->assertEquals($camel, $this->subject->kebabToCamelCase($kebab));
+    }
+}

--- a/test/unit/model/qti/converter/ItemConverterTest.php
+++ b/test/unit/model/qti/converter/ItemConverterTest.php
@@ -48,7 +48,4 @@ class ItemConverterTest extends TestCase
         //Delete file
         unlink($modifiedFile);
     }
-
-
-
 }

--- a/test/unit/model/qti/converter/ItemConverterTest.php
+++ b/test/unit/model/qti/converter/ItemConverterTest.php
@@ -43,7 +43,7 @@ class ItemConverterTest extends TestCase
             ->method('kebabToCamelCase')
             ->willReturn('camelCase');
 
-        $this->subject->convert($modifiedFile);
+        $this->subject->convertToQti2($modifiedFile);
 
         //Delete file
         unlink($modifiedFile);

--- a/test/unit/model/qti/converter/ItemConverterTest.php
+++ b/test/unit/model/qti/converter/ItemConverterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti\converter;
+
+use oat\taoQtiItem\model\qti\converter\CaseConversionService;
+use oat\taoQtiItem\model\qti\converter\ItemConverter;
+use PHPUnit\Framework\TestCase;
+
+class ItemConverterTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->caseConversionMock = $this->createMock(CaseConversionService::class);
+        $this->subject = new ItemConverter($this->caseConversionMock);
+    }
+
+    public function testConvert()
+    {
+        //Copy file
+        $modifiedFile = dirname(__FILE__) . '/../../../samples/model/qti/item/qti3_copy.xml';
+        copy(dirname(__FILE__) . '/../../../samples/model/qti/item/qti3.xml', $modifiedFile);
+        $this->caseConversionMock->expects($this->exactly(17))
+            ->method('kebabToCamelCase')
+            ->willReturn('camelCase');
+
+        $this->subject->convert($modifiedFile);
+
+        //Delete file
+        unlink($modifiedFile);
+    }
+
+
+
+}

--- a/test/unit/samples/model/qti/item/qti3.xml
+++ b/test/unit/samples/model/qti/item/qti3.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqtiasi_v3p0 https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0_v1p0.xsd"
+                     identifier="t1-test-entry-item2" title="T1 - Choice Interaction - Multiple Cardinality"
+                     adaptive="false" time-dependent="false" xml:lang="en-US">
+    <qti-response-declaration identifier="RESPONSE" cardinality="multiple" base-type="identifier"/>
+    <qti-item-body>
+        <qti-choice-interaction response-identifier="RESPONSE" min-choices="0" max-choices="3">
+            <qti-prompt>Select 0 to N SimpleChoices below and end the attempt by submitting the response.</qti-prompt>
+            <qti-simple-choice identifier="choice_c">choice_c</qti-simple-choice>
+        </qti-choice-interaction>
+    </qti-item-body>
+</qti-assessment-item>


### PR DESCRIPTION
This change allow TAO user to import QTI 3 Packages into Authoring. 

Process will downgrade QTI 3 package to QTI 2.2. 
All kebab case conventions will be converted into camel-case. 

All required xsd files has been stored in `model/qti/data/qtiv3`

How to test: 
1. Take QTI 3 package
2. Import it into Tests or Items
3. Make sure all content was successfully imported

Example QTI 3 Packages:
[A13captions_A15glossary.zip](https://github.com/user-attachments/files/18185910/A13captions_A15glossary.zip)
[qti-3-test.zip](https://github.com/user-attachments/files/18185911/qti-3-test.zip)



