### PR TITLE
NTS-458 Allow to configure languagesUrl

### DIFF
--- a/model/qti/Item.php
+++ b/model/qti/Item.php
@@ -136,7 +136,7 @@ class Item extends IdentifiedElement implements FlowContainer, IdentifiedElement
     {
         // override the tool options !
         $attributes['toolName'] = PRODUCT_NAME;
-        $attributes['toolVersion'] = \tao_models_classes_TaoService::singleton()->getPlatformVersion();
+        $attributes['toolVersion'] = defined('TOOL_VERSION') ? TOOL_VERSION : \tao_models_classes_TaoService::singleton()->getPlatformVersion();
 
         // create container
         $this->body = new ContainerItemBody('', $this);

--- a/model/qti/Item.php
+++ b/model/qti/Item.php
@@ -136,7 +136,7 @@ class Item extends IdentifiedElement implements FlowContainer, IdentifiedElement
     {
         // override the tool options !
         $attributes['toolName'] = PRODUCT_NAME;
-        $attributes['toolVersion'] = defined('TOOL_VERSION') ? TOOL_VERSION : \tao_models_classes_TaoService::singleton()->getPlatformVersion();
+        $attributes['toolVersion'] = \tao_models_classes_TaoService::singleton()->getPlatformVersion();
 
         // create container
         $this->body = new ContainerItemBody('', $this);

--- a/views/js/qtiCreator/helper/languages.js
+++ b/views/js/qtiCreator/helper/languages.js
@@ -22,10 +22,11 @@
  * v1 example: [{"ar-arb": "Arabic"}, ...]
  * v2 example: [{code: "ar-arb", label: "Arabic", orientation: "rtl", uri: "http://www.tao.lu/Ontologies/TAO.rdf#Langar-arb"}, ...]
  */
-define(['util/url', 'core/dataProvider/request'], function (urlUtil, request) {
+define(['util/url', 'core/dataProvider/request', 'module'], function (urlUtil, request, module) {
     'use strict';
 
-    const languagesUrl = urlUtil.route('index', 'Languages', 'tao');
+    const config = module.config();
+    const languagesUrl = config?.languagesUrl || urlUtil.route('index', 'Languages', 'tao');
     const headers = {'Accept-version': 'v2'};
 
     let languagesRequest = null;

--- a/views/js/qtiCreator/helper/languages.js
+++ b/views/js/qtiCreator/helper/languages.js
@@ -26,7 +26,7 @@ define(['util/url', 'core/dataProvider/request', 'module'], function (urlUtil, r
     'use strict';
 
     const config = module.config();
-    const languagesUrl = config?.languagesUrl || urlUtil.route('index', 'Languages', 'tao');
+    const languagesUrl = (config && config.languagesUrl) || urlUtil.route('index', 'Languages', 'tao');
     const headers = {'Accept-version': 'v2'};
 
     let languagesRequest = null;

--- a/views/js/qtiCreator/widgets/helpers/qtiIdentifier.js
+++ b/views/js/qtiCreator/widgets/helpers/qtiIdentifier.js
@@ -24,11 +24,13 @@ define(['module', 'i18n'], function (module, __) {
     const defaultInvalidQtiIdMessage = __('Identifiers must start with a letter or an underscore and contain only letters, numbers, dots, underscores ( _ ), or hyphens ( - ).');
     const invalidQtiIdMessage = module.config().invalidQtiIdMessage || defaultInvalidQtiIdMessage;
     const isDisabled = module.config().isDisabled || false;
+    const configuredMaxLength = Number(module.config().maxQtiIdLength);
+    const maxQtiIdLength = Number.isFinite(configuredMaxLength) && configuredMaxLength > 0 ? configuredMaxLength : 32;
 
     return {
         pattern: new RegExp(patternContent, flags),
         invalidQtiIdMessage,
-        maxQtiIdLength: 32,
+        maxQtiIdLength,
         isDisabled
     };
 });

--- a/views/js/test/qtiCreator/helper/languages/test.js
+++ b/views/js/test/qtiCreator/helper/languages/test.js
@@ -16,10 +16,12 @@
  * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
  */
 
-define(['jquery', 'taoQtiItem/qtiCreator/helper/languages', 'lib/jquery.mockjax/jquery.mockjax'], function (
-    $,
-    languages
-) {
+define([
+    'jquery',
+    'taoQtiItem/qtiCreator/helper/languages',
+    'util/url',
+    'lib/jquery.mockjax/jquery.mockjax'
+], function ($, languages, urlUtil) {
     'use strict';
     const languagesDataMock = [
         {
@@ -221,5 +223,181 @@ define(['jquery', 'taoQtiItem/qtiCreator/helper/languages', 'lib/jquery.mockjax/
                 );
             })
             .finally(done);
+    });
+
+    /**
+     * Tests for languagesUrl configuration fallback (lines 28-29 of languages.js):
+     *   const config = module.config();
+     *   const languagesUrl = (config && config.languagesUrl) || urlUtil.route('index', 'Languages', 'tao');
+     */
+    QUnit.module('languagesUrl configuration', {
+        afterEach: function () {
+            // Clean up: undefine the module so subsequent tests start fresh
+            require.undef('taoQtiItem/qtiCreator/helper/languages');
+        }
+    });
+
+    /**
+     * Test: When module.config() returns no languagesUrl, falls back to urlUtil.route()
+     *
+     * This tests the fallback branch:
+     *   const languagesUrl = (config && config.languagesUrl) || urlUtil.route('index', 'Languages', 'tao');
+     *
+     * When config.languagesUrl is falsy, urlUtil.route('index', 'Languages', 'tao') is used.
+     */
+    QUnit.test('languagesUrl falls back to urlUtil.route when not configured', function (assert) {
+        const done = assert.async();
+
+        // Get the expected fallback URL from urlUtil.route
+        const expectedFallbackUrl = urlUtil.route('index', 'Languages', 'tao');
+
+        // The module is already loaded with default config (no languagesUrl override)
+        // Mock the AJAX call to capture the URL being requested
+        $.mockjax.clear();
+
+        let capturedUrl = null;
+        $.mockjax({
+            url: /.*Languages.*/,
+            response: function (settings) {
+                capturedUrl = settings.url;
+                this.responseText = { success: true, data: [] };
+            },
+            status: 200
+        });
+
+        // Reload the module fresh with no languagesUrl config
+        require.undef('taoQtiItem/qtiCreator/helper/languages');
+        require.config({
+            config: {
+                'taoQtiItem/qtiCreator/helper/languages': {}
+            }
+        });
+
+        require(['taoQtiItem/qtiCreator/helper/languages'], function (langModule) {
+            // Reset the internal cache by creating a fresh request
+            langModule
+                .getList()
+                .then(function () {
+                    assert.ok(capturedUrl, 'AJAX request was made');
+                    assert.equal(
+                        capturedUrl,
+                        expectedFallbackUrl,
+                        'languagesUrl equals urlUtil.route("index", "Languages", "tao") when not configured'
+                    );
+                })
+                .catch(function (err) {
+                    assert.ok(false, 'getList() failed: ' + err);
+                })
+                .finally(function () {
+                    $.mockjax.clear();
+                    done();
+                });
+        });
+    });
+
+    /**
+     * Test: When module.config() returns an object with languagesUrl, that URL is used
+     *
+     * This tests the primary branch:
+     *   const languagesUrl = (config && config.languagesUrl) || urlUtil.route('index', 'Languages', 'tao');
+     *
+     * When config.languagesUrl is truthy, it takes precedence over the fallback.
+     */
+    QUnit.test('languagesUrl uses module.config().languagesUrl when provided', function (assert) {
+        const done = assert.async();
+        const customLanguagesUrl = 'http://custom.server/api/languages';
+
+        // Clear existing mocks
+        $.mockjax.clear();
+
+        let capturedUrl = null;
+        $.mockjax({
+            url: customLanguagesUrl,
+            response: function (settings) {
+                capturedUrl = settings.url;
+                this.responseText = { success: true, data: [] };
+            },
+            status: 200
+        });
+
+        // Undefine and reload the module with custom languagesUrl config
+        require.undef('taoQtiItem/qtiCreator/helper/languages');
+        require.config({
+            config: {
+                'taoQtiItem/qtiCreator/helper/languages': {
+                    languagesUrl: customLanguagesUrl
+                }
+            }
+        });
+
+        require(['taoQtiItem/qtiCreator/helper/languages'], function (langModule) {
+            langModule
+                .getList()
+                .then(function () {
+                    assert.ok(capturedUrl, 'AJAX request was made');
+                    assert.equal(
+                        capturedUrl,
+                        customLanguagesUrl,
+                        'languagesUrl equals the configured languagesUrl from module.config()'
+                    );
+                })
+                .catch(function (err) {
+                    assert.ok(false, 'getList() failed: ' + err);
+                })
+                .finally(function () {
+                    $.mockjax.clear();
+                    done();
+                });
+        });
+    });
+
+    /**
+     * Test: When module.config() returns null, falls back to urlUtil.route()
+     */
+    QUnit.test('languagesUrl falls back to urlUtil.route when config is null', function (assert) {
+        const done = assert.async();
+
+        const expectedFallbackUrl = urlUtil.route('index', 'Languages', 'tao');
+
+        $.mockjax.clear();
+
+        let capturedUrl = null;
+        $.mockjax({
+            url: /.*Languages.*/,
+            response: function (settings) {
+                capturedUrl = settings.url;
+                this.responseText = { success: true, data: [] };
+            },
+            status: 200
+        });
+
+        // Undefine and reload with null/undefined config
+        require.undef('taoQtiItem/qtiCreator/helper/languages');
+        // Setting config to undefined effectively means module.config() returns {}
+        require.config({
+            config: {
+                'taoQtiItem/qtiCreator/helper/languages': undefined
+            }
+        });
+
+        require(['taoQtiItem/qtiCreator/helper/languages'], function (langModule) {
+            langModule
+                .getList()
+                .then(function () {
+                    assert.ok(capturedUrl, 'AJAX request was made');
+                    assert.equal(
+                        capturedUrl,
+                        expectedFallbackUrl,
+                        'languagesUrl equals urlUtil.route fallback when config is null/undefined'
+                    );
+                })
+                .catch(function (err) {
+                    assert.ok(false, 'getList() failed: ' + err);
+                })
+                .finally(function () {
+                    $.mockjax.clear();
+                    done();
+                });
+        });
     });
 });

--- a/views/js/test/qtiCreator/helper/languages/test.js
+++ b/views/js/test/qtiCreator/helper/languages/test.js
@@ -352,9 +352,12 @@ define([
     });
 
     /**
-     * Test: When module.config() returns null, falls back to urlUtil.route()
+     * Test: When module.config() returns null/undefined, falls back to urlUtil.route()
+     *
+     * Note: RequireJS module.config() returns {} for both null and undefined config values,
+     * so this test verifies the fallback behavior when no languagesUrl is present.
      */
-    QUnit.test('languagesUrl falls back to urlUtil.route when config is null', function (assert) {
+    QUnit.test('languagesUrl falls back to urlUtil.route when config is null/undefined', function (assert) {
         const done = assert.async();
 
         const expectedFallbackUrl = urlUtil.route('index', 'Languages', 'tao');
@@ -371,12 +374,12 @@ define([
             status: 200
         });
 
-        // Undefine and reload with null/undefined config
+        // Undefine and reload with null config
         require.undef('taoQtiItem/qtiCreator/helper/languages');
-        // Setting config to undefined effectively means module.config() returns {}
+        // RequireJS normalizes both null and undefined to {}, triggering the fallback
         require.config({
             config: {
-                'taoQtiItem/qtiCreator/helper/languages': undefined
+                'taoQtiItem/qtiCreator/helper/languages': null
             }
         });
 


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/NTS-458

## What's Changed
- Allow to configure languagesUrl, fallback to default

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## How to test
- Add module config with languagesUrl, run item authoring, check it loads form URL
- Remove languagesUrl from module config, check it also works as usual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Language loader now supports an optional configuration override for the languages URL, while keeping the existing fallback behavior.
  * QTI identifier helper now supports configurable maximum ID length via module configuration, with a safe default when unset/invalid.
* **Tests**
  * Added unit tests to verify languages URL resolution for both configured and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->