### PR TITLE
fix: prevent .0 appearing in empty float response field

### DIFF
--- a/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
+++ b/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
@@ -55,7 +55,9 @@ define([
         if (attributes.baseType === 'float') {
             $correctInput.attr('placeholder', __(`example: 999${decimalSeparator}99`));
             // converting preloaded number to float if it not
-            correctResponse = (+correctResponse % 1) ? correctResponse : `${correctResponse}.0`;
+            if (correctResponse) {
+                correctResponse = (+correctResponse % 1) ? correctResponse : `${correctResponse}.0`;
+            }
         }
 
         if (attributes.baseType === 'float' && decimalSeparator !== '.') {

--- a/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
+++ b/views/js/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct.js
@@ -55,8 +55,8 @@ define([
         if (attributes.baseType === 'float') {
             $correctInput.attr('placeholder', __(`example: 999${decimalSeparator}99`));
             // converting preloaded number to float if it not
-            if (correctResponse) {
-                correctResponse = (+correctResponse % 1) ? correctResponse : `${correctResponse}.0`;
+            if (correctResponse && !String(correctResponse).includes('.')) {
+                correctResponse = `${correctResponse}.0`;
             }
         }
 

--- a/views/js/test/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct/test.html
+++ b/views/js/test/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct/test.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test - Text Entry Interaction Correct State</title>
+        <base href="../../../../../../../../../../../tao/views/"/>
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiItem/test/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct/test'], function () {
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct/test.js
+++ b/views/js/test/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct/test.js
@@ -25,8 +25,8 @@ define([], function () {
      * @returns {string} - The formatted response
      */
     function formatFloatResponse(correctResponse) {
-        if (correctResponse) {
-            return (+correctResponse % 1) ? correctResponse : `${correctResponse}.0`;
+        if (correctResponse && !String(correctResponse).includes('.')) {
+            return `${correctResponse}.0`;
         }
         return correctResponse;
     }

--- a/views/js/test/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct/test.js
+++ b/views/js/test/qtiCreator/widgets/interactions/textEntryInteraction/states/Correct/test.js
@@ -1,0 +1,112 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA ;
+ */
+define([], function () {
+    'use strict';
+
+    /**
+     * Replicates the float formatting logic from Correct.js state
+     * This is extracted for testability
+     * @param {string} correctResponse - The correct response value
+     * @returns {string} - The formatted response
+     */
+    function formatFloatResponse(correctResponse) {
+        if (correctResponse) {
+            return (+correctResponse % 1) ? correctResponse : `${correctResponse}.0`;
+        }
+        return correctResponse;
+    }
+
+    QUnit.module('qtiCreator/widgets/interactions/textEntryInteraction/states/Correct - float formatting');
+
+    QUnit.test('module', assert => {
+        assert.equal(typeof formatFloatResponse, 'function', 'formatFloatResponse is a function');
+    });
+
+    QUnit.cases
+        .init([
+            {
+                title: 'empty string should remain empty',
+                input: '',
+                expected: ''
+            },
+            {
+                title: 'undefined should remain undefined',
+                input: undefined,
+                expected: undefined
+            },
+            {
+                title: 'null should remain null',
+                input: null,
+                expected: null
+            },
+            {
+                title: 'whole number string should get .0 appended',
+                input: '5',
+                expected: '5.0'
+            },
+            {
+                title: 'decimal number should stay unchanged',
+                input: '5.5',
+                expected: '5.5'
+            },
+            {
+                title: 'zero should get .0 appended',
+                input: '0',
+                expected: '0.0'
+            },
+            {
+                title: 'negative whole number should get .0 appended',
+                input: '-10',
+                expected: '-10.0'
+            },
+            {
+                title: 'negative decimal should stay unchanged',
+                input: '-10.5',
+                expected: '-10.5'
+            },
+            {
+                title: 'number ending with .0 should stay unchanged',
+                input: '5.0',
+                expected: '5.0'
+            },
+            {
+                title: 'large whole number should get .0 appended',
+                input: '999',
+                expected: '999.0'
+            },
+            {
+                title: 'decimal with trailing zeros should stay unchanged',
+                input: '5.50',
+                expected: '5.50'
+            }
+        ])
+        .test('float formatting ', (data, assert) => {
+            const result = formatFloatResponse(data.input);
+            assert.strictEqual(
+                result,
+                data.expected,
+                `${data.title}: "${data.input}" -> "${data.expected}"`
+            );
+        });
+
+    QUnit.test('regression: empty string should NOT become ".0"', assert => {
+        const result = formatFloatResponse('');
+        assert.notEqual(result, '.0', 'Empty string should not be converted to ".0"');
+        assert.strictEqual(result, '', 'Empty string should remain empty');
+    });
+});


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-3621

## What's Changed

- Fix bug where .0 value automatically appeared in Text Entry interaction text field when response base type was set to float and the field was empty
- Add unit tests for the float formatting logic in the Correct state


https://github.com/user-attachments/assets/50b068ad-9bad-43b1-871e-87d4b81cec26


> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed float formatting in text-entry answers so empty/undefined values no longer get a ".0" suffix; whole-number answers keep a ".0" only when appropriate.

* **Tests**
  * Added comprehensive QUnit tests and a test runner page covering float formatting, edge cases, and a regression to prevent incorrect ".0" coercion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->