### PR TITLE
Feature/TR-6370/Item creator lang attribute and event

### DIFF
--- a/views/js/qtiCreator/widgets/item/Widget.js
+++ b/views/js/qtiCreator/widgets/item/Widget.js
@@ -97,6 +97,11 @@ define([
 
                 const item = this.element;
                 const $itemBody = this.$container.find('.qti-itemBody');
+
+                if (item.attr('xml:lang')) {
+                    $itemBody.attr('lang', item.attr('xml:lang'));
+                }
+
                 if (!item.bdy.attr('dir') && $itemBody.find('.grid-row[dir="rtl"]').length) {
                     // old xml with dir='rtl' in div.grid-row should be updated
                     item.bdy.attr('dir', 'rtl');

--- a/views/js/qtiCreator/widgets/item/states/Active.js
+++ b/views/js/qtiCreator/widgets/item/states/Active.js
@@ -105,6 +105,9 @@ define([
                 },
                 'xml:lang': function langChange(i, lang) {
                     item.attr('xml:lang', lang);
+                    $itemBody.attr('lang', lang);
+                    $itemBody.trigger('item-lang-changed');
+
                     languages.isRTLbyLanguageCode(lang).then(isRTL => {
                         if (isRTL) {
                             item.bdy.attr('dir', 'rtl');


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-6370

Goes with https://github.com/oat-sa/extension-tao-deliver-pcis/pull/5

Setting temporary `lang` attribute here allows AudioRecording interaction to know what item `xml:lang` value is configured.

![Screenshot 2025-01-10 at 16 23 39](https://github.com/user-attachments/assets/5fabd96b-2739-4e16-82a2-3b20527c3874)
