### PR TITLE
fix: remove dir attribute and set it only if necessary

### DIFF
--- a/model/Translation/Service/QtiLanguageSetter.php
+++ b/model/Translation/Service/QtiLanguageSetter.php
@@ -82,6 +82,8 @@ class QtiLanguageSetter
 
         $localeCode = str_replace(TaoOntology::LANGUAGE_PREFIX, '', $language->getUri());
 
+        $itemData->getBody()->removeAttributeValue('dir');
+
         if ($this->languageService->isRtlLanguage($localeCode)) {
             $itemData->getBody()->setAttribute('dir', 'rtl');
         }

--- a/scripts/install/ItemEventRegister.php
+++ b/scripts/install/ItemEventRegister.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2016-2025 (original work) Open Assessment Technologies SA.
  *
  *
  */
@@ -23,11 +23,11 @@
 namespace oat\taoQtiItem\scripts\install;
 
 use oat\oatbox\extension\InstallAction;
+use oat\tao\model\resources\Event\InstanceCopiedEvent;
 use oat\taoItems\model\event\ItemContentClonedEvent;
 use oat\taoItems\model\event\ItemCreatedEvent;
 use oat\taoItems\model\event\ItemDuplicatedEvent;
 use oat\taoItems\model\event\ItemRdfUpdatedEvent;
-use oat\taoItems\model\event\ItemUpdatedEvent;
 use oat\taoQtiItem\model\event\ItemImported;
 use oat\taoQtiItem\model\Listener\ItemUpdater;
 use oat\taoQtiItem\model\Listener\ReplaceCopiedQtiXmlIdentifierListener;
@@ -68,7 +68,7 @@ class ItemEventRegister extends InstallAction
             [ItemCreationListener::class, 'populateUniqueId']
         );
         $this->registerEvent(
-            InstanceCopiedEventroll::class,
+            InstanceCopiedEvent::class,
             [ItemCreationListener::class, 'populateUniqueId']
         );
     }

--- a/test/unit/model/Translation/Service/QtiLanguageSetterTest.php
+++ b/test/unit/model/Translation/Service/QtiLanguageSetterTest.php
@@ -123,6 +123,11 @@ class QtiLanguageSetterTest extends TestCase
 
         $itemData
             ->expects($this->once())
+            ->method('removeAttributeValue')
+            ->with('dir');
+
+        $itemData
+            ->expects($this->once())
             ->method('setAttribute')
             ->with('xml:lang', 'ar-arb');
 

--- a/test/unit/model/Translation/Service/QtiLanguageSetterTest.php
+++ b/test/unit/model/Translation/Service/QtiLanguageSetterTest.php
@@ -117,19 +117,19 @@ class QtiLanguageSetterTest extends TestCase
             ->willReturn(TaoOntology::LANGUAGE_PREFIX . 'ar-arb');
 
         $itemData
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getBody')
             ->willReturn($body);
 
         $itemData
             ->expects($this->once())
-            ->method('removeAttributeValue')
-            ->with('dir');
-
-        $itemData
-            ->expects($this->once())
             ->method('setAttribute')
             ->with('xml:lang', 'ar-arb');
+
+        $body
+            ->expects($this->once())
+            ->method('removeAttributeValue')
+            ->with('dir');
 
         $body
             ->expects($this->once())


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1906
https://oat-sa.atlassian.net/browse/ADF-1899

# Goal 

Unset dir and only set it if necessary to avoid translation creation issues

# Related PRs

- https://github.com/oat-sa/tao-core/pull/4213