### PR TITLE
fix: pci filename is used as identifier, not path

### DIFF
--- a/model/portableElement/storage/PortableElementRegistry.php
+++ b/model/portableElement/storage/PortableElementRegistry.php
@@ -145,7 +145,7 @@ abstract class PortableElementRegistry implements ServiceLocatorAwareInterface
 
         foreach ($contents as $file) {
             if ($file['type'] === 'file') {
-                $identifier = $file['path'];
+                $identifier = basename($file['path']);
                 $elements[$identifier] = $this->get($identifier);
             }
         }


### PR DESCRIPTION
Backport of https://github.com/oat-sa/extension-tao-itemqti/pull/2656

(cherry picked from commit 1ee16972fc286a6301859b7c27e38c20879b7a7d)