### PR TITLE
fix: add property checking to items

### DIFF
--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -329,12 +329,25 @@ class ImportService extends ConfigurableService
             $qtiItemResources = $this->createQtiManifest($folder . 'imsmanifest.xml');
 
             if ($importMetadataEnabled) {
-                $metadataValues = $this->getMetadataImporter()->extract($domManifest);
                 $metaMetadataValues = $this->getMetaMetadataExtractor()->extract($domManifest);
                 $mappedMetadataValues = $this->getMetaMetadataImportMapper()->mapMetaMetadataToProperties(
                     $metaMetadataValues,
                     $itemClass
                 );
+                $metadataValues = $this->getMetadataImporter()->extract($domManifest);
+                $metadataValueUris = $this->getMetadataImporter()->metadataValueUris($metadataValues);
+                $notMatchingProperties = array_diff(
+                    $metadataValueUris,
+                    array_keys($mappedMetadataValues['itemProperties'])
+                );
+                if (!empty($notMatchingProperties)) {
+                    return Report::createError(
+                        sprintf(
+                            __('Target class is missing the following metadata properties: %s'),
+                            implode(', ', $notMatchingProperties)
+                        )
+                    );
+                }
                 if (empty($mappedMetadataValues)) {
                     $mappedMetadataValues = $this->getMetaMetadataImportMapper()->mapMetadataToProperties(
                         $metadataValues,

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -335,10 +335,9 @@ class ImportService extends ConfigurableService
                     $itemClass
                 );
                 $metadataValues = $this->getMetadataImporter()->extract($domManifest);
-                $metadataValueUris = $this->getMetadataImporter()->metadataValueUris($metadataValues);
-                $notMatchingProperties = array_diff(
-                    $metadataValueUris,
-                    array_keys($mappedMetadataValues['itemProperties'])
+                $notMatchingProperties = $this->checkMissingClassProperties(
+                    $metadataValues,
+                    $mappedMetadataValues['itemProperties']
                 );
                 if (!empty($notMatchingProperties)) {
                     return Report::createError(
@@ -986,5 +985,20 @@ class ImportService extends ConfigurableService
     private function getItemConverter(): ItemConverter
     {
         return $this->getServiceManager()->getContainer()->get(ItemConverter::class);
+    }
+
+    /**
+     * Checks if target class has all the properties needed to import the metadata.
+     * @param array $metadataValues
+     * @param $itemProperties
+     * @return array
+     */
+    private function checkMissingClassProperties(array $metadataValues, $itemProperties): array
+    {
+        $metadataValueUris = $this->getMetadataImporter()->metadataValueUris($metadataValues);
+        return array_diff(
+            $metadataValueUris,
+            array_keys($itemProperties)
+        );
     }
 }

--- a/model/qti/metadata/importer/MetadataImporter.php
+++ b/model/qti/metadata/importer/MetadataImporter.php
@@ -29,6 +29,7 @@ use oat\taoQtiItem\model\qti\metadata\MetadataGuardian;
 use oat\taoQtiItem\model\qti\metadata\ContextualMetadataGuardian;
 use oat\taoQtiItem\model\qti\metadata\MetadataService;
 use oat\taoQtiItem\model\qti\metadata\MetadataValidator;
+use oat\taoQtiItem\model\qti\metadata\simple\SimpleMetadataValue;
 
 class MetadataImporter extends AbstractMetadataService
 {
@@ -229,6 +230,24 @@ class MetadataImporter extends AbstractMetadataService
                 break;
         }
         return parent::unregister($key, $name);
+    }
+
+    public function metadataValueUris($metadata): array
+    {
+        $metadataUriList = [];
+        foreach ($metadata as $resourceIdentifier => $metadataValueCollection) {
+            foreach ($metadataValueCollection as $metadataValue) {
+                if (!$metadataValue instanceof SimpleMetadataValue) {
+                    continue;
+                }
+                $uri = $metadataValue->getPath()[1];
+                if (!empty($uri)) {
+                    $metadataUriList[] = $uri;
+                }
+            }
+        }
+
+        return $metadataUriList;
     }
 
     /**

--- a/model/qti/metadata/importer/MetadataImporter.php
+++ b/model/qti/metadata/importer/MetadataImporter.php
@@ -247,7 +247,7 @@ class MetadataImporter extends AbstractMetadataService
             }
         }
 
-        return $metadataUriList;
+        return array_unique($metadataUriList);
     }
 
     /**


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4073
## Description
If we try to import item with metadata properties which doesn't exist in class the import fails
## What's Changed
- add property checking to items

## Dependencies PRs
- https://github.com/oat-sa/extension-tao-testqti/pull/2575

## Video

https://github.com/user-attachments/assets/d5f51487-77ec-425e-a409-5dd6298c1701

