### PR TITLE
Fix/hkd 761 transcription wrong config fix

### DIFF
--- a/model/CreatorConfig.php
+++ b/model/CreatorConfig.php
@@ -62,7 +62,7 @@ class CreatorConfig extends Config
         'previewRenderUrl' => ['taoQtiItem', 'QtiPreview', 'render'],
         'previewSubmitUrl' => ['taoQtiItem', 'QtiPreview', 'submitResponses'],
 
-        'resourceMetadataUrl' => ['tao', 'ResourceMetadata', 'get'],
+        'resourceMetadataUrl' => ['taoQtiItem', 'Metadata', 'resourceMetadata'],
     ];
 
     public function addInteraction($interactionFile)

--- a/model/CreatorConfig.php
+++ b/model/CreatorConfig.php
@@ -62,7 +62,7 @@ class CreatorConfig extends Config
         'previewRenderUrl' => ['taoQtiItem', 'QtiPreview', 'render'],
         'previewSubmitUrl' => ['taoQtiItem', 'QtiPreview', 'submitResponses'],
 
-        'resourceMetadataUrl' => ['taoQtiItem', 'Metadata', 'resourceMetadata'],
+        'resourceMetadataUrl' => ['tao', 'ResourceMetadata', 'get'],
     ];
 
     public function addInteraction($interactionFile)

--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/Widget.js
@@ -66,6 +66,8 @@ define([
             if (
                 interaction.object.attr('data')
                 && interaction.object.attr('data').includes('taomedia://mediamanager/')
+                && this.options.transcriptionMetadata
+                && this.options.resourceMetadataUrl
             ) {
                 interaction.object.metaData.transcriptionUrl = this.options.resourceMetadataUrl +
                     '?metadataUri=' + encodeURIComponent(this.options.transcriptionMetadata) +

--- a/views/js/qtiCreator/widgets/interactions/mediaInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/mediaInteraction/Widget.js
@@ -66,8 +66,6 @@ define([
             if (
                 interaction.object.attr('data')
                 && interaction.object.attr('data').includes('taomedia://mediamanager/')
-                && this.options.transcriptionMetadata
-                && this.options.resourceMetadataUrl
             ) {
                 interaction.object.metaData.transcriptionUrl = this.options.resourceMetadataUrl +
                     '?metadataUri=' + encodeURIComponent(this.options.transcriptionMetadata) +

--- a/views/js/qtiCreator/widgets/static/object/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/object/states/Active.js
@@ -82,6 +82,8 @@ define([
             obj.attributes.type
             && _config.mediaPlayerMimeType.includes(obj.attributes.type)
             && obj.attributes.data.includes('taomedia://mediamanager/')
+            && obj.metaData.widget.options.mediaManager.transcriptionMetadata
+            && obj.metaData.widget.options.mediaManager.resourceMetadataUrl
         ) {
             const metadataUri = encodeURIComponent(obj.metaData.widget.options.mediaManager.transcriptionMetadata);
             const resourceUri = obj.attributes.data.replace('taomedia://mediamanager/', '');

--- a/views/js/qtiCreator/widgets/static/object/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/object/states/Active.js
@@ -82,8 +82,6 @@ define([
             obj.attributes.type
             && _config.mediaPlayerMimeType.includes(obj.attributes.type)
             && obj.attributes.data.includes('taomedia://mediamanager/')
-            && obj.metaData.widget.options.mediaManager.transcriptionMetadata
-            && obj.metaData.widget.options.mediaManager.resourceMetadataUrl
         ) {
             const metadataUri = encodeURIComponent(obj.metaData.widget.options.mediaManager.transcriptionMetadata);
             const resourceUri = obj.attributes.data.replace('taomedia://mediamanager/', '');


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/HKD-761

## What's Changed
- change fallback hardcoded url for media manager to proper one
- prevent FE from executing api call with missing paramet

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful


## Related PRs
- https://github.com/oat-sa/extension-tao-mediamanager/pull/540
 
## How to test
- Check if `tao/config/taoQtiItem/CreatorConfigFactory.conf.php` is empty `CreatorConfigFactory` object.
- Go to items Authroing 
- Add Media interaction and select some asset
- Observe there is no malformed API call which previously resulted with user logout because of exception

## Videos

### Empty config, no fix, resulting in user logout
https://github.com/user-attachments/assets/db430ac3-d8b2-4700-9618-297e5f9e8c91

### Empty config, fix applied, no malformed API call, application working 

https://github.com/user-attachments/assets/dfaa30cd-dfbd-4c91-bf3e-312efbc54f3b

### Correct config, fix applied, correct API call, application working, functionality working

https://github.com/user-attachments/assets/ad276c35-0b3e-4a78-9a1e-70789adf1d23

