### PR TITLE
[ADF-2116] - feat: Enable strike plugin

### DIFF
--- a/views/js/qtiCreator/helper/ckConfigurator.js
+++ b/views/js/qtiCreator/helper/ckConfigurator.js
@@ -26,6 +26,7 @@ define(['lodash', 'ui/ckeditor/ckConfigurator', 'mathJax'], function(_, ckConfig
         qtiMedia : true,
         qtiInclude : true,
         underline : true,
+        strike: true, 
         mathJax : !!mathJax,
         horizontalRule: true,
         furiganaPlugin: true
@@ -44,6 +45,7 @@ define(['lodash', 'ui/ckeditor/ckConfigurator', 'mathJax'], function(_, ckConfig
      * @param {Boolean} [options.qtiImage] - enables the qtiImage plugin
      * @param {Boolean} [options.qtiInclude] - enables the qtiInclude plugin
      * @param {Boolean} [options.underline] - enables the underline plugin
+     * @param {Boolean} [options.strike] - enables the strike plugin
      * @param {Boolean} [options.mathJax] - enables the mathJax plugin
      *
      * @see http://docs.ckeditor.com/#!/api/CKEDITOR.config


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/ADF-2116

## What's Changed
- Enable strike plugin on CKEditor. 

## How to test in local
Follow steps from https://github.com/oat-sa/ckeditor-dev/pull/58

### Related PR:
https://github.com/oat-sa/tao-core-shared-libs-fe/pull/58
https://github.com/oat-sa/extension-tao-testqti/pull/2665
https://github.com/oat-sa/extension-tao-mediamanager/pull/544
https://github.com/oat-sa/tao-core-ui-fe/pull/659

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [X] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled strikethrough formatting option by default in the text editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->