### PR TITLE
fix: pci filename is used as identifier, not path

### DIFF
--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -145,7 +145,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
 
         foreach ($contents as $file) {
             if ($file['type'] === 'file') {
-                $identifier = $file['path'];
+                $identifier = basename($file['path']);
                 $elements[$identifier] = $this->get($identifier);
             }
         }


### PR DESCRIPTION
Fixes a regression in PCI listing. 

PCI filename should be used as identifier, not full path. 

  
#### How to test
 
- Update local TAO to 2025.01 community version
- Navigate to PCI list
- Witness that all PCIs are present as expected