### PR TITLE
fix: use <maxResponsePoint> instead <mapResponse> for 'point' interac…

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/helpers/answerState.js
+++ b/views/js/qtiCreator/widgets/interactions/helpers/answerState.js
@@ -55,7 +55,7 @@ define([
             CUSTOM: __('custom'),
             MATCH_CORRECT: __('match correct'),
             MAP_RESPONSE: __('map response'),
-            MAP_RESPONSE_POINT: __('map response'),
+            MAP_RESPONSE_POINT: __('map response point'),
             NONE: __('none')
         };
     };

--- a/views/js/qtiXmlRenderer/renderers/responses/SimpleFeedbackRule.js
+++ b/views/js/qtiXmlRenderer/renderers/responses/SimpleFeedbackRule.js
@@ -12,7 +12,6 @@ define([
         template : tpl,
         getData : function(rule, data){
 
-
             var template = null, ruleXml = '';
             var _values;
             var tplData = {

--- a/views/js/qtiXmlRenderer/renderers/responses/SimpleFeedbackRule.js
+++ b/views/js/qtiXmlRenderer/renderers/responses/SimpleFeedbackRule.js
@@ -22,7 +22,7 @@ define([
                     'else' : rule.feedbackElse ? rule.feedbackElse.id() : ''
                 }
             };
-            if (rule?.comparedOutcome?.attributes?.baseType === 'point') {
+            if (rule.comparedOutcome.attributes.baseType === 'point') {
                 tplData.mapResponsePoint = true;
             }
 

--- a/views/js/qtiXmlRenderer/renderers/responses/SimpleFeedbackRule.js
+++ b/views/js/qtiXmlRenderer/renderers/responses/SimpleFeedbackRule.js
@@ -11,7 +11,8 @@ define([
         qtiClass : '_simpleFeedbackRule',
         template : tpl,
         getData : function(rule, data){
-            
+
+
             var template = null, ruleXml = '';
             var _values;
             var tplData = {
@@ -22,6 +23,9 @@ define([
                     'else' : rule.feedbackElse ? rule.feedbackElse.id() : ''
                 }
             };
+            if (rule?.comparedOutcome?.attributes?.baseType === 'point') {
+                tplData.mapResponsePoint = true;
+            }
 
             switch(rule.condition){
                 case 'correct':
@@ -53,7 +57,7 @@ define([
                             _values.push(choice.id());
                         }
                     });
-                    
+
                     if(tplData.multiple){
                         tplData.choices = _values;
                     }else{


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4259

This is a POC

## What's Changed
- mapResponsePoint is used instead of mapResponse for 'point' interactions

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages


## How to test
- Edit item, add feedback, use 'map response' and one of these conditions: 'gt', 'gte', 'equal', 'lt', 'lte'