### PR TITLE
fix: explicitly require oat-sa/extension-tao-backoffice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,13 +62,14 @@
     "minimum-stability": "dev",
     "require": {
         "ext-simplexml": "*",
+        "naneau/semver": "~0.0.7",
+        "oat-sa/extension-tao-backoffice": ">=7.1.0",
+        "oat-sa/extension-tao-item": ">=12.4.0",
+        "oat-sa/extension-tao-test": ">=16.3.0",
+        "oat-sa/generis": ">=16.0.0",
         "oat-sa/lib-tao-qti": "^7.8.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "naneau/semver": "~0.0.7",
-        "oat-sa/generis": ">=16.0.0",
-        "oat-sa/tao-core": ">=54.39.1",
-        "oat-sa/extension-tao-item": ">=12.4.0",
-        "oat-sa/extension-tao-test": ">=16.3.0"
+        "oat-sa/tao-core": ">=54.39.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# [AUT-4187](https://oat-sa.atlassian.net/browse/AUT-4187)

This PR follows up https://github.com/oat-sa/extension-tao-itemqti/pull/2743 that had introduced a direct depedency on the `oat\taoBackOffice\model\lists\RemoteListService` featured in https://github.com/oat-sa/extension-tao-backoffice/releases/tag/v7.1.0