### PR TITLE
[AUT-4249]: fix form behavior when on initial audio load CA flag wasn't shows

### DIFF
--- a/views/js/qtiCreator/tpl/forms/interactions/media.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/media.tpl
@@ -134,17 +134,15 @@
 {{/unless}}
 
 {{#if isCompactAppearanceAvailable}}
-    {{#if isAudio}}
-        <div class="panel compact-appearance">
-            <label>
-                <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
-                <span class="icon-checkbox"></span>
-                {{__ "Compact Appearance"}}
-            </label>
-            <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-            <span class="tooltip-content">
-               {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
-            </span>
-        </div>
-    {{/if}}
+    <div class="panel compact-appearance" style="display: {{#if isAudio}}block{{else}}none{{/if}};">
+        <label>
+            <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
+            <span class="icon-checkbox"></span>
+            {{__ "Compact Appearance"}}
+        </label>
+        <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+        <span class="tooltip-content">
+           {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
+        </span>
+    </div>
 {{/if}}

--- a/views/js/qtiCreator/tpl/forms/static/object.tpl
+++ b/views/js/qtiCreator/tpl/forms/static/object.tpl
@@ -28,17 +28,15 @@
     </div>
 </div>
 {{#if isCompactAppearanceAvailable}}
-    {{#if isAudio}}
-        <div class="panel compact-appearance">
-            <label>
-                <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
-                <span class="icon-checkbox"></span>
-                {{__ "Compact Appearance"}}
-            </label>
-            <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-            <span class="tooltip-content">
-               {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
-            </span>
-        </div>
-    {{/if}}
+    <div class="panel compact-appearance" style="display: {{#if isAudio}}block{{else}}none{{/if}};">
+        <label>
+            <input name="compactAppearance" type="checkbox" {{#if compactAppearance}}checked="checked"{{/if}}/>
+            <span class="icon-checkbox"></span>
+            {{__ "Compact Appearance"}}
+        </label>
+        <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+        <span class="tooltip-content">
+           {{__ "Set the media player UI to Compact mode, displaying only the play button icon, hiding all other controls such as volume, seek bar."}}
+        </span>
+    </div>
 {{/if}}

--- a/views/js/qtiCreator/widgets/static/object/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/object/states/Active.js
@@ -281,6 +281,16 @@ define([
 
         $container.off('playerready').on('playerready', function () {
             setMediaSizeEditor(_widget);
+            if (isCompactAppearanceAvailable) {
+                if (/audio/.test(qtiObject.attr('type'))) {
+                    $form.find('.compact-appearance').show();
+                } else {
+                    qtiObject.attr('compact-appearance', false);
+                    $form.find('.compact-appearance').hide();
+                    $form.find('.compact-appearance input[name="compactAppearance"]').prop("checked", false);
+                    $container.parent().removeClass('compact-appearance');
+                }
+            }
         });
 
         const clearMediaSize = () => {


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4249

## What's Changed
- Additional check when file is selected, need for show/hide compact appearance checkbox.
Also fixed part when compact appearance state is saved whenever you change source file


![chrome_1Iljm2MyEi](https://github.com/user-attachments/assets/040e869e-6159-4cc5-b23a-78fb7faa37fe)

> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/extension-tao-mediamanager/pull/541