### PR TITLE
fix: trim boundary spaces in ruby annotations (INF-466)

### DIFF
--- a/views/js/qtiXmlRenderer/renderers/Container.js
+++ b/views/js/qtiXmlRenderer/renderers/Container.js
@@ -138,6 +138,7 @@ define([
             if (!config.skipReplaceNonBreakingSpaceCharacters) {
                 returnValue = replaceNonBreakingSpaceCharacters(returnValue);
             }
+            returnValue = trimRtBoundarySpaces(returnValue);
             returnValue = mergeSiblings(returnValue);
         }
 
@@ -175,6 +176,30 @@ define([
         }
         html = html.replace(/(&#160;)/g, ' ');
         return html.replace(/(&nbsp;)/g, ' ');
+    }
+
+    /**
+     * Trims boundary spaces in non-empty ruby annotation tags.
+     * Empty placeholders are kept unchanged.
+     * @param {string} html
+     * @returns {string}
+     */
+    function trimRtBoundarySpaces(html) {
+        if (typeof html !== 'string' || html.length <= 0) {
+            return html;
+        }
+
+        return html.replace(/(<(?:qh5:)?rt(?:\s+[^>]*)?>)([\s\S]*?)(<\/(?:qh5:)?rt>)/gi, function ($0, openTag, content, closeTag) {
+            if (/^(?:[\s\u00A0\u200B\uFEFF\u3000]|&nbsp;|&#160;)*$/i.test(content)) {
+                return $0;
+            }
+
+            const normalizedContent = content
+                .replace(/(&nbsp;|&#160;)/gi, ' ')
+                .replace(/^[\s\u00A0\u200B\uFEFF\u3000]+|[\s\u00A0\u200B\uFEFF\u3000]+$/g, '');
+
+            return `${openTag}${normalizedContent}${closeTag}`;
+        });
     }
 
     /**


### PR DESCRIPTION
# fix: trim boundary spaces in ruby annotations (INF-466)

## Summary

- Fixes exported QTI content where furigana annotation text (`rt`) can keep unwanted leading/trailing spaces.
- Adds ruby-specific serialization normalization in `taoQtiItem` to trim only boundary whitespace for non-empty `rt` tags.
- Preserves existing placeholder behavior for empty `rt` tags (no behavior change for intentionally empty placeholders).

## Root Cause

- The ruby editing flow can produce annotation values with boundary spaces (for example, `<rt> qwe </rt>`).
- During serialization, those boundary spaces were not normalized for non-empty `rt` values and were exported as-is.

## Scope

- Extension: `extension-tao-itemqti` (`taoQtiItem`)
- File changed:
  - `views/js/qtiXmlRenderer/renderers/Container.js`

## Technical Details

- Added `trimRtBoundarySpaces(html)` in container serializer pipeline.
- Applied after non-breaking-space replacement step and before sibling merge.
- Rules:
  - Non-empty `rt`: trim boundary whitespace (`U+0020`, `U+00A0`, zero-width, ideographic boundary spaces).
  - Empty/placeholder `rt` (whitespace-only / `&nbsp;` / `&#160;`): keep unchanged.

## Expected Result

- `<rt> qwe </rt>` -> `<rt>qwe</rt>`
- `<rt>  q w e  </rt>` -> `<rt>q w e</rt>`
- `<rt></rt>`, `<rt> </rt>`, `<rt>&nbsp;</rt>` remain unchanged placeholder-wise.

## Testing

Manual validation in item authoring/export flow:

1. Add ruby/furigana to selected text.
2. Save and export QTI.
3. Verify `rt` does not contain unintended boundary spaces for non-empty values.
4. Verify empty placeholder behavior for `rt` remains unchanged.

## Related

- Jira: INF-466
- Dependent ticket: INF-283


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved ruby text rendering by trimming excess whitespace around ruby annotation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->