### PR TITLE
fix: AUT-4172 restore other constraints zero-value behavior

### DIFF
--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -421,7 +421,7 @@ define([
                             _.isNumber(maxValue) && this.isFieldEnabled('min') && this.setMinValue(maxValue);
                         }
                         if (fromField === fields.min && minValue > maxValue) {
-                            _.isNumber(maxValue) && this.isFieldEnabled('min') && this.setMaxValue(minValue);
+                            _.isNumber(maxValue) && this.isFieldEnabled('max') && this.setMaxValue(minValue);
                         }
                     }
                     if (
@@ -445,6 +445,10 @@ define([
                  */
                 convertToNumber: function convertToNumber(fromField) {
                     if (isFieldSupported(fromField) && this.is('rendered')) {
+                        if (!this.isFieldEnabled(fromField)) {
+                            return this;
+                        }
+
                         if (fromField === fields.max) {
                             this.setMaxValue(this.parseNumber(this.getMaxValue()));
                         } else {

--- a/views/js/qtiCreator/widgets/helpers/formElement.js
+++ b/views/js/qtiCreator/widgets/helpers/formElement.js
@@ -300,6 +300,10 @@ define([
             };
 
             callbacks[attributeNameMax] = function (element, value, name) {
+                if (this && (this.disabled || $(this).hasClass('disabled'))) {
+                    value = 0;
+                }
+
                 value = options.floatVal ? parseFloat(value) : parseInt(value, 10) || 0;
 
                 if (element.is('interaction')) {

--- a/views/js/test/qtiCreator/widgets/component/minMax/test.js
+++ b/views/js/test/qtiCreator/widgets/component/minMax/test.js
@@ -280,6 +280,76 @@ define(['taoQtiItem/qtiCreator/widgets/component/minMax/minMax'], function(minMa
         });
     });
 
+    QUnit.test('disable max keeps zero when lower threshold is higher', function(assert) {
+        var ready = assert.async();
+        var container = document.getElementById('qunit-fixture');
+
+        assert.expect(4);
+
+        minMaxComponentFactory(container, {
+            min: {
+                fieldName: 'min',
+                value: 2,
+                toggler: true,
+                lowerThreshold: 1
+            },
+            max: {
+                fieldName: 'max',
+                value: 2,
+                toggler: true,
+                lowerThreshold: 2
+            },
+            upperThreshold: 5
+        })
+        .on('render', function() {
+            var element = this.getElement()[0];
+            var maxInput = element.querySelector('[name=max]');
+
+            this.disableField('max');
+
+            setTimeout(function() {
+                assert.ok(!this.isFieldEnabled('max'), 'max is disabled');
+                assert.equal(this.getMaxValue(), 0, 'max value remains at 0 after disabling');
+                assert.equal(maxInput.value, 0, 'max input remains at 0 after disabling');
+                assert.ok(maxInput.classList.contains('disabled'), 'max input stays disabled');
+                ready();
+            }.bind(this), 0);
+        });
+    });
+
+    QUnit.test('sync does not re-enable disabled max', function(assert) {
+        var ready = assert.async();
+        var container = document.getElementById('qunit-fixture');
+
+        assert.expect(2);
+
+        minMaxComponentFactory(container, {
+            min: {
+                fieldName: 'min',
+                value: 1,
+                toggler: true,
+                lowerThreshold: 1
+            },
+            max: {
+                fieldName: 'max',
+                value: 2,
+                toggler: true,
+                lowerThreshold: 2
+            },
+            upperThreshold: 5
+        })
+        .on('render', function() {
+            this.disableField('max');
+            this.updateThresholds(2, 4, 'min');
+
+            setTimeout(function() {
+                assert.equal(this.getMaxValue(), 0, 'max stays at 0 when min threshold changes');
+                assert.ok(!this.isFieldEnabled('max'), 'max remains disabled');
+                ready();
+            }.bind(this), 0);
+        });
+    });
+
     QUnit.test('change values, upper bound', function(assert) {
         var ready = assert.async();
         var container = document.getElementById('qunit-fixture');

--- a/views/js/test/qtiCreator/widgets/helpers/formElement/test.js
+++ b/views/js/test/qtiCreator/widgets/helpers/formElement/test.js
@@ -374,6 +374,39 @@ define([
         callbacks.maxChoices(element, 0, 'maxChoices');
     });
 
+    QUnit.test('max attribute with choiceInteraction uses zero when input is disabled', function (assert) {
+        assert.expect(2);
+        const callbacks = formElement.getMinMaxAttributeCallbacks('minChoices', 'maxChoices');
+
+        const element = elementFactory('choiceInteraction');
+        element.removeAttr = function () {
+            throw new Error('Attribute should not be removed');
+        };
+        element.attr = function (actualName, actualValue) {
+            assert.ok(actualName === 'maxChoices', 'Correct name should be used in set attribute callback');
+            assert.ok(actualValue === 0, 'Disabled input should force maxChoices to 0');
+        };
+
+        callbacks.maxChoices.call({ disabled: true }, element, 2, 'maxChoices');
+    });
+
+    QUnit.test('max attribute with choiceInteraction uses zero when input has disabled class', function (assert) {
+        assert.expect(2);
+        const callbacks = formElement.getMinMaxAttributeCallbacks('minChoices', 'maxChoices');
+
+        const element = elementFactory('choiceInteraction');
+        element.removeAttr = function () {
+            throw new Error('Attribute should not be removed');
+        };
+        element.attr = function (actualName, actualValue) {
+            assert.ok(actualName === 'maxChoices', 'Correct name should be used in set attribute callback');
+            assert.ok(actualValue === 0, 'Disabled class should force maxChoices to 0');
+        };
+
+        const disabledInput = $('<input class="disabled" />')[0];
+        callbacks.maxChoices.call(disabledInput, element, 2, 'maxChoices');
+    });
+
 
     QUnit.module('getLowerUpperAttributeCallbacks');
 


### PR DESCRIPTION
## Summary
- Branch created from commit `a3d49bb7b` to validate AUT-4172 behavior aligned with the original ticket expectations.
- Keeps disabled min/max constraints represented and displayed as `0` in Other constraints.
- Opened as Draft for BA confirmation before final implementation direction.

## Validation Scope
- Case 1: when `maxChoices` is disabled, UI displays `0`.
- Case 2: `minChoices` and `maxChoices` cannot both be disabled.
- Case 3: disabling `maxChoices` is preserved on save (no revert to previous value).

https://github.com/user-attachments/assets/242dbbca-6d8f-4dab-9eb7-e1e93a30b59e


## Context
This Draft PR is intended as a comparison branch for product/BA validation against the newer "attribute absent" approach discussed in AUT-4172.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed min/max field synchronization to correctly validate constraints when values conflict
  * Improved disabled field handling to prevent unintended value updates when min/max fields are disabled

* **Tests**
  * Added test coverage for min/max field disable and synchronization behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->