### PR TITLE
[Fix] Remove old properties before setting new props during QTI import

### DIFF
--- a/model/qti/metadata/ontology/MappedMetadataInjector.php
+++ b/model/qti/metadata/ontology/MappedMetadataInjector.php
@@ -98,7 +98,9 @@ class MappedMetadataInjector
 
     private function setListValue(Property $property, Resource $resource, SimpleMetadataValue $metadataValue): void
     {
+        $resource->removePropertyValues($property);
         $list = $this->listService->getListElements($property->getRange());
+
         foreach ($list as $listElement) {
             if (
                 $listElement->getLabel() === $metadataValue->getValue()

--- a/model/qti/metadata/ontology/MappedMetadataInjector.php
+++ b/model/qti/metadata/ontology/MappedMetadataInjector.php
@@ -42,6 +42,8 @@ class MappedMetadataInjector
 
     public function inject(array $mappedProperties, array $metadataValues, Resource $resource): void
     {
+        $purifiedProperties = [];
+
         /** @var SimpleMetadataValue $metadataValue */
         foreach ($metadataValues as $metadataValue) {
             foreach ($metadataValue->getPath() as $mappedPath) {
@@ -76,6 +78,13 @@ class MappedMetadataInjector
                 }
 
                 if ($mappedProperties[$mappedPath]->getRange() !== null) {
+                    $propertyUri = $mappedProperties[$mappedPath]->getUri();
+
+                    if (!in_array($propertyUri, $purifiedProperties, true)) {
+                        $resource->removePropertyValues($mappedProperties[$mappedPath]);
+                        $purifiedProperties[] = $propertyUri;
+                    }
+
                     $this->setListValue($mappedProperties[$mappedPath], $resource, $metadataValue);
                     break;
                 }
@@ -98,7 +107,6 @@ class MappedMetadataInjector
 
     private function setListValue(Property $property, Resource $resource, SimpleMetadataValue $metadataValue): void
     {
-        $resource->removePropertyValues($property);
         $list = $this->listService->getListElements($property->getRange());
 
         foreach ($list as $listElement) {

--- a/model/qti/metadata/ontology/MappedMetadataInjector.php
+++ b/model/qti/metadata/ontology/MappedMetadataInjector.php
@@ -42,7 +42,7 @@ class MappedMetadataInjector
 
     public function inject(array $mappedProperties, array $metadataValues, Resource $resource): void
     {
-        $purifiedProperties = [];
+        $removedProperties = [];
 
         /** @var SimpleMetadataValue $metadataValue */
         foreach ($metadataValues as $metadataValue) {
@@ -80,9 +80,9 @@ class MappedMetadataInjector
                 if ($mappedProperties[$mappedPath]->getRange() !== null) {
                     $propertyUri = $mappedProperties[$mappedPath]->getUri();
 
-                    if (!in_array($propertyUri, $purifiedProperties, true)) {
+                    if (!in_array($propertyUri, $removedProperties, true)) {
                         $resource->removePropertyValues($mappedProperties[$mappedPath]);
-                        $purifiedProperties[] = $propertyUri;
+                        $removedProperties[] = $propertyUri;
                     }
 
                     $this->setListValue($mappedProperties[$mappedPath], $resource, $metadataValue);

--- a/test/unit/model/qti/metadata/ontology/MappedMetadataInjectorTest.php
+++ b/test/unit/model/qti/metadata/ontology/MappedMetadataInjectorTest.php
@@ -107,7 +107,7 @@ class MappedMetadataInjectorTest extends TestCase
             ->willReturn($resourceMock);
 
         $resourceMock
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('removePropertyValues');
 
         $resourceMock

--- a/test/unit/model/qti/metadata/ontology/MappedMetadataInjectorTest.php
+++ b/test/unit/model/qti/metadata/ontology/MappedMetadataInjectorTest.php
@@ -30,19 +30,29 @@ use oat\tao\model\Lists\Business\Domain\Value;
 use oat\taoBackOffice\model\lists\ListService;
 use oat\taoQtiItem\model\qti\metadata\ontology\MappedMetadataInjector;
 use oat\taoQtiItem\model\qti\metadata\simple\SimpleMetadataValue;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class MappedMetadataInjectorTest extends TestCase
 {
+    /** @var ListService|MockObject */
+    private ListService $listServiceMock;
+
+    /** @var Ontology|MockObject */
+    private Ontology $ontologyMock;
+
+    private MappedMetadataInjector $subject;
+
     public function setUp(): void
     {
         $this->listServiceMock = $this->createMock(ListService::class);
         $this->ontologyMock = $this->createMock(Ontology::class);
+
         $this->subject = new MappedMetadataInjector($this->listServiceMock);
         $this->subject->setModel($this->ontologyMock);
     }
 
-    public function testInject()
+    public function testInject(): void
     {
         $propertyMock = $this->createMock(core_kernel_classes_Property::class);
         $simpleMetadataValue = $this->createMock(SimpleMetadataValue::class);
@@ -65,19 +75,24 @@ class MappedMetadataInjectorTest extends TestCase
             ->method('getPath')
             ->willReturn(['mappedPath1', 'mappedPath2']);
 
-        $this->listServiceMock->method('getListElements')
+        $this->listServiceMock
+            ->method('getListElements')
             ->willReturn([$valueMock, $valueMock, $valueMock]);
 
-        $propertyMock->method('getRange')
+        $propertyMock
+            ->method('getRange')
             ->willReturn($classMock);
 
-        $propertyMock->method('getWidget')
+        $propertyMock
+            ->method('getWidget')
             ->willReturn($widgetPropertyMock);
 
-        $widgetPropertyMock->method('getUri')
+        $widgetPropertyMock
+            ->method('getUri')
             ->willReturn('someUri');
 
-        $valueMock->method('getLabel')
+        $valueMock
+            ->method('getLabel')
             ->willReturn(
                 'label',
                 'valueLabel',
@@ -87,22 +102,28 @@ class MappedMetadataInjectorTest extends TestCase
                 'otherLabel'
             );
 
-
-
-        $this->ontologyMock->method('getResource')
+        $this->ontologyMock
+            ->method('getResource')
             ->willReturn($resourceMock);
 
-        $resourceMock->method('getLabel')
+        $resourceMock
+            ->expects($this->exactly(2))
+            ->method('removePropertyValues');
+
+        $resourceMock
+            ->method('getLabel')
             ->willReturn('label', 'mismatchLabel', 'otherMatchedLabel');
 
-        $simpleMetadataValue->method('getValue')
+        $simpleMetadataValue
+            ->method('getValue')
             ->willReturn('label', 'otherMismatchedLabel', 'matchedUri', 'otherMatchedLabel');
 
-        $valueMock->method('getOriginalUri')
+        $valueMock
+            ->method('getOriginalUri')
             ->willReturn('matchedUri', 'otherUri', 'otherUri');
 
         $resourceMock
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('setPropertyValue')
             ->with($propertyMock, $resourceMock);
 


### PR DESCRIPTION
# [HKD-295](https://oat-sa.atlassian.net/browse/HKD-295)

## Changes
* Now old list property value(s) will be removed before setting new properties during QTI import

[HKD-295]: https://oat-sa.atlassian.net/browse/HKD-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ