### PR TITLE
fix: add language plugin for choice interaction

### DIFF
--- a/views/js/qtiCreator/widgets/choices/simpleChoice/states/Choice.js
+++ b/views/js/qtiCreator/widgets/choices/simpleChoice/states/Choice.js
@@ -83,6 +83,10 @@ define([
                     }, {
                         name : 'paragraph',
                         items : ['NumberedList', 'BulletedList', '-', 'Blockquote', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock']
+                    },
+                    {
+                        name : 'language',
+                        items : ['Language']
                     }
                 ]
             });

--- a/views/js/qtiCreator/widgets/interactions/blockInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/blockInteraction/states/Question.js
@@ -67,6 +67,10 @@ define([
                 {
                     name : 'paragraph',
                     items : ['NumberedList', 'BulletedList', '-', 'Blockquote', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock']
+                },
+                {
+                    name: 'language',
+                    items: ['Language']
                 }
             ];
             var ENABLE_INTERACTION_SOURCE = context.featureFlags && context.featureFlags.FEATURE_FLAG_CKEDITOR_INTERACTION_SOURCE;


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4230

## What's Changed
- moved back plugins for languages for choice interactions

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## How to test
- Create item with choice interaction
- Check that on the ckeditor side inside toolbar you have Translation plugin 