### PR TITLE
fix: disable ctrl + l for inline choice

### DIFF
--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -86,7 +86,7 @@ define([
                     key: function (evt) {
                         const domEvent = evt.data.domEvent.$;
                         const isCtrlPressed = domEvent.ctrlKey || domEvent.metaKey;
-                        const key = domEvent.key;
+                        const key = (domEvent.key || '').toLowerCase();
 
                         const blockedKeys = ['b', 'i', 'u', 'k', 'l'];
                         if (isCtrlPressed && blockedKeys.includes(key)) {

--- a/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
+++ b/views/js/qtiCreator/widgets/choices/inlineChoice/states/Question.js
@@ -88,7 +88,7 @@ define([
                         const isCtrlPressed = domEvent.ctrlKey || domEvent.metaKey;
                         const key = domEvent.key;
 
-                        const blockedKeys = ['b', 'i', 'u', 'k'];
+                        const blockedKeys = ['b', 'i', 'u', 'k', 'l'];
                         if (isCtrlPressed && blockedKeys.includes(key)) {
                             evt.cancel();
                             domEvent.preventDefault();

--- a/views/js/test/qtiCreator/widgets/choices/inlineChoice/states/Question/test.html
+++ b/views/js/test/qtiCreator/widgets/choices/inlineChoice/states/Question/test.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Inline choice question state</title>
+        <link rel="stylesheet" type="text/css" href="/tao/views/js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="/tao/views/js/lib/require.js"></script>
+        <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="/tao/views/js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking"
+                data-cover-only="/qtiCreator/widgets/choices/inlineChoice/states/Question.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+            require(['/tao/ClientConfig/config'], function () {
+                require(['taoQtiItem/test/qtiCreator/widgets/choices/inlineChoice/states/Question/test'], function () {
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+    </body>
+</html>

--- a/views/js/test/qtiCreator/widgets/choices/inlineChoice/states/Question/test.js
+++ b/views/js/test/qtiCreator/widgets/choices/inlineChoice/states/Question/test.js
@@ -1,0 +1,144 @@
+define([
+    'jquery',
+    'taoQtiItem/qtiCreator/widgets/choices/inlineChoice/states/Question',
+    'taoQtiItem/qtiCreator/editor/ckEditor/htmlEditor'
+], function ($, InlineChoiceQuestionState, htmlEditor) {
+    'use strict';
+
+    QUnit.module('qtiCreator/widgets/choices/inlineChoice/states/Question', function (hooks) {
+        let originalHasEditor;
+        let originalBuildEditor;
+
+        hooks.beforeEach(function () {
+            originalHasEditor = htmlEditor.hasEditor;
+            originalBuildEditor = htmlEditor.buildEditor;
+        });
+
+        hooks.afterEach(function () {
+            htmlEditor.hasEditor = originalHasEditor;
+            htmlEditor.buildEditor = originalBuildEditor;
+        });
+
+        function getKeyHandler(assert) {
+            const $container = $(
+                '<div>' +
+                    '<div class="editable-container">' +
+                        '<div class="editable-content"></div>' +
+                    '</div>' +
+                '</div>'
+            );
+            const widget = {
+                element: {
+                    getBody: function () {
+                        return {};
+                    }
+                },
+                $container: $container,
+                changeState: function () {}
+            };
+            let keyHandler;
+
+            htmlEditor.hasEditor = function () {
+                return false;
+            };
+            htmlEditor.buildEditor = function ($editableContainer, options) {
+                assert.strictEqual($editableContainer[0], $container.find('.editable-container')[0], 'editor is built on the editable container');
+                keyHandler = options.on.key;
+            };
+
+            InlineChoiceQuestionState.prototype.buildEditor.call({
+                widget: widget
+            });
+
+            assert.strictEqual(typeof keyHandler, 'function', 'keyboard handler is registered');
+
+            return keyHandler;
+        }
+
+        function createEditorEvent(key, modifier) {
+            let preventDefaultCalls = 0;
+            let cancelCalls = 0;
+            const domEvent = {
+                key: key,
+                ctrlKey: modifier === 'ctrl',
+                metaKey: modifier === 'meta',
+                preventDefault: function () {
+                    preventDefaultCalls++;
+                }
+            };
+
+            return {
+                event: {
+                    data: {
+                        domEvent: {
+                            $: domEvent
+                        }
+                    },
+                    cancel: function () {
+                        cancelCalls++;
+                    }
+                },
+                getPreventDefaultCalls: function () {
+                    return preventDefaultCalls;
+                },
+                getCancelCalls: function () {
+                    return cancelCalls;
+                }
+            };
+        }
+
+        QUnit.test('blocked Ctrl and Meta shortcuts prevent the default action', function (assert) {
+            const keyHandler = getKeyHandler(assert);
+            const blockedShortcuts = [
+                { key: 'b', modifier: 'ctrl', label: 'Ctrl+B' },
+                { key: 'i', modifier: 'ctrl', label: 'Ctrl+I' },
+                { key: 'u', modifier: 'ctrl', label: 'Ctrl+U' },
+                { key: 'k', modifier: 'ctrl', label: 'Ctrl+K' },
+                { key: 'l', modifier: 'ctrl', label: 'Ctrl+L' },
+                { key: 'L', modifier: 'ctrl', label: 'Ctrl+Shift+L' },
+                { key: 'l', modifier: 'meta', label: 'Meta+L' },
+                { key: 'L', modifier: 'meta', label: 'Meta+Shift+L' }
+            ];
+
+            assert.expect(19);
+
+            blockedShortcuts.forEach(function (shortcut) {
+                const editorEvent = createEditorEvent(shortcut.key, shortcut.modifier);
+
+                keyHandler(editorEvent.event);
+
+                assert.strictEqual(editorEvent.getPreventDefaultCalls(), 1, shortcut.label + ' calls preventDefault');
+                assert.strictEqual(editorEvent.getCancelCalls(), 1, shortcut.label + ' cancels the editor event');
+            });
+
+            const nonBlockedShortcut = createEditorEvent('p', 'ctrl');
+            keyHandler(nonBlockedShortcut.event);
+            assert.strictEqual(nonBlockedShortcut.getPreventDefaultCalls(), 0, 'Ctrl+P does not call preventDefault');
+        });
+
+        QUnit.test('non-blocked shortcuts do not prevent default', function (assert) {
+            const keyHandler = getKeyHandler(assert);
+            const shortcuts = [
+                { key: 'p', modifier: 'ctrl', label: 'Ctrl+P' },
+                { key: 'z', modifier: 'meta', label: 'Meta+Z' },
+                { key: '1', modifier: 'ctrl', label: 'Ctrl+1' },
+                { key: 'Escape', modifier: 'meta', label: 'Meta+Escape' }
+            ];
+
+            assert.expect(11);
+
+            shortcuts.forEach(function (shortcut) {
+                const editorEvent = createEditorEvent(shortcut.key, shortcut.modifier);
+
+                keyHandler(editorEvent.event);
+
+                assert.strictEqual(editorEvent.getPreventDefaultCalls(), 0, shortcut.label + ' does not call preventDefault');
+                assert.strictEqual(editorEvent.getCancelCalls(), 0, shortcut.label + ' does not cancel the editor event');
+            });
+
+            const blockedShortcut = createEditorEvent('l', 'ctrl');
+            keyHandler(blockedShortcut.event);
+            assert.strictEqual(blockedShortcut.getPreventDefaultCalls(), 1, 'Ctrl+L still calls preventDefault');
+        });
+    });
+});


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INF-485

## What's Changed
- Disable Ctrl+L shortcut for inline choice



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in the rich-text editor: key input is normalized before comparison and Ctrl/Meta+L is now correctly blocked like other editor shortcuts.

* **Tests**
  * Added automated tests and a test harness validating blocked and non-blocked keyboard shortcuts and the editor's prevention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->