### PR TITLE
fix: keep `style` attribute intact when importing QTI

### DIFF
--- a/helpers/Authoring.php
+++ b/helpers/Authoring.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -15,16 +15,17 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoQtiItem\helpers;
 
 //use oat\taoQtiItem\helpers\Authoring;
+use common_ext_ExtensionsManager;
 use common_Logger;
 use DOMDocument;
+use DOMElement;
+use DOMXpath;
 use oat\oatbox\filesystem\File;
 use oat\taoQtiItem\model\qti\exception\QtiModelException;
 use oat\taoQtiItem\model\qti\Parser;
@@ -155,16 +156,12 @@ class Authoring
     {
         $doc = self::loadQtiXml($qti);
 
-        $xpath = new \DOMXpath($doc);
-
-        foreach ($xpath->query("//*[local-name() = 'itemBody']//*[@style]") as $elementWithStyle) {
-            $elementWithStyle->removeAttribute('style');
-        }
+        $xpath = new DOMXpath($doc);
 
         $ids = [];
         $elementsWithId = $xpath->query("//*[not(local-name()='lib') and not(local-name()='module') and @id]");
 
-        /** @var \DOMElement $elementWithId */
+        /** @var DOMElement $elementWithId */
         foreach ($elementsWithId as $elementWithId) {
             $id = $elementWithId->getAttribute('id');
             if (in_array($id, $ids)) {
@@ -195,7 +192,7 @@ class Authoring
         } elseif (is_file($file)) {
             $qti = file_get_contents($file);
         } else {
-            throw new \common_exception_Error(
+            throw new common_exception_Error(
                 "Wrong parameter. " . __CLASS__ . "::" . __METHOD__
                     . " accepts either XML content or the path to a file but got " . substr($file, 0, 500)
             );
@@ -203,7 +200,7 @@ class Authoring
 
         $dom = new DOMDocument('1.0', 'UTF-8');
 
-        $domDocumentConfig = \common_ext_ExtensionsManager::singleton()
+        $domDocumentConfig = common_ext_ExtensionsManager::singleton()
             ->getExtensionById('taoQtiItem')
             ->getConfig('XMLParser');
 

--- a/test/integration/helpers/AuthoringTest.php
+++ b/test/integration/helpers/AuthoringTest.php
@@ -15,12 +15,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2015-2025 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoQtiItem\test\integration\helpers;
 
+use DOMDocument;
 use oat\tao\test\TaoPhpUnitTestRunner;
 use oat\taoQtiItem\helpers\Authoring;
 use oat\taoQtiItem\model\qti\exception\QtiModelException;
@@ -46,13 +46,14 @@ class AuthoringTest extends TaoPhpUnitTestRunner
         $xmlStr = file_get_contents($this->getSamplePath('/authoring/sanitizeQtiXml.xml'));
         $xml = simplexml_load_string($xmlStr);
 
-        $this->assertTrue(count($xml->xpath("//*[local-name() = 'itemBody']//*[@style]")) > 0);
-
         $sanitizedXmlStr = Authoring::sanitizeQtiXml($xmlStr);
 
         $sanitizedXml = simplexml_load_string($sanitizedXmlStr);
 
-        $this->assertTrue(count($sanitizedXml->xpath("//*[local-name() = 'itemBody']//*[@style]")) === 0);
+        $this->assertCount(
+            count($xml->xpath("//*[local-name() = 'itemBody']//*[@style]")),
+            $sanitizedXml->xpath("//*[local-name() = 'itemBody']//*[@style]")
+        );
 
         return $sanitizedXmlStr;
     }
@@ -63,7 +64,7 @@ class AuthoringTest extends TaoPhpUnitTestRunner
     public function testValidateSanitizedString($xmlStr)
     {
         $dom = Authoring::loadQtiXml($xmlStr);
-        self::assertInstanceOf(\DOMDocument::class, $dom);
+        self::assertInstanceOf(DOMDocument::class, $dom);
     }
 
     public function testSanitizeQtiXmlMultipleIds()
@@ -119,13 +120,13 @@ class AuthoringTest extends TaoPhpUnitTestRunner
     public function testValidateSanitizedStringSingleId($xmlStr)
     {
         $dom = Authoring::loadQtiXml($xmlStr);
-        self::assertInstanceOf(\DOMDocument::class, $dom);
+        self::assertInstanceOf(DOMDocument::class, $dom);
     }
 
     public function testLoadQtiXml()
     {
         $xmlStr = file_get_contents($this->getSamplePath('/authoring/loadQtiXml.xml'));
-        $this->assertTrue(Authoring::loadQtiXml($xmlStr) instanceof \DOMDocument);
+        $this->assertTrue(Authoring::loadQtiXml($xmlStr) instanceof DOMDocument);
     }
 
     public function testLoadWrongQtiXml()


### PR DESCRIPTION
# [COECDP25-1009](https://oat-sa.atlassian.net/browse/COECDP25-1009)

This PR partially reverts #343 in an attempt to keep the `style` attributes intact when importing QTI.

[COECDP25-1009]: https://oat-sa.atlassian.net/browse/COECDP25-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ