### PR TITLE
Fix/tr 6665/choiceinter ipad scrollable

### DIFF
--- a/views/scss/qti/_choice.scss
+++ b/views/scss/qti/_choice.scss
@@ -316,6 +316,17 @@
     writing-mode: vertical-rl;
 
     .qti-choiceInteraction {
+        /* in iPad Safari & nested scroll container,
+           checked radio style sometimes isn't applied after click on choice - repaint is not triggered  */
+        .qti-choice {
+            &.user-selected {
+                opacity: 0.97;
+            }
+            &:not(.user-selected) {
+                opacity: 1;
+            }
+        }
+
         &.maskable {
             .qti-choice {
                 .answer-mask {
@@ -465,8 +476,8 @@
     }
 }
 
-.qti-choice:has(.compact-appearance){
-    [data-html-editable="true"]{
+.qti-choice:has(.compact-appearance) {
+    [data-html-editable='true'] {
         display: flex;
         position: relative;
         min-height: 4rem;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-6665

iPad, Safari (v18, maybe others), Choice interaction, vertical-writing:

Sometimes when you check or uncheck radio button, browser doesn't repaint, so in UI radio has old state.
Trick is to force repaint by changing opacity like here: https://github.com/oat-sa/tao-item-runner-qti-fe/blob/master/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js#L897-L904

"Sometimes" is:
- delivery: when interaction is inside scrollable container (use iPad with small screen, open navigation panel on the left, put two interactions in one column --> ensure there's a scrollbar for the item --> click on some radio for the second interaction)
- item preview in Authoring: same item, but reproduces even without scrollbar on the item