### PR TITLE
fix: improve importing items using cli and queue. Link translated ite…

### DIFF
--- a/model/tasks/ImportQtiItem.php
+++ b/model/tasks/ImportQtiItem.php
@@ -43,6 +43,7 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
     public const PARAM_VALIDATORS = 'enableMetadataValidators';
     public const PARAM_ITEM_MUST_EXIST = 'itemMustExist';
     public const PARAM_ITEM_MUST_BE_OVERWRITTEN = 'itemMustBeOverwritten';
+    public const PARAM_ITEM_METADATA = 'importMetadata';
 
     protected $service;
 
@@ -71,7 +72,8 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
             (isset($params[self::PARAM_GUARDIANS])) ? $params[self::PARAM_GUARDIANS] : true,
             (isset($params[self::PARAM_VALIDATORS])) ? $params[self::PARAM_VALIDATORS] : true,
             (isset($params[self::PARAM_ITEM_MUST_EXIST])) ? $params[self::PARAM_ITEM_MUST_EXIST] : false,
-            $params[self::PARAM_ITEM_MUST_BE_OVERWRITTEN] ?? false
+            $params[self::PARAM_ITEM_MUST_BE_OVERWRITTEN] ?? false,
+            $params[self::PARAM_ITEM_METADATA] ?? false
         );
     }
 
@@ -102,7 +104,8 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
         $enableMetadataGuardians = true,
         $enableMetadataValidators = true,
         $itemMustExist = false,
-        $itemMustBeOverwritten = false
+        $itemMustBeOverwritten = false,
+        $itemMetadata = false
     ) {
         $action = new self();
         $action->setServiceLocator($serviceManager);
@@ -120,7 +123,8 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
                 self::PARAM_GUARDIANS => $enableMetadataGuardians,
                 self::PARAM_VALIDATORS => $enableMetadataValidators,
                 self::PARAM_ITEM_MUST_EXIST => $itemMustExist,
-                self::PARAM_ITEM_MUST_BE_OVERWRITTEN => $itemMustBeOverwritten
+                self::PARAM_ITEM_MUST_BE_OVERWRITTEN => $itemMustBeOverwritten,
+                self::PARAM_ITEM_METADATA => $itemMetadata
             ],
             __('Import QTI ITEM into "%s"', $class->getLabel())
         );

--- a/scripts/cli/importItems.php
+++ b/scripts/cli/importItems.php
@@ -299,7 +299,7 @@ class importItems implements Action, ServiceLocatorAwareInterface
                     true,
                     $this->rollbackOnError,
                     $this->rollbackOnWarning,
-                    true, 
+                    true,
                     true,
                     false,
                     false,
@@ -316,10 +316,9 @@ class importItems implements Action, ServiceLocatorAwareInterface
                     false,
                     true
                 );
-    
+
                 $report = new Report(Report::TYPE_INFO, printf('Task %s created', $task->getId()));
             }
-            
         } catch (ExtractException $e) {
             $report = common_report_Report::createFailure(
                 __('The ZIP archive containing the IMS QTI Item cannot be extracted.')
@@ -337,7 +336,7 @@ class importItems implements Action, ServiceLocatorAwareInterface
         helpers_TimeOutHelper::reset();
 
         $this->showReport($report);
-        $this->processed ++;
+        $this->processed++;
 
         return new Report($report->getType());
     }

--- a/scripts/cli/importItems.php
+++ b/scripts/cli/importItems.php
@@ -33,6 +33,7 @@ use oat\tao\model\TaoOntology;
 use oat\taoQtiItem\model\qti\exception\ExtractException;
 use oat\taoQtiItem\model\qti\exception\ParsingException;
 use oat\taoQtiItem\model\qti\ImportService;
+use oat\taoQtiItem\model\tasks\ImportQtiItem;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
@@ -56,6 +57,7 @@ class importItems implements Action, ServiceLocatorAwareInterface
     protected $recurse = false;
     protected $directoryToClass = false;
     protected $processed = 0;
+    protected $async = false;
 
     /**
      * @param array $params
@@ -101,6 +103,10 @@ class importItems implements Action, ServiceLocatorAwareInterface
                     $this->rollbackOnWarning = true;
                     break;
 
+                case '-a':
+                    $this->async = true;
+                    break;
+
                 default:
                     if (file_exists($param)) {
                         $fileName = $param;
@@ -122,6 +128,7 @@ class importItems implements Action, ServiceLocatorAwareInterface
                 . "\t -e\t\t Rollback on error\n"
                 . "\t -w\t\t Rollback on warning\n"
                 . "\t -h\t\t Show this help\n"
+                . "\t -a\t\t Async import\n"
             );
         }
 
@@ -285,13 +292,34 @@ class importItems implements Action, ServiceLocatorAwareInterface
 
         try {
             $importService = ImportService::singleton();
-            $report = $importService->importQTIPACKFile(
-                $fileName,
-                $class,
-                true,
-                $this->rollbackOnError,
-                $this->rollbackOnWarning
-            );
+            if (!$this->async) {
+                $report = $importService->importQTIPACKFile(
+                    $fileName,
+                    $class,
+                    true,
+                    $this->rollbackOnError,
+                    $this->rollbackOnWarning,
+                    true, 
+                    true,
+                    false,
+                    false,
+                    true
+                );
+            } else {
+                $task = ImportQtiItem::createTask(
+                    $fileName,
+                    $class,
+                    $this->getServiceLocator(),
+                    true,
+                    true,
+                    false,
+                    false,
+                    true
+                );
+    
+                $report = new Report(Report::TYPE_INFO, printf('Task %s created', $task->getId()));
+            }
+            
         } catch (ExtractException $e) {
             $report = common_report_Report::createFailure(
                 __('The ZIP archive containing the IMS QTI Item cannot be extracted.')

--- a/scripts/cli/linkTranslatedItems.php
+++ b/scripts/cli/linkTranslatedItems.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+namespace oat\taoQtiItem\scripts\cli;
+
+use oat\generis\model\GenerisRdf;
+use oat\oatbox\reporting\Report;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\tao\model\TaoOntology;
+use taoItems_models_classes_ItemsService as ItemService;
+
+/**
+ * Class linkTranslatedItems
+ *
+ * php index.php '\oat\taoQtiItem\scripts\cli\linkTranslatedItems' -w -c 'http://www.tao.lu/Ontologies/TAO.rdf#QtiItem' -m 'en-US'
+ *
+ * @package oat\taoQtiItem\scripts\cli
+ */
+class linkTranslatedItems extends ScriptAction
+{
+    use OntologyAwareTrait;
+
+    private $wetRun = false;
+    private $classUri = '';
+    private $mainLanguage = '';
+    private $report;
+
+    protected function provideOptions()
+    {
+        return [
+            'wet-run' => [
+                'prefix' => 'w',
+                'flag' => true,
+                'longPrefix' => 'wet-run',
+                'description' => 'Find and remove all orphan triples related to files for removed items.',
+            ],
+            'class' => [
+                'prefix' => 'c',
+                'longPrefix' => 'class',
+                'description' => 'Class to link translations',
+                'required' => true
+            ],
+            'main-language' => [
+                'prefix' => 'm',
+                'longPrefix' => 'main-language',
+                'description' => 'Main language to link translations',
+                'required' => false,
+                'default' => 'en-US'
+            ]
+
+        ];
+    }
+
+    protected function provideDescription()
+    {
+        return 'Tool to remove orphan files attached to removed items. By default in dry-run';
+    }
+
+    protected function provideUsage()
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Prints a help statement'
+        ];
+    }
+    public function run()
+    {
+        $this->report = Report::createInfo('Starting linking translations');
+        $this->init();
+
+        $class = $this->getClass($this->classUri);
+
+        $this->report->add(new Report(Report::TYPE_INFO, 'Linking translations for class ' . $class->getLabel()));
+
+        $aliasProperty = $this->getProperty(GenerisRdf::PROPERTY_ALIAS);
+        $classProperties = $class->getProperties(true);
+
+        foreach ($classProperties as $property) {
+            $aliasName = (string)$property->getOnePropertyValue($aliasProperty);
+
+            if (empty($aliasName)) {
+                continue;
+            }
+
+            if ($aliasName === 'taoImportedUniqueIdentifier') {
+                $uniqueIdentifierProperty = $property->getUri();
+                break;
+            }
+        }
+
+        $items = $this->getItemService()->getRootClass()->searchInstances([
+            TaoOntology::PROPERTY_TRANSLATION_TYPE => TaoOntology::PROPERTY_VALUE_TRANSLATION_TYPE_ORIGINAL,
+            TaoOntology::PROPERTY_LANGUAGE => 'http://www.tao.lu/Ontologies/TAO.rdf#Lang' . $this->mainLanguage
+        ],
+        ['like' => false, 'recursive' => true]);
+        $mainItem = 0;
+        $translations = 0;
+        
+        foreach($items as $item){
+            $importedUniqueId = $item->getOnePropertyValue($this->getProperty($uniqueIdentifierProperty));
+            if ($this->wetRun) {
+                $item->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS), TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY);
+                $item->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER), $importedUniqueId);
+            }
+            $mainItem++;
+            $translatedIn = $item->getPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES));
+            foreach ($translatedIn as $lang){
+                $linkedItems =  $this->getItemService()->getRootClass()->searchInstances([
+                    TaoOntology::PROPERTY_LANGUAGE => $lang,
+                    $uniqueIdentifierProperty => $importedUniqueId
+                    
+                ],
+                ['like' => false, 'recursive' => true]);
+                foreach($linkedItems as $linkedItem){
+                    $translations++;
+                    if ($this->wetRun) {
+                        $linkedItem->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS),  TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY);
+                        $linkedItem->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_TYPE), TaoOntology::PROPERTY_VALUE_TRANSLATION_TYPE_TRANSLATION);
+                        $linkedItem->setPropertyValue($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI), $item->getUri());
+                        $linkedItem->setPropertyValue($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_PROGRESS), TaoOntology::PROPERTY_VALUE_TRANSLATION_PROGRESS_TRANSLATED);
+                    }
+                }
+            }
+        }
+        $this->report->add(new Report(Report::TYPE_SUCCESS, 'Linked ' . $translations . ' translations to ' . $mainItem . ' main items'));
+        return $this->report;
+    }
+
+    private function init()
+    {
+        if ($this->getOption('wet-run')) {
+            $this->wetRun = true;
+        }
+        $this->classUri = $this->getOption('class');
+        $this->mainLanguage = $this->getOption('main-language');
+    }
+
+    protected function getItemService(): ItemService
+    {
+        return $this->getServiceLocator()->get(ItemService::class);
+    }
+
+}

--- a/scripts/cli/linkTranslatedItems.php
+++ b/scripts/cli/linkTranslatedItems.php
@@ -31,7 +31,7 @@ use taoItems_models_classes_ItemsService as ItemService;
 /**
  * Class linkTranslatedItems
  *
- * php index.php '\oat\taoQtiItem\scripts\cli\linkTranslatedItems' -w -c 'http://www.tao.lu/Ontologies/TAO.rdf#QtiItem' -m 'en-US'
+ * php index.php '\oat\taoQtiItem\scripts\cli\linkTranslatedItems'
  *
  * @package oat\taoQtiItem\scripts\cli
  */
@@ -125,10 +125,15 @@ class linkTranslatedItems extends ScriptAction
                     $this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS),
                     TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY
                 );
-                $item->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER), $importedUniqueId);
+                $item->editPropertyValues(
+                    $this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER),
+                    $importedUniqueId
+                );
             }
             $mainItem++;
-            $translatedIn = $item->getPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES));
+            $translatedIn = $item->getPropertyValues(
+                $this->getProperty(TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES)
+            );
             foreach ($translatedIn as $lang) {
                 $linkedItems =  $this->getItemService()->getRootClass()->searchInstances(
                     [
@@ -161,7 +166,12 @@ class linkTranslatedItems extends ScriptAction
                 }
             }
         }
-        $this->report->add(new Report(Report::TYPE_SUCCESS, 'Linked ' . $translations . ' translations to ' . $mainItem . ' main items'));
+        $this->report->add(
+            new Report(
+                Report::TYPE_SUCCESS,
+                'Linked ' . $translations . ' translations to ' . $mainItem . ' main items'
+            )
+        );
         return $this->report;
     }
 

--- a/scripts/cli/linkTranslatedItems.php
+++ b/scripts/cli/linkTranslatedItems.php
@@ -108,15 +108,17 @@ class linkTranslatedItems extends ScriptAction
             }
         }
 
-        $items = $this->getItemService()->getRootClass()->searchInstances([
+        $items = $this->getItemService()->getRootClass()->searchInstances(
+            [
             TaoOntology::PROPERTY_TRANSLATION_TYPE => TaoOntology::PROPERTY_VALUE_TRANSLATION_TYPE_ORIGINAL,
             TaoOntology::PROPERTY_LANGUAGE => 'http://www.tao.lu/Ontologies/TAO.rdf#Lang' . $this->mainLanguage
-        ],
-        ['like' => false, 'recursive' => true]);
+            ],
+            ['like' => false, 'recursive' => true]
+        );
         $mainItem = 0;
         $translations = 0;
-        
-        foreach($items as $item){
+
+        foreach ($items as $item) {
             $importedUniqueId = $item->getOnePropertyValue($this->getProperty($uniqueIdentifierProperty));
             if ($this->wetRun) {
                 $item->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS), TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY);
@@ -124,17 +126,19 @@ class linkTranslatedItems extends ScriptAction
             }
             $mainItem++;
             $translatedIn = $item->getPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES));
-            foreach ($translatedIn as $lang){
-                $linkedItems =  $this->getItemService()->getRootClass()->searchInstances([
+            foreach ($translatedIn as $lang) {
+                $linkedItems =  $this->getItemService()->getRootClass()->searchInstances(
+                    [
                     TaoOntology::PROPERTY_LANGUAGE => $lang,
                     $uniqueIdentifierProperty => $importedUniqueId
-                    
-                ],
-                ['like' => false, 'recursive' => true]);
-                foreach($linkedItems as $linkedItem){
+
+                    ],
+                    ['like' => false, 'recursive' => true]
+                );
+                foreach ($linkedItems as $linkedItem) {
                     $translations++;
                     if ($this->wetRun) {
-                        $linkedItem->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS),  TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY);
+                        $linkedItem->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS), TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY);
                         $linkedItem->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_TYPE), TaoOntology::PROPERTY_VALUE_TRANSLATION_TYPE_TRANSLATION);
                         $linkedItem->setPropertyValue($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI), $item->getUri());
                         $linkedItem->setPropertyValue($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_PROGRESS), TaoOntology::PROPERTY_VALUE_TRANSLATION_PROGRESS_TRANSLATED);
@@ -159,5 +163,4 @@ class linkTranslatedItems extends ScriptAction
     {
         return $this->getServiceLocator()->get(ItemService::class);
     }
-
 }

--- a/scripts/cli/linkTranslatedItems.php
+++ b/scripts/cli/linkTranslatedItems.php
@@ -121,7 +121,10 @@ class linkTranslatedItems extends ScriptAction
         foreach ($items as $item) {
             $importedUniqueId = $item->getOnePropertyValue($this->getProperty($uniqueIdentifierProperty));
             if ($this->wetRun) {
-                $item->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS), TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY);
+                $item->editPropertyValues(
+                    $this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS),
+                    TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY
+                );
                 $item->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER), $importedUniqueId);
             }
             $mainItem++;
@@ -138,10 +141,22 @@ class linkTranslatedItems extends ScriptAction
                 foreach ($linkedItems as $linkedItem) {
                     $translations++;
                     if ($this->wetRun) {
-                        $linkedItem->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS), TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY);
-                        $linkedItem->editPropertyValues($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_TYPE), TaoOntology::PROPERTY_VALUE_TRANSLATION_TYPE_TRANSLATION);
-                        $linkedItem->setPropertyValue($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI), $item->getUri());
-                        $linkedItem->setPropertyValue($this->getProperty(TaoOntology::PROPERTY_TRANSLATION_PROGRESS), TaoOntology::PROPERTY_VALUE_TRANSLATION_PROGRESS_TRANSLATED);
+                        $linkedItem->editPropertyValues(
+                            $this->getProperty(TaoOntology::PROPERTY_TRANSLATION_STATUS),
+                            TaoOntology::PROPERTY_VALUE_TRANSLATION_STATUS_READY
+                        );
+                        $linkedItem->editPropertyValues(
+                            $this->getProperty(TaoOntology::PROPERTY_TRANSLATION_TYPE),
+                            TaoOntology::PROPERTY_VALUE_TRANSLATION_TYPE_TRANSLATION
+                        );
+                        $linkedItem->setPropertyValue(
+                            $this->getProperty(TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI),
+                            $item->getUri()
+                        );
+                        $linkedItem->setPropertyValue(
+                            $this->getProperty(TaoOntology::PROPERTY_TRANSLATION_PROGRESS),
+                            TaoOntology::PROPERTY_VALUE_TRANSLATION_PROGRESS_TRANSLATED
+                        );
                     }
                 }
             }

--- a/scripts/cli/linkTranslatedItems.php
+++ b/scripts/cli/linkTranslatedItems.php
@@ -63,7 +63,7 @@ class linkTranslatedItems extends ScriptAction
             'main-language' => [
                 'prefix' => 'm',
                 'longPrefix' => 'main-language',
-                'description' => 'Main item language to link translations. Default is en-US. Item with this language will be considered as main item',
+                'description' => 'Item with this language will be considered as main item',
                 'required' => false,
                 'default' => 'en-US'
             ]

--- a/scripts/cli/linkTranslatedItems.php
+++ b/scripts/cli/linkTranslatedItems.php
@@ -24,6 +24,7 @@ namespace oat\taoQtiItem\scripts\cli;
 use oat\generis\model\GenerisRdf;
 use oat\oatbox\reporting\Report;
 use oat\generis\model\OntologyAwareTrait;
+use oat\generis\model\OntologyRdf;
 use oat\oatbox\extension\script\ScriptAction;
 use oat\tao\model\TaoOntology;
 use taoItems_models_classes_ItemsService as ItemService;
@@ -161,6 +162,10 @@ class linkTranslatedItems extends ScriptAction
                         $linkedItem->setPropertyValue(
                             $this->getProperty(TaoOntology::PROPERTY_TRANSLATION_PROGRESS),
                             TaoOntology::PROPERTY_VALUE_TRANSLATION_PROGRESS_TRANSLATED
+                        );
+                        $linkedItem->editPropertyValues(
+                            $this->getProperty(OntologyRdf::RDF_TYPE),
+                            TaoOntology::CLASS_URI_ITEM
                         );
                     }
                 }


### PR DESCRIPTION
We need to make sure that all required metadata propagated to main and  translated items
so authoring translation solution take it into account as translated versions of language

After migration from the client, we have all items for different languages. We need to link them based on the uniq ID 