### PR TITLE
[Fix] Prevent changing unique QTI ID

### DIFF
--- a/model/qti/Service.php
+++ b/model/qti/Service.php
@@ -27,7 +27,7 @@ use oat\oatbox\filesystem\File;
 use oat\oatbox\filesystem\FilesystemException;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
-use oat\taoQtiItem\model\qti\exception\QtiModelException;
+use oat\tao\model\TaoOntology;
 use oat\taoQtiItem\model\qti\parser\XmlToItemParser;
 use tao_helpers_Uri;
 use common_exception_FileSystemError;
@@ -146,13 +146,7 @@ class Service extends ConfigurableService
      */
     public function saveDataItemToRdfItem(Item $qtiItem, core_kernel_classes_Resource $rdfItem)
     {
-        if ($this->getFeatureFlagChecker()->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')) {
-            $currentQtiItem = $this->getDataItemByRdfItem($rdfItem);
-
-            if ($currentQtiItem && $currentQtiItem->getIdentifier() !== $qtiItem->getIdentifier()) {
-                throw new QtiModelException('QTI identifier is unique and cannot be modified');
-            }
-        }
+        $this->syncUniqueId($qtiItem, $rdfItem);
 
         $label = mb_substr($rdfItem->getLabel(), 0, 256, 'UTF-8');
         //set the current data lang in the item content to keep the integrity
@@ -343,6 +337,19 @@ class Service extends ConfigurableService
     public static function singleton()
     {
         return ServiceManager::getServiceManager()->get(self::class);
+    }
+
+    private function syncUniqueId(Item $qtiItem, core_kernel_classes_Resource $rdfItem): void
+    {
+        if (!$this->getFeatureFlagChecker()->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')) {
+            return;
+        }
+
+        $uniqueId = (string) $rdfItem->getOnePropertyValue($this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER));
+
+        if (!empty($uniqueId) && $uniqueId !== $qtiItem->getIdentifier()) {
+            $qtiItem->setIdentifier($uniqueId);
+        }
     }
 
     private function getItemService(): taoItems_models_classes_ItemsService

--- a/model/qti/Service.php
+++ b/model/qti/Service.php
@@ -25,6 +25,9 @@ use common_exception_Error;
 use common_exception_NotFound;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\filesystem\FilesystemException;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\taoQtiItem\model\qti\exception\QtiModelException;
 use oat\taoQtiItem\model\qti\parser\XmlToItemParser;
 use tao_helpers_Uri;
 use common_exception_FileSystemError;
@@ -143,6 +146,14 @@ class Service extends ConfigurableService
      */
     public function saveDataItemToRdfItem(Item $qtiItem, core_kernel_classes_Resource $rdfItem)
     {
+        if ($this->getFeatureFlagChecker()->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')) {
+            $currentQtiItem = $this->getDataItemByRdfItem($rdfItem);
+
+            if ($currentQtiItem && $currentQtiItem->getIdentifier() !== $qtiItem->getIdentifier()) {
+                throw new QtiModelException('QTI identifier is unique and cannot be modified');
+            }
+        }
+
         $label = mb_substr($rdfItem->getLabel(), 0, 256, 'UTF-8');
         //set the current data lang in the item content to keep the integrity
         if ($qtiItem->hasAttribute('xml:lang') && !empty($qtiItem->getAttributeValue('xml:lang'))) {
@@ -359,5 +370,10 @@ class Service extends ConfigurableService
     private function getXmlToItemParser(): XmlToItemParser
     {
         return $this->getServiceLocator()->get(XmlToItemParser::class);
+    }
+
+    private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
+    {
+        return $this->getServiceLocator()->get(FeatureFlagChecker::class);
     }
 }


### PR DESCRIPTION
## Ticket: [HKD-510](https://oat-sa.atlassian.net/browse/HKD-510)

## What's Changed
- Added validation to not allow changing QTI ID if `FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER` is set to `true`;

> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## Companion PRs
- https://github.com/oat-sa/extension-tao-testqti/pull/2612

## How to test
- create a new item and edit it
- use the browser’s inspector to enable the `identifier` field
- change its value
- click on `save`

Bug: item is saved with the new QTI identifier value.
Fix: an error that the QTI schema is invalid + the corresponding log with the error message that the QTI identifier is unique and cannot be changed.