### PR TITLE
fix: Exclude translated into languages from export/clone

### DIFF
--- a/model/qti/metadata/importer/MetadataImporter.php
+++ b/model/qti/metadata/importer/MetadataImporter.php
@@ -49,6 +49,11 @@ class MetadataImporter extends AbstractMetadataService
     public const VALIDATOR_KEY = 'validators';
 
     /**
+     * Properties to exclude from metadata import
+     */
+    protected array $excludedProperties = [];
+
+    /**
      * Extract metadata value from a DomManifest
      *
      * {@inheritdoc}
@@ -60,7 +65,16 @@ class MetadataImporter extends AbstractMetadataService
                 __('Metadata import requires an instance of DomManifest to extract metadata')
             );
         }
-        return parent::extract($domManifest);
+
+        $metadataValues = parent::extract($domManifest);
+
+        foreach ($this->excludedProperties as $property) {
+            if (isset($metadataValues[$property])) {
+                unset($metadataValues[$property]);
+            }
+        }
+
+        return $metadataValues;
     }
 
     /**

--- a/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
+++ b/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
@@ -25,6 +25,7 @@ use core_kernel_classes_Resource as Resource;
 use core_kernel_classes_Triple as Triple;
 use oat\generis\model\OntologyAwareTrait;
 use oat\generis\model\OntologyRdf;
+use oat\tao\model\TaoOntology;
 use oat\taoQtiItem\model\qti\metadata\imsManifest\classificationMetadata\ClassificationEntryMetadataValue;
 use oat\taoQtiItem\model\qti\metadata\imsManifest\classificationMetadata\ClassificationMetadataValue;
 use oat\taoQtiItem\model\qti\metadata\imsManifest\classificationMetadata\ClassificationSourceMetadataValue;
@@ -44,6 +45,7 @@ class LabelBasedLomOntologyClassificationExtractor implements MetadataExtractor
         TaoItemOntology::PROPERTY_ITEM_MODEL,
         taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL,
         taoTests_models_classes_TestsService::PROPERTY_TEST_CONTENT,
+        TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES
     ];
 
     /**

--- a/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
+++ b/model/qti/metadata/ontology/LabelBasedLomOntologyClassificationExtractor.php
@@ -45,7 +45,6 @@ class LabelBasedLomOntologyClassificationExtractor implements MetadataExtractor
         TaoItemOntology::PROPERTY_ITEM_MODEL,
         taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL,
         taoTests_models_classes_TestsService::PROPERTY_TEST_CONTENT,
-        TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES
     ];
 
     /**


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/ADF-1969

## What's Changed
- Excluded `TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES` during export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the set of metadata properties excluded from extraction to improve handling of certain ontology properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->