### PR TITLE
fix: check only files when build list of content

### DIFF
--- a/model/Export/AbstractQTIItemExporter.php
+++ b/model/Export/AbstractQTIItemExporter.php
@@ -175,6 +175,11 @@ abstract class AbstractQTIItemExporter extends taoItems_models_classes_ItemExpor
                 $replacementList[$assetUrl] = '';
                 $report->setMessage($e->getMessage());
                 $report->setType(Report::TYPE_ERROR);
+            } catch (FilesystemException $exception) {
+                $replacementList[$assetUrl] = '';
+                $report->setMessage($exception->getMessage());
+                $report->setType(Report::TYPE_ERROR);
+                return $report;
             }
         }
 

--- a/model/Export/QTIPackedItemExporter.php
+++ b/model/Export/QTIPackedItemExporter.php
@@ -72,17 +72,18 @@ class QTIPackedItemExporter extends AbstractQTIItemExporter
     {
         if (!$this->containsItem()) {
             $report = parent::export($options);
-            if ($report->getType() !== \common_report_Report::TYPE_ERROR || !$report->containsError()) {
-                try {
-                    $exportResult = [];
-                    if (is_array($report->getData())) {
-                        $exportResult = $report->getData();
-                    }
-                    $this->exportManifest($options, $exportResult);
-                } catch (ExportException $e) {
-                    $report->setType(\common_report_Report::TYPE_ERROR);
-                    $report->setMessage($e->getUserMessage());
+            if ($report->getType() === \common_report_Report::TYPE_ERROR || $report->containsError()) {
+                return $report;
+            }
+            try {
+                $exportResult = [];
+                if (is_array($report->getData())) {
+                    $exportResult = $report->getData();
                 }
+                $this->exportManifest($options, $exportResult);
+            } catch (ExportException $e) {
+                $report->setType(\common_report_Report::TYPE_ERROR);
+                $report->setMessage($e->getUserMessage());
             }
             return $report;
         }

--- a/model/Export/QTIPackedItemExporter.php
+++ b/model/Export/QTIPackedItemExporter.php
@@ -29,9 +29,9 @@ use oat\taoQtiItem\model\qti\exception\ExportException;
 use oat\taoQtiItem\model\qti\Service;
 use core_kernel_classes_Resource;
 use oat\taoQtiTest\models\classes\metadata\GenericLomOntologyExtractor;
-use oat\taoQtiTest\models\classes\metadata\MetadataLomService;
 use ZipArchive;
 use DOMDocument;
+use oat\oatbox\reporting\Report;
 use tao_helpers_Uri;
 use taoItems_models_classes_TemplateRenderer;
 use tao_helpers_Display;
@@ -72,7 +72,7 @@ class QTIPackedItemExporter extends AbstractQTIItemExporter
     {
         if (!$this->containsItem()) {
             $report = parent::export($options);
-            if ($report->getType() === \common_report_Report::TYPE_ERROR || $report->containsError()) {
+            if ($report->getType() === Report::TYPE_ERROR || $report->containsError()) {
                 return $report;
             }
             try {
@@ -82,12 +82,12 @@ class QTIPackedItemExporter extends AbstractQTIItemExporter
                 }
                 $this->exportManifest($options, $exportResult);
             } catch (ExportException $e) {
-                $report->setType(\common_report_Report::TYPE_ERROR);
+                $report->setType(Report::TYPE_ERROR);
                 $report->setMessage($e->getUserMessage());
             }
             return $report;
         }
-        return \common_report_Report::createSuccess();
+        return Report::createSuccess();
     }
 
     /**

--- a/model/Export/Stylesheet/AssetStylesheetLoader.php
+++ b/model/Export/Stylesheet/AssetStylesheetLoader.php
@@ -33,7 +33,6 @@ use oat\oatbox\service\ConfigurableService;
 use oat\taoMediaManager\model\fileManagement\FlySystemManagement;
 use oat\taoQtiItem\model\Export\AbstractQTIItemExporter;
 use tao_helpers_Uri as UriHelper;
-
 class AssetStylesheetLoader extends ConfigurableService
 {
     use OntologyAwareTrait;
@@ -56,22 +55,25 @@ class AssetStylesheetLoader extends ConfigurableService
                 $cssFilesInfo = [];
 
                 foreach ($cssFiles as $key => $file) {
-                    $cssFilesInfo[$key] = $file instanceof StorageAttributes ? $file->jsonSerialize() : $file;
-                    $cssFilesInfo[$key]['stream'] = $this->getFileSystem()->readStream(
-                        $stylesheetPath . DIRECTORY_SEPARATOR . basename($file['path'])
-                    );
+                    if ($file['type'] == 'file') {
+                        $cssFilesInfo[$key] = $file instanceof StorageAttributes ? $file->jsonSerialize() : $file;
+                        $cssFilesInfo[$key]['stream'] = $this->getFileSystem()->readStream(
+                            $stylesheetPath . DIRECTORY_SEPARATOR . basename($file['path'])
+                        );
+                    }
                 }
 
                 return $cssFilesInfo;
             } catch (FilesystemException $exception) {
-                $this->getLogger()->notice(
-                    sprintf(
-                        'Stylesheet %s not found for resource %s',
-                        $exception->getPath(),
-                        $property
-                    ),
-                    ['exception' => $exception, 'directory' => $stylesheetPath, 'property' => $property]
+                $this->getLogger()->error(
+                    'Error loading asset stylesheet',
+                    [
+                        'exception' => $exception,
+                        'path' => $stylesheetPath,
+                    ]
                 );
+
+                throw $exception;
             }
         }
 


### PR DESCRIPTION
In scope of using GCP file system the listContents method return also directories with files

How to test:

1. Configure TAO with GcsFileSystemService
2. import XML asset
3. Attach CSS to asset
4. Add asset to item
5. Create a test with the item
6. Export a test

Can be tested on https://construct1-oat-unit07.dev.gcp-eu.taocloud.org/
