### PR TITLE
fix: put htmledit logic uder ff to not braek default behaviour

### DIFF
--- a/views/js/qtiCreator/plugins/interactionModifiers/interactionSourcePlugin.js
+++ b/views/js/qtiCreator/plugins/interactionModifiers/interactionSourcePlugin.js
@@ -21,8 +21,9 @@ define([
     'lodash',
     'core/plugin',
     'core/logger',
-    'taoQtiItem/qtiCreator/plugins/interactionModifiers/interactionSourceHandler'
-], function($, _, pluginFactory, loggerFactory, interactionSourceHandlerFactory) {
+    'taoQtiItem/qtiCreator/plugins/interactionModifiers/interactionSourceHandler',
+    'context'
+], function($, _, pluginFactory, loggerFactory, interactionSourceHandlerFactory, context) {
     'use strict';
 
     const logger = loggerFactory('taoQtiItem/qtiCreator/plugins/interactionModifiers/interactionSourcePlugin');
@@ -38,6 +39,10 @@ define([
          */
         init: function init() {
             try {
+                var ENABLE_INTERACTION_SOURCE = context.featureFlags && context.featureFlags.FEATURE_FLAG_CKEDITOR_INTERACTION_SOURCE;
+                if (!ENABLE_INTERACTION_SOURCE) {
+                    return this;
+                }
                 this.handler = interactionSourceHandlerFactory({
                     itemCreator: this.getHost()
                 });


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4318

## What's Changed
- put htmledit logic uder ff to not break default behavior

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## Steps to reproduce:

Scenario 1 (creating a second row):

- Go to the Items tab.
- Create a new item.
- Add Inline Interactions → A-Block.
- Add a math expression as content.
- Click the + button to create a second A-Block (to create the second row).
- Click Save.
- Exit authoring mode and enter it again.
- Click Save again — an error occurs.

Scenario 2 (creating a second column):

- Go to the Items tab.
- Create a new item.
- Add Inline Interactions → A-Block.
- Add a math expression as content.
- Add a second A-Block next to the first one (to create the second column).
- Click Save.
- Exit authoring mode and enter it again.
- Click Save again — an error occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature-flagged “Interaction Source” integration in the editor. When the flag is enabled, the interaction source initializes and becomes available; when disabled, the editor behaves as before with no visible changes.
* **Chores**
  * Prepared the plugin to read feature flag context to control availability of the Interaction Source feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->