### PR TITLE
feat: allow using remote list as a scale source.

### DIFF
--- a/model/qti/metadata/exporter/CustomPropertiesManifestScanner.php
+++ b/model/qti/metadata/exporter/CustomPropertiesManifestScanner.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\metadata\exporter;
+
+use DOMDocument;
+use DOMNodeList;
+use DOMXPath;
+
+class CustomPropertiesManifestScanner
+{
+    public function getCustomPropertyByUri(DOMDocument $manifest, string $scaleUri): DOMNodeList
+    {
+        $xpath = new DOMXPath($manifest);
+        // Register namespaces
+        $xpath->registerNamespace('default', 'http://www.imsglobal.org/xsd/imscp_v1p1');
+        $xpath->registerNamespace('imsmd', 'http://ltsc.ieee.org/xsd/LOM');
+
+        $query = '//default:manifest/default:metadata/imsmd:lom/imsmd:metaMetadata/*[local-name()="extension"]/'
+            . '*[local-name()="customProperties"]/*[local-name()="property"][*[local-name()="uri"]="'
+            . $scaleUri
+            . '"]';
+
+        return $xpath->query($query);
+    }
+
+    public function getCustomProperties(DOMDocument $manifest): DOMNodeList
+    {
+        $xpath = new DOMXPath($manifest);
+        $this->registerAllNamespaces($xpath, $manifest);
+        $query = '//*//*[local-name()="customProperties"]';
+        return $xpath->query($query);
+    }
+
+    private function registerAllNamespaces(DOMXPath $xpath, DOMDocument $manifest)
+    {
+        $rootElement = $manifest->documentElement;
+        if (!$rootElement) {
+            return;
+        }
+
+        // Register default namespace
+        $defaultNamespace = $rootElement->lookupNamespaceUri(null);
+        if ($defaultNamespace) {
+            $xpath->registerNamespace('default', $defaultNamespace);
+        }
+
+        // Register all namespaces
+        if ($rootElement->hasAttributes()) {
+            foreach ($rootElement->attributes as $attribute) {
+                if (strpos($attribute->nodeName, 'xmlns:') === 0) {
+                    $prefix = substr($attribute->nodeName, 6);
+                    $xpath->registerNamespace($prefix, $attribute->nodeValue);
+                }
+            }
+        }
+    }
+}

--- a/model/qti/metadata/exporter/scale/ScalePreprocessor.php
+++ b/model/qti/metadata/exporter/scale/ScalePreprocessor.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\metadata\exporter\scale;
+
+use DOMDocument;
+use DOMNodeList;
+use Monolog\Logger;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\Lists\Business\Domain\RemoteSourceContext;
+use oat\tao\model\Lists\Business\Service\RemoteSource;
+use oat\taoQtiItem\model\qti\metadata\exporter\CustomPropertiesManifestScanner;
+use Throwable;
+
+class ScalePreprocessor
+{
+    private RemoteSource $remoteSource;
+    private CustomPropertiesManifestScanner $manifestScanner;
+    private ?string $remoteListScale;
+    private LoggerService $loggerService;
+    private array $scaleCollection;
+
+    public function __construct(
+        RemoteSource                    $remoteSource,
+        CustomPropertiesManifestScanner $manifestScanner,
+        LoggerService                   $loggerService,
+        ?string                         $remoteListScale
+    )
+    {
+        $this->remoteSource = $remoteSource;
+        $this->manifestScanner = $manifestScanner;
+        $this->remoteListScale = $remoteListScale;
+        $this->loggerService = $loggerService;
+    }
+
+    public function includeScaleObject(DomDocument $manifest, DOMDocument $testDoc): void
+    {
+        if (!$this->isRemoteListScaleValid()) {
+            return;
+        }
+        //Find Outcome Declaration in testDoc
+        $outcomeDeclarations = $testDoc->getElementsByTagName('outcomeDeclaration');
+        //Find interpretation attribute in each outcome declaration
+        foreach ($outcomeDeclarations as $outcomeDeclaration) {
+            $interpretation = $outcomeDeclaration->getAttribute('interpretation');
+            if ($this->isScaleInterpretation($interpretation, $this->scaleCollection)) {
+                if ($this->manifestScanner->getCustomPropertyByUri($manifest, $interpretation)->length === 0) {
+                    $this->addCustomProperty(
+                        $manifest,
+                        $this->manifestScanner->getCustomProperties($manifest),
+                        array_filter($this->scaleCollection, function ($scale) use ($interpretation) {
+                            return $scale['uri'] === $interpretation;
+                        })
+                    );
+                }
+            }
+        }
+    }
+
+    private function isScaleInterpretation(string $interpretation, array $scales): array
+    {
+        //Find and return scale interpretation
+        $scale = array_filter($scales, function ($scale) use ($interpretation) {
+            return $scale['uri'] === $interpretation;
+        });
+
+        if (empty($scale)) {
+            return [];
+        }
+
+        return reset($scale);
+    }
+
+    private function addCustomProperty(DOMDocument $manifest, DOMNodeList $customProperties, array $scale): void
+    {
+        $scale = reset($scale);
+        $customProperties = $customProperties->item(0);
+        $newProperty = $manifest->createElement('property');
+        // Create and append child elements to the property
+        $uriElement = $manifest->createElement('uri', $scale['uri']);
+        $labelElement = $manifest->createElement('label', $scale['label']);
+        $domainElement = $manifest->createElement('domain', 'http://www.tao.lu/Ontologies/TAO.rdf#Scale');
+        $scaleElement = $manifest->createElement('scale', json_encode($scale['values']));
+        // Append all child elements to the new property
+        $newProperty->appendChild($uriElement);
+        $newProperty->appendChild($labelElement);
+        $newProperty->appendChild($domainElement);
+        $newProperty->appendChild($scaleElement);
+
+        $customProperties->appendChild($newProperty);
+    }
+
+    private function isRemoteListScaleValid(): bool
+    {
+        if (!$this->remoteListScale) {
+            $this->loggerService->debug('Environment variable REMOTE_LIST_SCALE is not defined');
+            return false;
+        }
+
+        $scaleCollection = iterator_to_array($this->remoteSource->fetchByContext(
+            new RemoteSourceContext([
+                RemoteSourceContext::PARAM_SOURCE_URL => $this->remoteListScale,
+                RemoteSourceContext::PARAM_PARSER => 'scale',
+            ])
+        ));
+
+        if (
+            is_array($scaleCollection)
+            && count($scaleCollection) > 0
+            && $this->hasRequiredFields($scaleCollection)
+        ) {
+            $this->scaleCollection = $scaleCollection;
+            return true;
+        }
+
+        $this->loggerService->warning('Remote list for scale is malformed');
+        return false;
+    }
+
+    private function hasRequiredFields(array $scaleCollection): bool
+    {
+        foreach ($scaleCollection as $scale) {
+            if (!isset($scale['uri'], $scale['label'], $scale['values'])) {
+                return false;
+            }
+            if (!is_array($scale['values'])) {
+                return false;
+            }
+            foreach ($scale['values'] as $value) {
+                if (!is_string($value)) {
+                    return false;
+                }
+            }
+
+            //in values array key and value are strings
+            foreach ($scale['values'] as $key => $value) {
+                if (!(is_string($key) || is_int($key)) || !is_string($value)) {
+                    return false;
+                }
+            }
+
+        }
+        return true;
+    }
+}

--- a/model/qti/metadata/exporter/scale/ScaleRemoteListParser.php
+++ b/model/qti/metadata/exporter/scale/ScaleRemoteListParser.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\metadata\exporter\scale;
+
+use oat\generis\model\Context\ContextInterface;
+use oat\tao\model\Lists\Business\Domain\RemoteSourceContext;
+use oat\tao\model\Lists\Business\Service\RemoteSourceParserInterface;
+
+class ScaleRemoteListParser implements RemoteSourceParserInterface
+{
+
+    public function iterate(array $json, string $uriRule, string $labelRule): iterable
+    {
+        yield from $this->iterateByContext(
+            new RemoteSourceContext([
+                RemoteSourceContext::PARAM_JSON => $json,
+                RemoteSourceContext::PARAM_URI_PATH => $uriRule,
+                RemoteSourceContext::PARAM_LABEL_PATH => $labelRule,
+            ])
+        );
+    }
+
+    public function iterateByContext(ContextInterface $context): iterable
+    {
+        return $context->getParameter('json');
+    }
+}

--- a/model/qti/metadata/importer/MetaMetadataServiceProvider.php
+++ b/model/qti/metadata/importer/MetaMetadataServiceProvider.php
@@ -22,12 +22,17 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\model\qti\metadata\importer;
 
+use http\Env;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\tao\model\Lists\Business\Service\RemoteSource;
 use oat\taoBackOffice\model\lists\ListService;
 use oat\taoQtiItem\model\import\ChecksumGenerator;
+use oat\taoQtiItem\model\qti\metadata\exporter\CustomPropertiesManifestScanner;
+use oat\taoQtiItem\model\qti\metadata\exporter\scale\ScalePreprocessor;
 use oat\taoQtiItem\model\qti\metadata\ontology\MappedMetadataInjector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 class MetaMetadataServiceProvider implements ContainerServiceProviderInterface
@@ -47,6 +52,17 @@ class MetaMetadataServiceProvider implements ContainerServiceProviderInterface
             ->set(MetaMetadataImportMapper::class, MetaMetadataImportMapper::class)
             ->args([
                 service(ChecksumGenerator::class)
+            ])
+            ->public();
+
+        $services
+            ->set(CustomPropertiesManifestScanner::class);
+
+        $services->set(ScalePreprocessor::class)
+            ->args([
+                service(RemoteSource::SERVICE_ID),
+                service(CustomPropertiesManifestScanner::class),
+                env('REMOTE_LIST_SCALE')
             ])
             ->public();
     }

--- a/test/unit/model/qti/metadata/exporter/ScalePreprocessorTest.php
+++ b/test/unit/model/qti/metadata/exporter/ScalePreprocessorTest.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti\metadata\exporter;
+
+use ArrayIterator;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMNodeList;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\Lists\Business\Service\RemoteSource;
+use oat\taoQtiItem\model\qti\metadata\exporter\CustomPropertiesManifestScanner;
+use oat\taoQtiItem\model\qti\metadata\exporter\scale\ScalePreprocessor;
+use PHPUnit\Framework\TestCase;
+
+class ScalePreprocessorTest extends TestCase
+{
+    private const SCALE_COLLECTION = [
+        [
+            'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1',
+            'label' => 'A2-B1',
+            'values' => [
+                "1" => "A2-B1-1",
+                "3" => "A2-B1-2",
+                "5" => "A2-B1-3",
+            ]
+        ],
+        [
+            'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B2',
+            'label' => 'A2-B2',
+            'values' => [
+                "1" => "A2-B2-1",
+                "6" => "A2-B2-2",
+                "7" => "A2-B2-3",
+            ]
+        ]
+    ];
+
+    public function setUp(): void
+    {
+        $this->manifest = new DOMDocument();
+        $this->manifest->loadXML($this->readSampleFile('manifestSample.xml'));
+        $this->testDoc = new DOMDocument();
+        $this->testDoc->loadXML($this->readSampleFile('testSample.xml'));
+        $this->remoteSource = $this->createMock(RemoteSource::class);
+        $this->manifestScanner = $this->createMock(CustomPropertiesManifestScanner::class);
+        $this->loggerMock = $this->createMock(LoggerService::class);
+        $this->subject = new ScalePreprocessor(
+            $this->remoteSource,
+            $this->manifestScanner,
+            $this->loggerMock,
+            'http://ScaleUrl.example.com/scale.json'
+        );
+    }
+
+    /**
+     * @dataProvider invalidRemoteListScaleCollection
+     */
+    public function testIncludeScaleObjectInvalid(array $collection)
+    {
+
+        $this->remoteSource
+            ->expects($this->once())
+            ->method('fetchByContext')
+            ->willReturn(new ArrayIterator($collection));
+
+        $this->subject->includeScaleObject($this->manifest, $this->testDoc);
+    }
+
+    public function testIncludeScaleObjectChangeManifest()
+    {
+        $this->remoteSource
+            ->expects($this->once())
+            ->method('fetchByContext')
+            ->willReturn(new ArrayIterator(self::SCALE_COLLECTION));
+
+        $nodeListMock = $this->createMock(DOMNodeList::class);
+
+        $nodeListWithOneElement = $this->createCustomProperties()->item(0)->getElementsByTagName('property');
+        $nodeListWithNoElement = $this->createCustomProperties()->item(0)->getElementsByTagName('NoProperty');
+        $domElementMock = $this->createMock(DOMElement::class);
+
+        $nodeListMock->expects($this->once())
+            ->method('item')
+            ->willReturn($domElementMock);
+
+        $domElementMock->expects($this->once())
+            ->method('appendChild');
+
+        $this->manifestScanner
+            ->expects($this->once())
+            ->method('getCustomProperties')
+            ->willReturn($nodeListMock);
+
+        $this->manifestScanner
+            ->expects($this->exactly(2))
+            ->method('getCustomPropertyByUri')
+            ->willReturnOnConsecutiveCalls(
+                $nodeListWithOneElement,
+                $nodeListWithNoElement
+            );
+
+        $domNodeMock = $this->createMock(DOMNode::class);
+
+        $nodeListMock->expects($this->once())
+            ->method('item')
+            ->willReturn($domNodeMock);
+
+        $domNodeMock
+            ->method('appendChild');
+
+        $this->subject->includeScaleObject($this->manifest, $this->testDoc);
+    }
+
+    private function readSampleFile(string $filename): string
+    {
+
+        $adapter = new LocalFilesystemAdapter(
+            dirname(__FILE__, 2)
+        );
+
+        $filesystem = new Filesystem($adapter);
+        return $filesystem->read('samples/' . $filename);
+    }
+
+    public function invalidRemoteListScaleCollection()
+    {
+        return [
+            'empty array' => [
+                'collection' => [],
+            ],
+            'missing url' => [
+                [
+                    [
+                        'label' => 'A2-B1',
+                        'values' => [
+                            "1" => "A2-B1-1",
+                            "2" => "A2-B1-2",
+                            "3" => "A2-B1-3",
+                        ]
+                    ],
+                    [
+                        'label' => 'A2-B2',
+                        'values' => [
+                            "1" => "A2-B2-1",
+                            "2" => "A2-B2-2",
+                            "3" => "A2-B2-3",
+                        ]
+                    ]
+                ]
+            ],
+            'missing label' => [
+                [
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1',
+                        'values' => [
+                            "1" => "A2-B1-1",
+                            "2" => "A2-B1-2",
+                            "3" => "A2-B1-3",
+                        ]
+                    ],
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B2',
+                        'values' => [
+                            "1" => "A2-B2-1",
+                            "2" => "A2-B2-2",
+                            "3" => "A2-B2-3",
+                        ]
+                    ]
+                ]
+            ],
+            'missing values' => [
+                [
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1',
+                        'label' => 'A2-B1',
+                    ],
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B2',
+                        'label' => 'A2-B2',
+                    ]
+                ]
+            ],
+            'values not an array' => [
+                [
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1',
+                        'label' => 'A2-B1',
+                        'values' => 'A2-B1-1'
+                    ],
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B2',
+                        'label' => 'A2-B2',
+                        'values' => 123
+                    ]
+                ]
+            ],
+            'values are illegal' => [
+                [
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1',
+                        'label' => 'A2-B1',
+                        'values' => [
+                            "1" => "A2-B1-1",
+                            "2" => 123,
+                            "3" => "A2-B1-3",
+                        ]
+                    ],
+                    [
+                        'uri' => 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B2',
+                        'label' => 'A2-B2',
+                        'values' => [
+                            "1" => "A2-B2-1",
+                            "2" => "A2-B2-2",
+                            "3" => 123
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    private function createCustomProperties(): DOMNodeList
+    {
+        $dom = new DOMDocument();
+        $dom->loadXML('
+<customProperties>
+    <property>
+        <uri>http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1</uri>
+        <label>CERF</label>
+        <domain>http://www.tao.lu/Ontologies/TAO.rdf#Scale</domain>
+    </property>
+</customProperties>
+');
+        return $dom->getElementsByTagName('customProperties');
+    }
+
+    private function getCustomProperty(DOMDocument $manifest)
+    {
+
+    }
+}

--- a/test/unit/model/qti/metadata/imsManifest/CustomPropertiesManifestScannerTest.php
+++ b/test/unit/model/qti/metadata/imsManifest/CustomPropertiesManifestScannerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti\metadata\imsManifest;
+
+use DOMDocument;
+use DOMNodeList;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use oat\taoQtiItem\model\qti\metadata\exporter\CustomPropertiesManifestScanner;
+use PHPUnit\Framework\TestCase;
+
+class CustomPropertiesManifestScannerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->subject = new CustomPropertiesManifestScanner();
+    }
+
+    public function testGetCustomPropertyByUri(): void
+    {
+        $dom = new DOMDocument();
+        $dom->loadXML($this->readSampleFile('manifestSample.xml'));
+        $this->assertInstanceOf(
+            DOMNodeList::class,
+            $this->subject->getCustomPropertyByUri($dom, 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1')
+        );
+        $this->assertEquals(
+            1,
+            $this->subject
+                ->getCustomPropertyByUri($dom, 'http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1')
+                ->length
+        );
+    }
+
+    public function testGetCustomProperties(): void
+    {
+        $dom = new DOMDocument();
+        $dom->loadXML($this->readSampleFile('manifestSample.xml'));
+
+        $result = $this->subject->getCustomProperties($dom);
+        $this->assertInstanceOf(
+            DOMNodeList::class,
+            $result
+        );
+        $this->assertEquals(
+            1,
+            $result->length
+        );
+
+    }
+
+    private function readSampleFile($filename): string
+    {
+        $adapter = new LocalFilesystemAdapter(
+            dirname(__FILE__, 2)
+        );
+
+        $filesystem = new Filesystem($adapter);
+        return $filesystem->read('samples/' . $filename);
+    }
+}

--- a/test/unit/model/qti/metadata/samples/manifestSample.xml
+++ b/test/unit/model/qti/metadata/samples/manifestSample.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.imsglobal.org/xsd/imscp_v1p1 http://www.imsglobal.org/xsd/qti/qtiv2p2/qtiv2p2_imscpv1p2_v1p0.xsd http://ltsc.ieee.org/xsd/LOM http://www.imsglobal.org/xsd/imsmd_loose_v1p3p2.xsd http://ltsc.ieee.org/xsd/LOM http://www.imsglobal.org/xsd/imsmd_loose_v1p3p2.xsd"
+          identifier="QTI-TEST-MANIFEST-tao681908c2041d35-26197390" xmlns:imsmd="http://ltsc.ieee.org/xsd/LOM">
+    <metadata>
+        <schema>QTIv2.2 Package</schema>
+        <schemaversion>1.0.0</schemaversion>
+        <imsmd:lom>
+            <imsmd:metaMetadata>
+                <extension>
+                    <customProperties>
+                        <property>
+                            <uri>http://www.tao.lu/Ontologies/TAOItem.rdf#ItemContent</uri>
+                            <label>Item Content</label>
+                            <domain>http://www.tao.lu/Ontologies/TAOItem.rdf#Item</domain>
+                            <checksum>da39a3ee5e6b4b0d3255bfef95601890afd80709</checksum>
+                        </property>
+                        <property>
+                            <uri>http://www.tao.lu/Ontologies/TAOItem.rdf#ItemModel</uri>
+                            <label>Item Model</label>
+                            <domain>http://www.tao.lu/Ontologies/TAOItem.rdf#Item</domain>
+                            <widget>http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox</widget>
+                            <checksum>99336650bf0c454a35ac0dafa585708284ad57b1</checksum>
+                        </property>
+                        <property>
+                            <uri>http://www.w3.org/2000/01/rdf-schema#label</uri>
+                            <label>Label</label>
+                            <domain>http://www.w3.org/2000/01/rdf-schema#Resource</domain>
+                            <widget>http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox</widget>
+                        </property>
+                        <property>
+                            <uri>http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1</uri>
+                            <label>CERF</label>
+                            <domain>http://www.tao.lu/Ontologies/TAO.rdf#Scale</domain>
+                        </property>
+                    </customProperties>
+                </extension>
+            </imsmd:metaMetadata>
+        </imsmd:lom>
+    </metadata>
+    <organizations/>
+    <resources>
+        <resource identifier="i68121bf8b7bac20250430144752a6e92a1c" type="imsqti_item_xmlv2p2"
+                  href="items/i68121bf8b7bac20250430144752a6e92a1c/qti.xml">
+            <metadata>
+                <imsmd:lom>
+                    <imsmd:classification>
+                        <imsmd:taxonPath>
+                            <imsmd:source>
+                                <imsmd:string xml:lang="en-US">http://www.tao.lu/Ontologies/TAO.rdf#Language
+                                </imsmd:string>
+                            </imsmd:source>
+                            <imsmd:taxon>
+                                <imsmd:entry>
+                                    <imsmd:string xml:lang="en-US">http://www.tao.lu/Ontologies/TAO.rdf#Langen-US
+                                    </imsmd:string>
+                                </imsmd:entry>
+                            </imsmd:taxon>
+                        </imsmd:taxonPath>
+                        <imsmd:taxonPath>
+                            <imsmd:source>
+                                <imsmd:string xml:lang="en-US">http://www.tao.lu/Ontologies/TAO.rdf#TranslationStatus
+                                </imsmd:string>
+                            </imsmd:source>
+                            <imsmd:taxon>
+                                <imsmd:entry>
+                                    <imsmd:string xml:lang="en-US">
+                                        http://www.tao.lu/Ontologies/TAO.rdf#TranslationStatusNotReadyForTranslation
+                                    </imsmd:string>
+                                </imsmd:entry>
+                            </imsmd:taxon>
+                        </imsmd:taxonPath>
+                        <imsmd:taxonPath>
+                            <imsmd:source>
+                                <imsmd:string xml:lang="en-US">http://www.tao.lu/Ontologies/TAO.rdf#TranslationType
+                                </imsmd:string>
+                            </imsmd:source>
+                            <imsmd:taxon>
+                                <imsmd:entry>
+                                    <imsmd:string xml:lang="en-US">
+                                        http://www.tao.lu/Ontologies/TAO.rdf#TranslationTypeOriginal
+                                    </imsmd:string>
+                                </imsmd:entry>
+                            </imsmd:taxon>
+                        </imsmd:taxonPath>
+                        <imsmd:taxonPath>
+                            <imsmd:source>
+                                <imsmd:string xml:lang="en-US">http://www.tao.lu/Ontologies/TAO.rdf#UniqueIdentifier
+                                </imsmd:string>
+                            </imsmd:source>
+                            <imsmd:taxon>
+                                <imsmd:entry>
+                                    <imsmd:string xml:lang="en-US">174601791</imsmd:string>
+                                </imsmd:entry>
+                            </imsmd:taxon>
+                        </imsmd:taxonPath>
+                        <imsmd:taxonPath>
+                            <imsmd:source>
+                                <imsmd:string xml:lang="en-US">http://www.w3.org/2000/01/rdf-schema#label</imsmd:string>
+                            </imsmd:source>
+                            <imsmd:taxon>
+                                <imsmd:entry>
+                                    <imsmd:string xml:lang="en-US">Item_2 3</imsmd:string>
+                                </imsmd:entry>
+                            </imsmd:taxon>
+                        </imsmd:taxonPath>
+                    </imsmd:classification>
+                </imsmd:lom>
+            </metadata>
+            <file href="items/i68121bf8b7bac20250430144752a6e92a1c/qti.xml"/>
+            <file href="items/i68121bf8b7bac20250430144752a6e92a1c/assets/9d4feb50680f990a4576a.mp4"/>
+        </resource>
+        <resource identifier="i6818cddbe1e9a20250505164027013009d1" type="imsqti_test_xmlv2p2"
+                  href="tests/i6818cddbe1e9a20250505164027013009d1/test.xml">
+            <metadata>
+                <imsmd:lom>
+                    <imsmd:classification>
+                        <imsmd:taxonPath>
+                            <imsmd:source>
+                                <imsmd:string xml:lang="en-US">http://www.tao.lu/Ontologies/TAO.rdf#Language
+                                </imsmd:string>
+                            </imsmd:source>
+                            <imsmd:taxon>
+                                <imsmd:entry>
+                                    <imsmd:string xml:lang="en-US">http://www.tao.lu/Ontologies/TAO.rdf#Langen-US
+                                    </imsmd:string>
+                                </imsmd:entry>
+                            </imsmd:taxon>
+                        </imsmd:taxonPath>
+                    </imsmd:classification>
+                </imsmd:lom>
+            </metadata>
+            <file href="tests/i6818cddbe1e9a20250505164027013009d1/test.xml"/>
+            <dependency identifierref="i68121bf8b7bac20250430144752a6e92a1c"/>
+        </resource>
+    </resources>
+</manifest>

--- a/test/unit/model/qti/metadata/samples/testSample.xml
+++ b/test/unit/model/qti/metadata/samples/testSample.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                identifier="SIIWHUUG" title="Test_1 1" toolName="tao" toolVersion="2025.05 LTS"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p1.xsd">
+    <outcomeDeclaration identifier="OUTCOME_1" cardinality="single" baseType="float"
+                        interpretation="http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B1"/>
+    <outcomeDeclaration identifier="OUTCOME_2" cardinality="single" baseType="float"
+                        interpretation="http://www.tao.lu/Ontologies/TAO.rdf#NON_EXISTING_SCALE"/>
+    <outcomeDeclaration identifier="OUTCOME_3" cardinality="single" baseType="float"
+                        interpretation="http://www.tao.lu/Ontologies/TAO.rdf#CERF-A2-B2"/>
+    <timeLimits allowLateSubmission="false"/>
+    <testPart identifier="testPart-1" navigationMode="linear" submissionMode="individual">
+        <itemSessionControl maxAttempts="0" showFeedback="false" allowReview="true" showSolution="false"
+                            allowComment="false" allowSkipping="true" validateResponses="false"/>
+        <assessmentSection identifier="assessmentSection-1" required="true" fixed="false" title="Section" visible="true"
+                           keepTogether="true">
+            <itemSessionControl maxAttempts="0" showFeedback="false" allowReview="true" showSolution="false"
+                                allowComment="false" allowSkipping="true" validateResponses="false"/>
+            <assessmentItemRef identifier="item-1" required="false" fixed="false"
+                               href="../../items/i68121bf8b7bac20250430144752a6e92a1c/qti.xml">
+                <itemSessionControl maxAttempts="0" showFeedback="false" allowReview="true" showSolution="false"
+                                    allowComment="false" allowSkipping="true" validateResponses="false"/>
+            </assessmentItemRef>
+        </assessmentSection>
+    </testPart>
+    <outcomeProcessing/>
+</assessmentTest>


### PR DESCRIPTION
This pull request introduces functionality for handling scales in QTI metadata. Key changes include the implementation of a manifest scanner and scale preprocessor.

### New functionality for custom properties and scales:

* `CustomPropertiesManifestScanner` class: Added to scan IMS manifests for custom properties and retrieve them based on URI or namespace registration.
* `ScalePreprocessor` class: Introduced to handle scale-related metadata, including validating remote scale lists, adding custom properties to manifests, and processing outcome declarations in test documents.
* `ScaleRemoteListParser` class: Added to parse remote scale lists using context-based rules for URI and label extraction.

### Dependency injection updates:

* [`MetaMetadataServiceProvider`](diffhunk://#diff-2bd78b8d5cef28df8be30ec48f061858f4d6b84479b305abc13a0f84418c5eb4R25-R35): Integrated `CustomPropertiesManifestScanner` and `ScalePreprocessor` into the service container, enabling dependency injection for these components. The `ScalePreprocessor` is configured with environment variables for remote scale list handling.

