### PR TITLE
fix: rewrite items using api with itemMustBeOverwritten

### DIFF
--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -506,6 +506,9 @@ class ImportService extends ConfigurableService
                 $guardian = false;
 
                 if ($enableMetadataGuardians === true) {
+                    if (!empty($metadataValues)) {
+                        $this->getMetadataImporter()->setMetadataValues($metadataValues);
+                    }
                     $guardian = $this->getMetadataImporter()->guard($resourceIdentifier);
                     if ($guardian !== false) {
                         // Item found by guardians.

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -506,9 +506,7 @@ class ImportService extends ConfigurableService
                 $guardian = false;
 
                 if ($enableMetadataGuardians === true) {
-                    if (!empty($metadataValues)) {
-                        $this->getMetadataImporter()->setMetadataValues($metadataValues);
-                    }
+                    $this->getMetadataImporter()->setMetadataValues($metadataValues);
                     $guardian = $this->getMetadataImporter()->guard($resourceIdentifier);
                     if ($guardian !== false) {
                         // Item found by guardians.

--- a/model/qti/metadata/AbstractMetadataService.php
+++ b/model/qti/metadata/AbstractMetadataService.php
@@ -45,12 +45,12 @@ abstract class AbstractMetadataService extends ConfigurableService
     /**
      * @var array Array of metadata, with metadata key with associated value
      */
-    protected $metadataValues;
+    protected $metadataValues = [];
 
     /**
      * @var array Instances to manage metadata values
      */
-    protected $instances;
+    protected $instances = [];
 
     /**
      * Allow to register into config a metadataService

--- a/test/unit/model/qti/ImportServiceMetadataGuardTest.php
+++ b/test/unit/model/qti/ImportServiceMetadataGuardTest.php
@@ -22,31 +22,25 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\test\unit\model\qti;
 
+use core_kernel_classes_Class as RdfClass;
 use core_kernel_classes_Resource as RdfResource;
 use oat\generis\test\ServiceManagerMockTrait;
+use oat\oatbox\reporting\Report;
+use oat\taoQtiItem\model\qti\ImportService;
 use oat\taoQtiItem\model\qti\metadata\importer\MetadataImporter;
-use oat\taoQtiItem\model\qti\metadata\MetadataService;
+use oat\taoQtiItem\model\qti\metadata\MetadataGuardianResource;
+use oat\taoQtiItem\model\qti\Resource;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockInterface;
 
 /**
- * Unit tests for MetadataImporter guard behavior as used by ImportService.
+ * Unit tests for ImportService guard behavior with MetadataImporter.
  *
- * These tests verify the contract between ImportService and MetadataImporter,
- * specifically around the overwrite guard behavior in ImportService::importQtiItem()
- * (lines 509-513).
+ * These tests invoke ImportService::importQtiItem() with mocked dependencies
+ * and verify observable outcomes based on guard() results and $itemMustBeOverwritten flag.
  *
- * The tests ensure:
- * - setMetadataValues() correctly sets metadata state before guard() is called
- * - guard() returns appropriate values based on metadata presence
- * - Empty metadata prevents guard from reusing prior state
- *
- * Note: Full orchestration testing of ImportService::importQtiItem() with all
- * its dependencies (file system, locks, QTI parsing, RDF creation) is covered
- * by integration tests in taoQtiItem/test/integration/metadata/.
- *
- * @see \oat\taoQtiItem\model\qti\ImportService::importQtiItem()
- * @see \oat\taoQtiItem\test\integration\metadata\LomIdentifierGuardianTest
+ * @see \oat\taoQtiItem\model\qti\ImportService::importQtiItem() lines 509-544
  */
 class ImportServiceMetadataGuardTest extends TestCase
 {
@@ -55,19 +49,20 @@ class ImportServiceMetadataGuardTest extends TestCase
     private const RESOURCE_IDENTIFIER = 'item-resource-123';
 
     /**
-     * Test: When metadataValues is non-empty and item exists, guard allows overwrite.
+     * Test: ImportService returns INFO report when guard finds item and overwrite disabled.
      *
-     * Verifies the MetadataImporter contract that ImportService relies on:
-     * 1. setMetadataValues($metadataValues) stores metadata keyed by identifier
-     * 2. guard($resourceIdentifier) returns the existing resource when found
+     * Invokes ImportService::importQtiItem() with:
+     * - $enableMetadataGuardians = true
+     * - $itemMustBeOverwritten = false
+     * - MetadataImporter mock where guard() returns existing resource
      *
-     * In ImportService::importQtiItem() (line 509-513), when:
-     * - $enableMetadataGuardians === true
-     * - $metadataValues contains the resource identifier
-     * - Guardian finds an existing item
-     * Then guard() returns the resource, allowing overwrite when $itemMustBeOverwritten
+     * Verifies:
+     * - setMetadataValues() is called with provided metadata
+     * - guard() is called with resource identifier
+     * - Report type is INFO (item already exists, not overwritten)
+     * - Report data contains MetadataGuardianResource with the found item
      */
-    public function testGuardAllowsOverwriteWhenMetadataValuesNonEmptyAndItemExists(): void
+    public function testImportQtiItemReturnsInfoReportWhenGuardFindsItemAndOverwriteDisabled(): void
     {
         $resourceIdentifier = self::RESOURCE_IDENTIFIER;
         $existingResource = $this->createMock(RdfResource::class);
@@ -89,100 +84,57 @@ class ImportServiceMetadataGuardTest extends TestCase
             ->with($resourceIdentifier)
             ->willReturn($existingResource);
 
-        $metadataServiceMock = $this->createMock(MetadataService::class);
-        $metadataServiceMock->method('getImporter')->willReturn($metadataImporterMock);
+        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
+        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
+        $itemClass = $this->createMock(RdfClass::class);
 
-        $metadataImporterMock->setMetadataValues($metadataValues);
-        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
+        $sharedFiles = [];
+        $createdClasses = [];
+        $overwrittenItems = [];
 
-        $this->assertNotFalse(
-            $guardResult,
-            'guard() should return a non-false value (existing resource) when metadata is present'
+        $report = $importService->importQtiItem(
+            '/tmp/test/',
+            $qtiResource,
+            $itemClass,
+            $sharedFiles,
+            [],
+            $metadataValues,
+            $createdClasses,
+            true,
+            false,
+            false,
+            false,
+            $overwrittenItems
         );
+
         $this->assertSame(
-            $existingResource,
-            $guardResult,
-            'guard() should return the existing resource when item is found by guardians'
+            Report::TYPE_INFO,
+            $report->getType(),
+            'ImportService should return INFO report when guard finds existing item and overwrite is disabled'
+        );
+
+        $reportData = $report->getData();
+        $this->assertInstanceOf(
+            MetadataGuardianResource::class,
+            $reportData,
+            'Report data should contain MetadataGuardianResource'
         );
     }
 
     /**
-     * Test: When metadataValues is empty, guard returns false (no prior state reused).
+     * Test: ImportService returns ERROR report when guard finds no item but itemMustExist is true.
      *
-     * Verifies the MetadataImporter contract that ImportService relies on:
-     * 1. setMetadataValues([]) clears any prior metadata
-     * 2. guard($resourceIdentifier) returns false when no metadata exists
+     * Invokes ImportService::importQtiItem() with:
+     * - $enableMetadataGuardians = true
+     * - $itemMustExist = true
+     * - MetadataImporter mock where guard() returns false (item not found)
      *
-     * This is critical because ImportService reuses the same MetadataImporter
-     * instance across multiple items. Without setMetadataValues() clearing state,
-     * guard() could incorrectly match an item based on stale metadata.
+     * Verifies:
+     * - setMetadataValues() is called
+     * - guard() is called and returns false
+     * - Report type is ERROR (item must exist but was not found)
      */
-    public function testGuardReturnsFalseWhenMetadataValuesEmpty(): void
-    {
-        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
-        $emptyMetadataValues = [];
-
-        /** @var MetadataImporter&MockObject $metadataImporterMock */
-        $metadataImporterMock = $this->createMock(MetadataImporter::class);
-
-        $metadataImporterMock->expects($this->once())
-            ->method('setMetadataValues')
-            ->with($emptyMetadataValues);
-
-        $metadataImporterMock->expects($this->once())
-            ->method('guard')
-            ->with($resourceIdentifier)
-            ->willReturn(false);
-
-        $metadataImporterMock->setMetadataValues($emptyMetadataValues);
-        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
-
-        $this->assertFalse(
-            $guardResult,
-            'guard() should return false when metadataValues is empty (no prior state reused)'
-        );
-    }
-
-    /**
-     * Integration test: Real MetadataImporter guard() returns false with empty metadata.
-     *
-     * Uses actual MetadataImporter to verify:
-     * 1. setMetadataValues([]) clears metadata state
-     * 2. hasMetadataValue() returns false for any identifier
-     * 3. guard() returns false without invoking guardians
-     *
-     * This mirrors ImportService behavior when importing items without metadata.
-     */
-    public function testRealMetadataImporterGuardWithEmptyMetadata(): void
-    {
-        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
-
-        $metadataImporter = new MetadataImporter();
-        $metadataImporter->setMetadataValues([]);
-
-        $this->assertFalse(
-            $metadataImporter->hasMetadataValue($resourceIdentifier),
-            'hasMetadataValue() should return false when metadataValues is empty'
-        );
-
-        $guardResult = $metadataImporter->guard($resourceIdentifier);
-
-        $this->assertFalse(
-            $guardResult,
-            'guard() should return false when hasMetadataValue() is false'
-        );
-    }
-
-    /**
-     * Integration test: Real MetadataImporter hasMetadataValue() returns true when set.
-     *
-     * Uses actual MetadataImporter to verify:
-     * 1. setMetadataValues() with non-empty metadata stores values correctly
-     * 2. hasMetadataValue() returns true for identifiers present in metadata
-     *
-     * This is a precondition for guard() to invoke guardians in ImportService.
-     */
-    public function testRealMetadataImporterHasMetadataValueWithNonEmptyMetadata(): void
+    public function testImportQtiItemReturnsErrorReportWhenGuardFindsNoItemButMustExist(): void
     {
         $resourceIdentifier = self::RESOURCE_IDENTIFIER;
         $metadataValues = [
@@ -191,23 +143,181 @@ class ImportServiceMetadataGuardTest extends TestCase
             ]
         ];
 
-        $metadataImporter = new MetadataImporter();
-        $metadataImporter->setMetadataValues($metadataValues);
+        /** @var MetadataImporter&MockObject $metadataImporterMock */
+        $metadataImporterMock = $this->createMock(MetadataImporter::class);
 
-        $this->assertTrue(
-            $metadataImporter->hasMetadataValue($resourceIdentifier),
-            'hasMetadataValue() should return true when metadataValues contains the identifier'
+        $metadataImporterMock->expects($this->once())
+            ->method('setMetadataValues')
+            ->with($metadataValues);
+
+        $metadataImporterMock->expects($this->once())
+            ->method('guard')
+            ->with($resourceIdentifier)
+            ->willReturn(false);
+
+        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
+        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
+        $itemClass = $this->createMock(RdfClass::class);
+
+        $sharedFiles = [];
+        $createdClasses = [];
+        $overwrittenItems = [];
+
+        $report = $importService->importQtiItem(
+            '/tmp/test/',
+            $qtiResource,
+            $itemClass,
+            $sharedFiles,
+            [],
+            $metadataValues,
+            $createdClasses,
+            true,
+            false,
+            true,
+            false,
+            $overwrittenItems
+        );
+
+        $this->assertSame(
+            Report::TYPE_ERROR,
+            $report->getType(),
+            'ImportService should return ERROR report when guard finds no item but itemMustExist is true'
+        );
+
+        $this->assertStringContainsString(
+            $resourceIdentifier,
+            $report->getMessage(),
+            'Error message should reference the resource identifier'
         );
     }
 
     /**
-     * Test: setMetadataValues replaces previous state (no accumulation).
+     * Test: ImportService calls setMetadataValues before guard when guardians enabled.
      *
-     * Verifies that calling setMetadataValues() replaces (not merges) previous values.
-     * This is critical for ImportService which processes multiple items sequentially
-     * and needs each item to start with fresh metadata state.
+     * This test verifies the correct call sequence in ImportService::importQtiItem().
+     * The MetadataImporter mock tracks call order to ensure setMetadataValues()
+     * is invoked before guard().
      */
-    public function testSetMetadataValuesReplacesExistingState(): void
+    public function testImportQtiItemCallsSetMetadataValuesBeforeGuard(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+        $existingResource = $this->createMock(RdfResource::class);
+        $metadataValues = [
+            $resourceIdentifier => [
+                ['path' => ['lom', 'identifier'], 'value' => 'unique-id-123']
+            ]
+        ];
+
+        $callOrder = [];
+
+        /** @var MetadataImporter&MockObject $metadataImporterMock */
+        $metadataImporterMock = $this->createMock(MetadataImporter::class);
+
+        $metadataImporterMock->expects($this->once())
+            ->method('setMetadataValues')
+            ->with($metadataValues)
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'setMetadataValues';
+            });
+
+        $metadataImporterMock->expects($this->once())
+            ->method('guard')
+            ->with($resourceIdentifier)
+            ->willReturnCallback(function () use (&$callOrder, $existingResource) {
+                $callOrder[] = 'guard';
+                return $existingResource;
+            });
+
+        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
+        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
+        $itemClass = $this->createMock(RdfClass::class);
+
+        $sharedFiles = [];
+        $createdClasses = [];
+        $overwrittenItems = [];
+
+        $importService->importQtiItem(
+            '/tmp/test/',
+            $qtiResource,
+            $itemClass,
+            $sharedFiles,
+            [],
+            $metadataValues,
+            $createdClasses,
+            true,
+            false,
+            false,
+            false,
+            $overwrittenItems
+        );
+
+        $this->assertSame(
+            ['setMetadataValues', 'guard'],
+            $callOrder,
+            'ImportService must call setMetadataValues() before guard()'
+        );
+    }
+
+    /**
+     * Test: ImportService skips guard when metadata guardians are disabled.
+     *
+     * Verifies that when $enableMetadataGuardians = false, ImportService
+     * does not call setMetadataValues() or guard() on MetadataImporter.
+     */
+    public function testImportQtiItemSkipsGuardWhenGuardiansDisabled(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+
+        /** @var MetadataImporter&MockObject $metadataImporterMock */
+        $metadataImporterMock = $this->createMock(MetadataImporter::class);
+
+        $metadataImporterMock->expects($this->never())
+            ->method('setMetadataValues');
+
+        $metadataImporterMock->expects($this->never())
+            ->method('guard');
+
+        $metadataImporterMock->method('classLookUp')->willReturn(false);
+
+        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
+        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
+        $itemClass = $this->createMock(RdfClass::class);
+
+        $sharedFiles = [];
+        $createdClasses = [];
+        $overwrittenItems = [];
+
+        try {
+            $importService->importQtiItem(
+                '/tmp/test/',
+                $qtiResource,
+                $itemClass,
+                $sharedFiles,
+                [],
+                [],
+                $createdClasses,
+                false,
+                false,
+                false,
+                false,
+                $overwrittenItems
+            );
+        } catch (\Throwable $e) {
+            // Expected - method will fail later due to missing file, but guard methods weren't called
+        }
+
+        // Assertions are in the mock expectations (expects never)
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Test: Real MetadataImporter state management.
+     *
+     * Uses actual MetadataImporter to verify:
+     * 1. setMetadataValues() correctly stores/clears metadata
+     * 2. hasMetadataValue() and guard() behave correctly based on state
+     */
+    public function testRealMetadataImporterStateManagement(): void
     {
         $identifier1 = 'item-1';
         $identifier2 = 'item-2';
@@ -217,74 +327,68 @@ class ImportServiceMetadataGuardTest extends TestCase
         $metadataImporter->setMetadataValues([
             $identifier1 => [['path' => ['lom', 'id'], 'value' => 'value-1']]
         ]);
-
         $this->assertTrue($metadataImporter->hasMetadataValue($identifier1));
-        $this->assertFalse($metadataImporter->hasMetadataValue($identifier2));
+        $this->assertFalse($metadataImporter->guard($identifier1));
 
         $metadataImporter->setMetadataValues([
             $identifier2 => [['path' => ['lom', 'id'], 'value' => 'value-2']]
         ]);
-
         $this->assertFalse(
             $metadataImporter->hasMetadataValue($identifier1),
-            'Previous metadata should be replaced, not accumulated'
+            'Previous metadata should be replaced by setMetadataValues()'
         );
-        $this->assertTrue(
-            $metadataImporter->hasMetadataValue($identifier2),
-            'New metadata should be available'
-        );
-    }
+        $this->assertTrue($metadataImporter->hasMetadataValue($identifier2));
 
-    /**
-     * Test: Guard behavior when item exists but overwrite is disabled.
-     *
-     * When guard() returns a resource (item found) but $itemMustBeOverwritten is false,
-     * ImportService::importQtiItem() returns an INFO report instead of proceeding.
-     * This test verifies the guard contract that enables this behavior.
-     */
-    public function testGuardReturnsResourceWhenItemExistsAllowingOverwriteDecision(): void
-    {
-        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
-        $existingResource = $this->createMock(RdfResource::class);
-
-        /** @var MetadataImporter&MockObject $metadataImporterMock */
-        $metadataImporterMock = $this->createMock(MetadataImporter::class);
-
-        $metadataImporterMock->method('guard')
-            ->with($resourceIdentifier)
-            ->willReturn($existingResource);
-
-        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
-
-        $this->assertInstanceOf(
-            RdfResource::class,
-            $guardResult,
-            'When item exists, guard() returns the resource for ImportService to decide overwrite'
-        );
-    }
-
-    /**
-     * Test: Guard returns false when item not found.
-     *
-     * When guard() returns false (item not found), ImportService::importQtiItem()
-     * creates a new item. If $itemMustExist is true, it returns an error instead.
-     */
-    public function testGuardReturnsFalseWhenItemNotFound(): void
-    {
-        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
-
-        /** @var MetadataImporter&MockObject $metadataImporterMock */
-        $metadataImporterMock = $this->createMock(MetadataImporter::class);
-
-        $metadataImporterMock->method('guard')
-            ->with($resourceIdentifier)
-            ->willReturn(false);
-
-        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
-
+        $metadataImporter->setMetadataValues([]);
         $this->assertFalse(
-            $guardResult,
-            'When item not found, guard() returns false for ImportService to create new item'
+            $metadataImporter->hasMetadataValue($identifier2),
+            'Empty setMetadataValues() should clear all metadata'
         );
+        $this->assertFalse($metadataImporter->guard($identifier2));
+    }
+
+    /**
+     * Creates an ImportService with injected MetadataImporter mock.
+     */
+    private function createImportServiceWithMetadataImporter(
+        MetadataImporter $metadataImporter
+    ): ImportService {
+        $lockMock = $this->createMock(LockInterface::class);
+        $lockMock->method('acquire')->willReturn(true);
+        $lockMock->method('release');
+
+        $importService = new class ($metadataImporter, $lockMock) extends ImportService {
+            private MetadataImporter $injectedMetadataImporter;
+            private LockInterface $injectedLock;
+
+            public function __construct(MetadataImporter $metadataImporter, LockInterface $lock)
+            {
+                $this->injectedMetadataImporter = $metadataImporter;
+                $this->injectedLock = $lock;
+            }
+
+            protected function getMetadataImporter(): MetadataImporter
+            {
+                return $this->injectedMetadataImporter;
+            }
+
+            public function createLock($resource, $ttl = 300.0, $autoRelease = true): LockInterface
+            {
+                return $this->injectedLock;
+            }
+        };
+
+        return $importService;
+    }
+
+    /**
+     * Creates a QTI Resource mock with the given identifier.
+     */
+    private function createQtiResourceMock(string $identifier): Resource
+    {
+        $resource = $this->createMock(Resource::class);
+        $resource->method('getIdentifier')->willReturn($identifier);
+        $resource->method('getFile')->willReturn('item.xml');
+        return $resource;
     }
 }

--- a/test/unit/model/qti/ImportServiceMetadataGuardTest.php
+++ b/test/unit/model/qti/ImportServiceMetadataGuardTest.php
@@ -30,14 +30,23 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for MetadataImporter interaction with setMetadataValues() and guard()
- * covering overwrite guard behavior in ImportService (lines 509-513).
+ * Unit tests for MetadataImporter guard behavior as used by ImportService.
  *
- * These tests verify:
- * - getMetadataImporter()->setMetadataValues() is called correctly
- * - guard($resourceIdentifier) behaves correctly based on metadata state
+ * These tests verify the contract between ImportService and MetadataImporter,
+ * specifically around the overwrite guard behavior in ImportService::importQtiItem()
+ * (lines 509-513).
  *
- * @see \oat\taoQtiItem\model\qti\ImportService::importQTIFile()
+ * The tests ensure:
+ * - setMetadataValues() correctly sets metadata state before guard() is called
+ * - guard() returns appropriate values based on metadata presence
+ * - Empty metadata prevents guard from reusing prior state
+ *
+ * Note: Full orchestration testing of ImportService::importQtiItem() with all
+ * its dependencies (file system, locks, QTI parsing, RDF creation) is covered
+ * by integration tests in taoQtiItem/test/integration/metadata/.
+ *
+ * @see \oat\taoQtiItem\model\qti\ImportService::importQtiItem()
+ * @see \oat\taoQtiItem\test\integration\metadata\LomIdentifierGuardianTest
  */
 class ImportServiceMetadataGuardTest extends TestCase
 {
@@ -46,14 +55,17 @@ class ImportServiceMetadataGuardTest extends TestCase
     private const RESOURCE_IDENTIFIER = 'item-resource-123';
 
     /**
-     * Test: When metadataValues is non-empty and overwrite is enabled, guard allows overwrite.
+     * Test: When metadataValues is non-empty and item exists, guard allows overwrite.
      *
-     * Scenario: ImportService calls getMetadataImporter()->setMetadataValues($metadataValues)
-     * followed by guard($resourceIdentifier). When metadata contains the identifier and
-     * an existing resource is found, guard() returns the resource (non-false), allowing
-     * ImportService to proceed with overwrite when $itemMustBeOverwritten is true.
+     * Verifies the MetadataImporter contract that ImportService relies on:
+     * 1. setMetadataValues($metadataValues) stores metadata keyed by identifier
+     * 2. guard($resourceIdentifier) returns the existing resource when found
      *
-     * @see \oat\taoQtiItem\model\qti\ImportService::importQTIFile() lines 509-513
+     * In ImportService::importQtiItem() (line 509-513), when:
+     * - $enableMetadataGuardians === true
+     * - $metadataValues contains the resource identifier
+     * - Guardian finds an existing item
+     * Then guard() returns the resource, allowing overwrite when $itemMustBeOverwritten
      */
     public function testGuardAllowsOverwriteWhenMetadataValuesNonEmptyAndItemExists(): void
     {
@@ -97,13 +109,13 @@ class ImportServiceMetadataGuardTest extends TestCase
     /**
      * Test: When metadataValues is empty, guard returns false (no prior state reused).
      *
-     * Scenario: ImportService calls getMetadataImporter()->setMetadataValues($emptyArray)
-     * followed by guard($resourceIdentifier). With empty metadata, guard() should return
-     * false because hasMetadataValue() will be false, preventing guardians from being
-     * called and ensuring no prior state from previous imports is accidentally reused.
+     * Verifies the MetadataImporter contract that ImportService relies on:
+     * 1. setMetadataValues([]) clears any prior metadata
+     * 2. guard($resourceIdentifier) returns false when no metadata exists
      *
-     * @see \oat\taoQtiItem\model\qti\ImportService::importQTIFile() lines 509-513
-     * @see \oat\taoQtiItem\model\qti\metadata\importer\MetadataImporter::guard()
+     * This is critical because ImportService reuses the same MetadataImporter
+     * instance across multiple items. Without setMetadataValues() clearing state,
+     * guard() could incorrectly match an item based on stale metadata.
      */
     public function testGuardReturnsFalseWhenMetadataValuesEmpty(): void
     {
@@ -132,12 +144,14 @@ class ImportServiceMetadataGuardTest extends TestCase
     }
 
     /**
-     * Integration test: Real MetadataImporter guard() returns false when metadata is empty.
+     * Integration test: Real MetadataImporter guard() returns false with empty metadata.
      *
-     * This test uses the actual MetadataImporter implementation to verify that:
-     * 1. setMetadataValues([]) clears any previous metadata state
+     * Uses actual MetadataImporter to verify:
+     * 1. setMetadataValues([]) clears metadata state
      * 2. hasMetadataValue() returns false for any identifier
-     * 3. guard() returns false without calling guardians
+     * 3. guard() returns false without invoking guardians
+     *
+     * This mirrors ImportService behavior when importing items without metadata.
      */
     public function testRealMetadataImporterGuardWithEmptyMetadata(): void
     {
@@ -160,11 +174,13 @@ class ImportServiceMetadataGuardTest extends TestCase
     }
 
     /**
-     * Integration test: Real MetadataImporter hasMetadataValue() returns true when metadata exists.
+     * Integration test: Real MetadataImporter hasMetadataValue() returns true when set.
      *
-     * This test uses the actual MetadataImporter implementation to verify that:
-     * 1. setMetadataValues() with non-empty metadata stores the values
-     * 2. hasMetadataValue() returns true for the identifier present in metadata
+     * Uses actual MetadataImporter to verify:
+     * 1. setMetadataValues() with non-empty metadata stores values correctly
+     * 2. hasMetadataValue() returns true for identifiers present in metadata
+     *
+     * This is a precondition for guard() to invoke guardians in ImportService.
      */
     public function testRealMetadataImporterHasMetadataValueWithNonEmptyMetadata(): void
     {
@@ -181,6 +197,94 @@ class ImportServiceMetadataGuardTest extends TestCase
         $this->assertTrue(
             $metadataImporter->hasMetadataValue($resourceIdentifier),
             'hasMetadataValue() should return true when metadataValues contains the identifier'
+        );
+    }
+
+    /**
+     * Test: setMetadataValues replaces previous state (no accumulation).
+     *
+     * Verifies that calling setMetadataValues() replaces (not merges) previous values.
+     * This is critical for ImportService which processes multiple items sequentially
+     * and needs each item to start with fresh metadata state.
+     */
+    public function testSetMetadataValuesReplacesExistingState(): void
+    {
+        $identifier1 = 'item-1';
+        $identifier2 = 'item-2';
+
+        $metadataImporter = new MetadataImporter();
+
+        $metadataImporter->setMetadataValues([
+            $identifier1 => [['path' => ['lom', 'id'], 'value' => 'value-1']]
+        ]);
+
+        $this->assertTrue($metadataImporter->hasMetadataValue($identifier1));
+        $this->assertFalse($metadataImporter->hasMetadataValue($identifier2));
+
+        $metadataImporter->setMetadataValues([
+            $identifier2 => [['path' => ['lom', 'id'], 'value' => 'value-2']]
+        ]);
+
+        $this->assertFalse(
+            $metadataImporter->hasMetadataValue($identifier1),
+            'Previous metadata should be replaced, not accumulated'
+        );
+        $this->assertTrue(
+            $metadataImporter->hasMetadataValue($identifier2),
+            'New metadata should be available'
+        );
+    }
+
+    /**
+     * Test: Guard behavior when item exists but overwrite is disabled.
+     *
+     * When guard() returns a resource (item found) but $itemMustBeOverwritten is false,
+     * ImportService::importQtiItem() returns an INFO report instead of proceeding.
+     * This test verifies the guard contract that enables this behavior.
+     */
+    public function testGuardReturnsResourceWhenItemExistsAllowingOverwriteDecision(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+        $existingResource = $this->createMock(RdfResource::class);
+
+        /** @var MetadataImporter&MockObject $metadataImporterMock */
+        $metadataImporterMock = $this->createMock(MetadataImporter::class);
+
+        $metadataImporterMock->method('guard')
+            ->with($resourceIdentifier)
+            ->willReturn($existingResource);
+
+        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
+
+        $this->assertInstanceOf(
+            RdfResource::class,
+            $guardResult,
+            'When item exists, guard() returns the resource for ImportService to decide overwrite'
+        );
+    }
+
+    /**
+     * Test: Guard returns false when item not found.
+     *
+     * When guard() returns false (item not found), ImportService::importQtiItem()
+     * creates a new item. If $itemMustExist is true, it returns an error instead.
+     */
+    public function testGuardReturnsFalseWhenItemNotFound(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+
+        /** @var MetadataImporter&MockObject $metadataImporterMock */
+        $metadataImporterMock = $this->createMock(MetadataImporter::class);
+
+        $metadataImporterMock->method('guard')
+            ->with($resourceIdentifier)
+            ->willReturn(false);
+
+        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
+
+        $this->assertFalse(
+            $guardResult,
+            'When item not found, guard() returns false for ImportService to create new item'
         );
     }
 }

--- a/test/unit/model/qti/ImportServiceMetadataGuardTest.php
+++ b/test/unit/model/qti/ImportServiceMetadataGuardTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti;
+
+use core_kernel_classes_Resource as RdfResource;
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\taoQtiItem\model\qti\metadata\importer\MetadataImporter;
+use oat\taoQtiItem\model\qti\metadata\MetadataService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for MetadataImporter interaction with setMetadataValues() and guard()
+ * covering overwrite guard behavior in ImportService (lines 509-513).
+ *
+ * These tests verify:
+ * - getMetadataImporter()->setMetadataValues() is called correctly
+ * - guard($resourceIdentifier) behaves correctly based on metadata state
+ *
+ * @see \oat\taoQtiItem\model\qti\ImportService::importQTIFile()
+ */
+class ImportServiceMetadataGuardTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    private const RESOURCE_IDENTIFIER = 'item-resource-123';
+
+    /**
+     * Test: When metadataValues is non-empty and overwrite is enabled, guard allows overwrite.
+     *
+     * Scenario: ImportService calls getMetadataImporter()->setMetadataValues($metadataValues)
+     * followed by guard($resourceIdentifier). When metadata contains the identifier and
+     * an existing resource is found, guard() returns the resource (non-false), allowing
+     * ImportService to proceed with overwrite when $itemMustBeOverwritten is true.
+     *
+     * @see \oat\taoQtiItem\model\qti\ImportService::importQTIFile() lines 509-513
+     */
+    public function testGuardAllowsOverwriteWhenMetadataValuesNonEmptyAndItemExists(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+        $existingResource = $this->createMock(RdfResource::class);
+        $metadataValues = [
+            $resourceIdentifier => [
+                ['path' => ['lom', 'identifier'], 'value' => 'unique-id-123']
+            ]
+        ];
+
+        /** @var MetadataImporter&MockObject $metadataImporterMock */
+        $metadataImporterMock = $this->createMock(MetadataImporter::class);
+
+        $metadataImporterMock->expects($this->once())
+            ->method('setMetadataValues')
+            ->with($metadataValues);
+
+        $metadataImporterMock->expects($this->once())
+            ->method('guard')
+            ->with($resourceIdentifier)
+            ->willReturn($existingResource);
+
+        $metadataServiceMock = $this->createMock(MetadataService::class);
+        $metadataServiceMock->method('getImporter')->willReturn($metadataImporterMock);
+
+        $metadataImporterMock->setMetadataValues($metadataValues);
+        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
+
+        $this->assertNotFalse(
+            $guardResult,
+            'guard() should return a non-false value (existing resource) when metadata is present'
+        );
+        $this->assertSame(
+            $existingResource,
+            $guardResult,
+            'guard() should return the existing resource when item is found by guardians'
+        );
+    }
+
+    /**
+     * Test: When metadataValues is empty, guard returns false (no prior state reused).
+     *
+     * Scenario: ImportService calls getMetadataImporter()->setMetadataValues($emptyArray)
+     * followed by guard($resourceIdentifier). With empty metadata, guard() should return
+     * false because hasMetadataValue() will be false, preventing guardians from being
+     * called and ensuring no prior state from previous imports is accidentally reused.
+     *
+     * @see \oat\taoQtiItem\model\qti\ImportService::importQTIFile() lines 509-513
+     * @see \oat\taoQtiItem\model\qti\metadata\importer\MetadataImporter::guard()
+     */
+    public function testGuardReturnsFalseWhenMetadataValuesEmpty(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+        $emptyMetadataValues = [];
+
+        /** @var MetadataImporter&MockObject $metadataImporterMock */
+        $metadataImporterMock = $this->createMock(MetadataImporter::class);
+
+        $metadataImporterMock->expects($this->once())
+            ->method('setMetadataValues')
+            ->with($emptyMetadataValues);
+
+        $metadataImporterMock->expects($this->once())
+            ->method('guard')
+            ->with($resourceIdentifier)
+            ->willReturn(false);
+
+        $metadataImporterMock->setMetadataValues($emptyMetadataValues);
+        $guardResult = $metadataImporterMock->guard($resourceIdentifier);
+
+        $this->assertFalse(
+            $guardResult,
+            'guard() should return false when metadataValues is empty (no prior state reused)'
+        );
+    }
+
+    /**
+     * Integration test: Real MetadataImporter guard() returns false when metadata is empty.
+     *
+     * This test uses the actual MetadataImporter implementation to verify that:
+     * 1. setMetadataValues([]) clears any previous metadata state
+     * 2. hasMetadataValue() returns false for any identifier
+     * 3. guard() returns false without calling guardians
+     */
+    public function testRealMetadataImporterGuardWithEmptyMetadata(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+
+        $metadataImporter = new MetadataImporter();
+        $metadataImporter->setMetadataValues([]);
+
+        $this->assertFalse(
+            $metadataImporter->hasMetadataValue($resourceIdentifier),
+            'hasMetadataValue() should return false when metadataValues is empty'
+        );
+
+        $guardResult = $metadataImporter->guard($resourceIdentifier);
+
+        $this->assertFalse(
+            $guardResult,
+            'guard() should return false when hasMetadataValue() is false'
+        );
+    }
+
+    /**
+     * Integration test: Real MetadataImporter hasMetadataValue() returns true when metadata exists.
+     *
+     * This test uses the actual MetadataImporter implementation to verify that:
+     * 1. setMetadataValues() with non-empty metadata stores the values
+     * 2. hasMetadataValue() returns true for the identifier present in metadata
+     */
+    public function testRealMetadataImporterHasMetadataValueWithNonEmptyMetadata(): void
+    {
+        $resourceIdentifier = self::RESOURCE_IDENTIFIER;
+        $metadataValues = [
+            $resourceIdentifier => [
+                ['path' => ['lom', 'identifier'], 'value' => 'unique-id-123']
+            ]
+        ];
+
+        $metadataImporter = new MetadataImporter();
+        $metadataImporter->setMetadataValues($metadataValues);
+
+        $this->assertTrue(
+            $metadataImporter->hasMetadataValue($resourceIdentifier),
+            'hasMetadataValue() should return true when metadataValues contains the identifier'
+        );
+    }
+}

--- a/test/unit/model/qti/ImportServiceMetadataGuardTest.php
+++ b/test/unit/model/qti/ImportServiceMetadataGuardTest.php
@@ -302,12 +302,14 @@ class ImportServiceMetadataGuardTest extends TestCase
                 false,
                 $overwrittenItems
             );
+        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
+            throw $e;
         } catch (\Throwable $e) {
             // Expected - method will fail later due to missing file, but guard methods weren't called
         }
 
-        // Assertions are in the mock expectations (expects never)
-        $this->assertTrue(true);
+        // Mock expectations (expects never) are verified by PHPUnit after test completes
+        $this->addToAssertionCount(1);
     }
 
     /**


### PR DESCRIPTION
## Ticket:

https://oat-sa.atlassian.net/browse/AUT-4551

## What's Changed
- Fix rewriting items with `itemMustBeOverwritten` parameter

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful


For using itemMustBeOverwritten you need to setup guardians here `config/taoQtiItem/metadataService.conf.php`
``` 
'guardians' => array(
            'oat\\taoQtiItem\\model\\qti\\metadata\\guardians\\ItemMetadataGuardian'
        ),
```

after that in the config of this guardian you need to setup mapping:
`config/taoQtiItem/ItemMetadataGuardian.conf.php`

```
<?php
/**
 * Default config header created during install
 */

return new oat\taoQtiItem\model\qti\metadata\guardians\ItemMetadataGuardian(array(
    'expectedPath' => array(
        'http://ltsc.ieee.org/xsd/LOM#lom',
        'http://www.w3.org/2000/01/rdf-schema#label',
    ),
    'propertyUri' => 'http://www.w3.org/2000/01/rdf-schema#label'
));

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QTI imports now apply metadata values before metadata checks when guardians are enabled, and metadata storage arrays are initialized by default—reducing incorrect overwrite/duplicate decisions.

* **Tests**
  * Added unit tests covering metadata application, guard call-ordering, disabled-guardian behavior, and real importer state management to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->