### PR TITLE
fix: multiple hottext support when disallowHTMLInHottext is enabled

### DIFF
--- a/views/js/qtiCreator/widgets/helpers/selectionWrapper.js
+++ b/views/js/qtiCreator/widgets/helpers/selectionWrapper.js
@@ -134,10 +134,10 @@ define(['jquery'], function ($) {
              * @param {jQuery} $wrapper - the element that will wrap the selection
              * @returns {boolean}
              */
-            wrapWith: function wrapWith($wrapper) {
-                const range = selection.getRangeAt(0);
+            wrapWith: function wrapWith($wrapper, providedRange) {
+                const range = providedRange || selection.getRangeAt(0);
 
-                if (this.canWrap()) {
+                if (this.canWrap(range)) {
                     try {
                         range.surroundContents($wrapper[0]);
                         selection.removeAllRanges();

--- a/views/js/qtiCreator/widgets/interactions/hottextInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/hottextInteraction/states/Question.js
@@ -140,7 +140,7 @@ define([
             } else {
                 if (
                     $cloneContent.text() === $cloneContent.html() &&
-                    wrapper.wrapWith($newHottextClone)
+                    wrapper.wrapWith($newHottextClone, range)
                 ) {
                     await this.createNewHottext($newHottextClone);
                 } else {


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3890

## What's Changed

- Added support for multiple `hottext` when `disallowHTMLInHottext` is enabled


## How to test
- Enable FF `disallowHTMLInHottext`
- Create an Item and add hottext interaction to it
- Select the text
- Click multiple `hottext` button
- The words should be selected separately, divided by the space in selection

The changes are **deployed** to https://construct1-oat-unit04.dev.gcp-eu.taocloud.org/tao/Main/login
The FF is enabled there