### PR TITLE
fix: align item-new tree action weight with runtime order

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -5,7 +5,7 @@
         <sections>
             <section id="manage_items" name="Manage items" url="/taoItems/Items/index">
                 <actions>
-                    <action id="item-new" name="New item" url="/taoQtiItem/QtiCreator/createItem" context="resource" group="tree" binding="instanciate" weight="1">
+                    <action id="item-new" name="New item" url="/taoQtiItem/QtiCreator/createItem" context="resource" group="tree" binding="instanciate" weight="15">
                         <icon id="icon-item"/>
                     </action>
                 </actions>

--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -341,6 +341,9 @@ define([
                             valueToSet = initialValue > 1 ? initialValue : 1;
                         }
 
+                        // Keep config in sync before input 'change' so convertToNumber and isFieldEnabled see enabled state
+                        config[field].value = valueToSet;
+
                         controls[field].input
                             .val(valueToSet)
                             .incrementer('enable')


### PR DESCRIPTION
## Summary
- increase `item-new` tree action weight so Quick Wins sorting preserves the expected runtime order in Items
- keep explicit ordering deterministic with Access control and New item at the end of the tree action list

## Validation
- cleared cache with `rm -Rf data/generis/cache/*`
- verified browser order in `manage_items` with an instance selected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix for enabling form fields so their internal state updates before the UI change, ensuring change handlers and related behaviors react reliably.

* **Chores**
  * Adjusted priority ordering for the item creation action in the management interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/extension-tao-itemqti/pull/3000)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->