### PR TITLE
fix: add hard space to mitigate gap being removed by CKEditor internal mechanism

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/gapMatchInteraction/states/Question.js
@@ -90,6 +90,25 @@ define([
             //hack : prevent ckeditor from removing empty spans
             $container.find('.gapmatch-content').html('...');
 
+            var $editable = $editableContainer.find('[data-html-editable]');
+            if ($editable.length && $editable.html()) {
+                var content = $editable.html();
+
+                if (content.trim().startsWith('<p>')) {
+                    $editable.find('p').each(function() {
+                        var $p = $(this);
+                        var pContent = $p.html();
+                        if (pContent && !pContent.startsWith('&#8203;') && !pContent.startsWith('\u200B')) {
+                            $p.html('&#8203;' + pContent);
+                        }
+                    });
+                } else {
+                    if (!content.startsWith('&#8203;') && !content.startsWith('\u200B')) {
+                        $editable.html('&#8203;' + content);
+                    }
+                }
+            }
+
             //create editor
             htmlEditor.buildEditor($editableContainer, {
                 shieldInnerContent : false,


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INF-200
## What's Changed
- add hard space to mitigate gap being removed by CKEditor internal mechanism

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## How to test
- Go to Authoring and add Gap Match Interaction 
- Add gap to first word in the sentence using magic wand
- Switch to Response tab or lose focus on the interaction
- Gap is still there 

## Video

https://github.com/user-attachments/assets/2c511df4-5e8c-4912-b281-9de866edc1b8

