### PR TITLE
feature: use FF to show/hide compact appearance

### DIFF
--- a/model/FeatureFlag/FeatureFlagFlaHandler.php
+++ b/model/FeatureFlag/FeatureFlagFlaHandler.php
@@ -43,6 +43,9 @@ class FeatureFlagFlaHandler implements FeatureFlagConfigHandlerInterface
         $configs['services/features']['visibility']['taoQtiItem/creator/interaction/media/property/fla'] =
             $this->featureFlagChecker->isEnabled('FEATURE_FLAG_FLA') ? 'show' : 'hide';
 
+        $configs['services/features']['visibility']['taoQtiItem/creator/interaction/media/property/compactAppearance'] =
+            $this->featureFlagChecker->isEnabled('FEATURE_FLAG_TAO_ADVANCE_ONLY') ? 'show' : 'hide';
+
         return $configs;
     }
 }

--- a/views/js/qtiCreator/tpl/forms/interactions/media.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/media.tpl
@@ -133,16 +133,18 @@
     </div>
 {{/unless}}
 
-{{#if isAudio}}
-    <div class="panel compact-appearance">
-        <label>
-            <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
-            <span class="icon-checkbox"></span>
-            {{__ "Compact Appearance"}}
-        </label>
-        <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-        <span class="tooltip-content">
-           {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
-        </span>
-    </div>
+{{#if isCompactAppearanceAvailable}}
+    {{#if isAudio}}
+        <div class="panel compact-appearance">
+            <label>
+                <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
+                <span class="icon-checkbox"></span>
+                {{__ "Compact Appearance"}}
+            </label>
+            <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <span class="tooltip-content">
+               {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
+            </span>
+        </div>
+    {{/if}}
 {{/if}}

--- a/views/js/qtiCreator/tpl/forms/static/object.tpl
+++ b/views/js/qtiCreator/tpl/forms/static/object.tpl
@@ -27,16 +27,18 @@
         <!-- mediaEditorComponent goes here -->
     </div>
 </div>
-{{#if isAudio}}
-    <div class="panel compact-appearance">
-        <label>
-            <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
-            <span class="icon-checkbox"></span>
-            {{__ "Compact Appearance"}}
-        </label>
-        <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-        <span class="tooltip-content">
-           {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
-        </span>
-    </div>
+{{#if isCompactAppearanceAvailable}}
+    {{#if isAudio}}
+        <div class="panel compact-appearance">
+            <label>
+                <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
+                <span class="icon-checkbox"></span>
+                {{__ "Compact Appearance"}}
+            </label>
+            <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <span class="tooltip-content">
+               {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
+            </span>
+        </div>
+    {{/if}}
 {{/if}}

--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/states/Question.js
@@ -65,6 +65,7 @@ define([
         const options = widget.options;
         const interaction = widget.element;
         const isFlaAvailable = features.isVisible('taoQtiItem/creator/interaction/media/property/fla');
+        const isCompactAppearanceAvailable = features.isVisible('taoQtiItem/creator/interaction/media/property/compactAppearance');
         let isAudio = getIsAudio(interaction);
         const defaultVideoHeight = 270;
         const defaultAudioHeight = 30;
@@ -429,6 +430,7 @@ define([
                     //tpl data for the interaction
                     isAudio: isAudio,
                     isFlaAvailable: isFlaAvailable,
+                    isCompactAppearanceAvailable: isCompactAppearanceAvailable,
                     autostart: !!interaction.attr('autostart'),
                     sequential: !!interaction.hasClass('sequential'),
                     hidePlayer: !!interaction.hasClass('hide-player'),


### PR DESCRIPTION
## Ticket:

## What's Changed
- feature: use FF to show/hide compact appearance

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful


## Dependencies PRs
- https://github.com/oat-sa/extension-tao-mediamanager/pull/538

## How to test
- Add/remove `FEATURE_FLAG_TAO_ADVANCE_ONLY` to show/hide compact appearence feature for media player

## Video

https://github.com/user-attachments/assets/57d60485-acf8-4d3e-be88-f636f75391a5