### PR TITLE
Fix/aut 4551/rewrite items api fix 2

### DIFF
--- a/controller/AbstractRestQti.php
+++ b/controller/AbstractRestQti.php
@@ -60,6 +60,8 @@ abstract class AbstractRestQti extends tao_actions_RestController
 
     public const ITEM_MUST_BE_OVERWRITTEN = 'itemMustBeOverwritten';
 
+    public const OVERWRITE_ITEM_BY_LABEL_IN_TARGET_CLASS = 'overwriteByLabelInTargetClass';
+
     protected static $accepted_types = [
         'application/zip',
         'application/x-zip-compressed',
@@ -194,6 +196,23 @@ abstract class AbstractRestQti extends tao_actions_RestController
         }
 
         return filter_var($isItemMustBeOverwrittenEnabled, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    protected function isOverwriteByLabelInTargetClassEnabled(): bool
+    {
+        $overwriteByLabelInTargetClass = $this->getQueryParams(self::OVERWRITE_ITEM_BY_LABEL_IN_TARGET_CLASS);
+
+        if (is_null($overwriteByLabelInTargetClass)) {
+            return false;
+        }
+
+        if (!in_array($overwriteByLabelInTargetClass, ['true', 'false'], true)) {
+            throw new BadRequestException(
+                self::OVERWRITE_ITEM_BY_LABEL_IN_TARGET_CLASS . ' parameter should be boolean (true or false).'
+            );
+        }
+
+        return filter_var($overwriteByLabelInTargetClass, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/controller/RestQtiItem.php
+++ b/controller/RestQtiItem.php
@@ -118,7 +118,8 @@ class RestQtiItem extends AbstractRestQti
                 $this->isMetadataValidatorsEnabled(),
                 $this->isItemMustExistEnabled(),
                 $this->isItemMustBeOverwrittenEnabled(),
-                $this->isMetadataRequired()
+                $this->isMetadataRequired(),
+                $this->isOverwriteByLabelInTargetClassEnabled()
             );
             helpers_TimeOutHelper::reset();
 
@@ -181,7 +182,8 @@ class RestQtiItem extends AbstractRestQti
                 $this->isMetadataValidatorsEnabled(),
                 $this->isItemMustExistEnabled(),
                 $this->isItemMustBeOverwrittenEnabled(),
-                $this->isMetadataRequired()
+                $this->isMetadataRequired(),
+                $this->isOverwriteByLabelInTargetClassEnabled()
             );
 
             $result = [

--- a/doc/rest.json
+++ b/doc/rest.json
@@ -136,6 +136,13 @@
                         "required": false
                     },
                     {
+                        "name": "overwriteByLabelInTargetClass",
+                        "in": "formData",
+                        "description": "When true together with itemMustBeOverwritten, finds an existing item by label in the target class (class-uri or class-label) and overwrites it. Metadata guardians are not used for this lookup. Default value is false.",
+                        "type": "boolean",
+                        "required": false
+                    },
+                    {
                         "name": "metadataRequired",
                         "in": "formData",
                         "description": "Boolean flag that indicates whether metadata is required for the import. Default value is false.",
@@ -273,6 +280,13 @@
                         "name": "itemMustBeOverwritten",
                         "in": "formData",
                         "description": "Boolean flag that indicates whether items found by guardians should be overwritten. Default value is false.",
+                        "type": "boolean",
+                        "required": false
+                    },
+                    {
+                        "name": "overwriteByLabelInTargetClass",
+                        "in": "formData",
+                        "description": "When true together with itemMustBeOverwritten, finds an existing item by label in the target class (class-uri or class-label) and overwrites it. Metadata guardians are not used for this lookup. Default value is false.",
                         "type": "boolean",
                         "required": false
                     },

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -995,8 +995,7 @@ class ImportService extends ConfigurableService
         $itemClassUri = $itemClass->getUri();
         $matches = [];
         foreach ($instances as $instance) {
-            $resourceClass = $instance->getClass();
-            if ($resourceClass !== null && $resourceClass->getUri() === $itemClassUri) {
+            if ($instance->getParentClassId() === $itemClassUri) {
                 $matches[] = $instance;
             }
         }

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -537,7 +537,8 @@ class ImportService extends ConfigurableService
                             $qtiModel,
                             $importMetadataEnabled,
                             $resourceIdentifier,
-                            $metadataValues
+                            $metadataValues,
+                            $metaMedataValues
                         )
                     );
 
@@ -961,19 +962,24 @@ class ImportService extends ConfigurableService
     /**
      * @param \qtism\data\AssessmentItem $qtiModel
      * @param array<string, array> $metadataValues
+     * @param array<string, \core_kernel_classes_Property> $mappedItemProperties
      */
     private function extractItemLabel(
         $qtiModel,
         bool $importMetadataEnabled = false,
         string $resourceIdentifier = '',
-        array $metadataValues = []
+        array $metadataValues = [],
+        array $mappedItemProperties = []
     ): string {
         if (
             $importMetadataEnabled
             && $resourceIdentifier !== ''
             && isset($metadataValues[$resourceIdentifier])
         ) {
-            $labelFromMetadata = $this->extractItemLabelFromMetadata($metadataValues[$resourceIdentifier]);
+            $labelFromMetadata = $this->extractItemLabelFromMetadata(
+                $metadataValues[$resourceIdentifier],
+                $mappedItemProperties
+            );
             if ($labelFromMetadata !== '') {
                 return $labelFromMetadata;
             }
@@ -992,23 +998,39 @@ class ImportService extends ConfigurableService
     }
 
     /**
+     * Resolves the item label from manifest metadata using the same path matching as MappedMetadataInjector.
+     *
      * @param MetadataValue[] $metadataValuesForResource
+     * @param array<string, \core_kernel_classes_Property> $mappedItemProperties
      */
-    private function extractItemLabelFromMetadata(array $metadataValuesForResource): string
-    {
+    private function extractItemLabelFromMetadata(
+        array $metadataValuesForResource,
+        array $mappedItemProperties = []
+    ): string {
         foreach ($metadataValuesForResource as $metadataValue) {
             if (!$metadataValue instanceof MetadataValue) {
                 continue;
             }
 
-            $path = $metadataValue->getPath();
-            if (!isset($path[1]) || $path[1] !== OntologyRdfs::RDFS_LABEL) {
+            $value = trim((string) $metadataValue->getValue());
+            if ($value === '') {
                 continue;
             }
 
-            $value = trim((string) $metadataValue->getValue());
-            if ($value !== '') {
-                return $value;
+            foreach ($metadataValue->getPath() as $mappedPath) {
+                if (!empty($mappedItemProperties)) {
+                    if (
+                        isset($mappedItemProperties[$mappedPath])
+                        && $mappedItemProperties[$mappedPath]->getUri() === OntologyRdfs::RDFS_LABEL
+                    ) {
+                        return $value;
+                    }
+                    continue;
+                }
+
+                if ($mappedPath === OntologyRdfs::RDFS_LABEL) {
+                    return $value;
+                }
             }
         }
 

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -1006,7 +1006,8 @@ class ImportService extends ConfigurableService
 
         if (count($matches) > 1) {
             \common_Logger::i(sprintf(
-                'Multiple items with label "%s" found in class "%s". The most recently created item will be overwritten.',
+                'Multiple items with label "%s" found in class "%s". '
+                . 'The most recently created item will be overwritten.',
                 $label,
                 $itemClass->getLabel()
             ));

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -518,11 +518,22 @@ class ImportService extends ConfigurableService
                 $overwriteByLabelInTargetClassEnabled = $itemMustBeOverwritten === true
                     && $overwriteByLabelInTargetClass === true;
 
+                if (
+                    $overwriteByLabelInTargetClassEnabled
+                    || $enableMetadataGuardians === true
+                    || $enableMetadataValidators === true
+                ) {
+                    $this->getMetadataImporter()->setMetadataValues($metadataValues);
+                }
+
                 if ($overwriteByLabelInTargetClassEnabled) {
                     $tmpQtiFile = $tmpFolder . helpers_File::urlToPath($qtiItemResource->getFile());
                     $this->convertToQti2($tmpQtiFile);
                     $qtiModel = $this->createQtiItemModel($tmpQtiFile);
-                    $guardian = $this->findItemByLabelInClass($itemClass, $this->extractItemLabel($qtiModel));
+                    $guardian = $this->findItemByLabelInClass(
+                        $itemClass,
+                        $this->extractItemLabel($qtiModel)
+                    );
 
                     if ($guardian !== false) {
                         \common_Logger::i(
@@ -532,7 +543,6 @@ class ImportService extends ConfigurableService
                         $overWriting = true;
                     }
                 } elseif ($enableMetadataGuardians === true) {
-                    $this->getMetadataImporter()->setMetadataValues($metadataValues);
                     $guardian = $this->getMetadataImporter()->guard($resourceIdentifier);
                     if ($guardian !== false) {
                         // Item found by guardians.
@@ -970,14 +980,40 @@ class ImportService extends ConfigurableService
 
         $instances = $itemClass->searchInstances(
             [OntologyRdfs::RDFS_LABEL => $label],
-            ['like' => false, 'recursive' => true]
+            [
+                'like' => false,
+                'recursive' => false,
+                'order' => TaoOntology::PROPERTY_UPDATED_AT,
+                'orderdir' => 'DESC',
+            ]
         );
 
         if (empty($instances)) {
             return false;
         }
 
-        return reset($instances);
+        $itemClassUri = $itemClass->getUri();
+        $matches = [];
+        foreach ($instances as $instance) {
+            $resourceClass = $instance->getClass();
+            if ($resourceClass !== null && $resourceClass->getUri() === $itemClassUri) {
+                $matches[] = $instance;
+            }
+        }
+
+        if (empty($matches)) {
+            return false;
+        }
+
+        if (count($matches) > 1) {
+            \common_Logger::i(sprintf(
+                'Multiple items with label "%s" found in class "%s". The most recently created item will be overwritten.',
+                $label,
+                $itemClass->getLabel()
+            ));
+        }
+
+        return reset($matches);
     }
 
     /**

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -52,6 +52,7 @@ use oat\taoQtiItem\model\qti\exception\TemplateException;
 use oat\taoQtiItem\model\qti\metadata\importer\MetadataImporter;
 use oat\taoQtiItem\model\qti\metadata\importer\MetaMetadataImportMapper;
 use oat\taoQtiItem\model\qti\metadata\imsManifest\MetaMetadataExtractor;
+use oat\generis\model\OntologyRdfs;
 use oat\taoQtiItem\model\qti\metadata\MetadataGuardianResource;
 use oat\taoQtiItem\model\qti\metadata\MetadataService;
 use oat\taoQtiItem\model\qti\metadata\ontology\MappedMetadataInjector;
@@ -265,6 +266,7 @@ class ImportService extends ConfigurableService
      * @param bool $enableMetadataValidators
      * @param bool $itemMustExist
      * @param bool $itemMustBeOverwritten
+     * @param bool $overwriteByLabelInTargetClass
      * @return Report
      * @throws Exception
      * @throws ExtractException
@@ -284,7 +286,8 @@ class ImportService extends ConfigurableService
         $enableMetadataValidators = true,
         $itemMustExist = false,
         $itemMustBeOverwritten = false,
-        $importMetadataEnabled = false
+        $importMetadataEnabled = false,
+        $overwriteByLabelInTargetClass = false
     ) {
         $initialLogMsg = "Importing QTI Package with the following options:\n";
         $initialLogMsg .= '- Rollback On Warning: ' . json_encode($rollbackOnWarning) . "\n";
@@ -294,6 +297,7 @@ class ImportService extends ConfigurableService
         $initialLogMsg .= '- Item Must Exist: ' . json_encode($itemMustExist) . "\n";
         $initialLogMsg .= '- Item Must Be Overwritten: ' . json_encode($itemMustBeOverwritten) . "\n";
         $initialLogMsg .= '- Import Metadata Enabled: ' . json_encode($importMetadataEnabled) . "\n";
+        $initialLogMsg .= '- Overwrite By Label In Target Class: ' . json_encode($overwriteByLabelInTargetClass) . "\n";
         \common_Logger::d($initialLogMsg);
 
         //load and validate the package
@@ -325,6 +329,8 @@ class ImportService extends ConfigurableService
 
             /** @var Resource[] $qtiItemResources */
             $qtiItemResources = $this->createQtiManifest($folder . 'imsmanifest.xml');
+
+            $mappedMetadataValues = [];
 
             if ($importMetadataEnabled) {
                 $metaMetadataValues = $this->getMetaMetadataExtractor()->extract($domManifest);
@@ -374,7 +380,8 @@ class ImportService extends ConfigurableService
                     $itemMustBeOverwritten,
                     $overwrittenItems,
                     isset($mappedMetadataValues['itemProperties']) ? $mappedMetadataValues['itemProperties'] : [],
-                    $importMetadataEnabled
+                    $importMetadataEnabled,
+                    $overwriteByLabelInTargetClass
                 );
 
                 $allCreatedClasses = array_merge($allCreatedClasses, $createdClasses);
@@ -465,6 +472,7 @@ class ImportService extends ConfigurableService
      * @param bool $itemMustExist
      * @param bool $itemMustBeOverwritten
      * @param array $overwrittenItems
+     * @param bool $overwriteByLabelInTargetClass
      * @return Report
      * @throws common_exception_Error
      */
@@ -482,7 +490,8 @@ class ImportService extends ConfigurableService
         $itemMustBeOverwritten = false,
         &$overwrittenItems = [],
         $metaMedataValues = [],
-        $importMetadataEnabled = false
+        $importMetadataEnabled = false,
+        $overwriteByLabelInTargetClass = false
     ) {
         // if report can't be finished
         $report = Report::createError(
@@ -504,8 +513,25 @@ class ImportService extends ConfigurableService
             try {
                 $resourceIdentifier = $qtiItemResource->getIdentifier();
                 $guardian = false;
+                $qtiModel = null;
 
-                if ($enableMetadataGuardians === true) {
+                $overwriteByLabelInTargetClassEnabled = $itemMustBeOverwritten === true
+                    && $overwriteByLabelInTargetClass === true;
+
+                if ($overwriteByLabelInTargetClassEnabled) {
+                    $tmpQtiFile = $tmpFolder . helpers_File::urlToPath($qtiItemResource->getFile());
+                    $this->convertToQti2($tmpQtiFile);
+                    $qtiModel = $this->createQtiItemModel($tmpQtiFile);
+                    $guardian = $this->findItemByLabelInClass($itemClass, $this->extractItemLabel($qtiModel));
+
+                    if ($guardian !== false) {
+                        \common_Logger::i(
+                            'Resource "' . $resourceIdentifier
+                                . '" matches an item label in the target class and will be overwritten.'
+                        );
+                        $overWriting = true;
+                    }
+                } elseif ($enableMetadataGuardians === true) {
                     $this->getMetadataImporter()->setMetadataValues($metadataValues);
                     $guardian = $this->getMetadataImporter()->guard($resourceIdentifier);
                     if ($guardian !== false) {
@@ -562,8 +588,11 @@ class ImportService extends ConfigurableService
                 $targetClass = $this->getMetadataImporter()->classLookUp($resourceIdentifier, $createdClasses);
                 $tmpQtiFile = $tmpFolder . helpers_File::urlToPath($qtiItemResource->getFile());
                 common_Logger::i('file :: ' . $qtiItemResource->getFile());
-                $this->convertToQti2($tmpQtiFile);
-                $qtiModel = $this->createQtiItemModel($tmpQtiFile);
+
+                if ($qtiModel === null) {
+                    $this->convertToQti2($tmpQtiFile);
+                    $qtiModel = $this->createQtiItemModel($tmpQtiFile);
+                }
 
                 if (
                     $this->getOption(self::CONFIG_VALIDATE_RESPONSE_PROCESSING) && !$this->validResponseProcessing(
@@ -911,6 +940,44 @@ class ImportService extends ConfigurableService
         foreach ($createdClasses as $createdClass) {
             @$createdClass->delete();
         }
+    }
+
+    /**
+     * @param \qtism\data\AssessmentItem $qtiModel
+     */
+    private function extractItemLabel($qtiModel): string
+    {
+        $label = '';
+        if ($qtiModel->hasAttribute('label')) {
+            $label = trim((string) $qtiModel->getAttributeValue('label'));
+        }
+
+        if ($label === '' && $qtiModel->hasAttribute('title')) {
+            $label = trim((string) $qtiModel->getAttributeValue('title'));
+        }
+
+        return $label;
+    }
+
+    /**
+     * @return false|core_kernel_classes_Resource
+     */
+    private function findItemByLabelInClass(core_kernel_classes_Class $itemClass, string $label)
+    {
+        if ($label === '') {
+            return false;
+        }
+
+        $instances = $itemClass->searchInstances(
+            [OntologyRdfs::RDFS_LABEL => $label],
+            ['like' => false, 'recursive' => true]
+        );
+
+        if (empty($instances)) {
+            return false;
+        }
+
+        return reset($instances);
     }
 
     /**

--- a/model/qti/ImportService.php
+++ b/model/qti/ImportService.php
@@ -55,6 +55,7 @@ use oat\taoQtiItem\model\qti\metadata\imsManifest\MetaMetadataExtractor;
 use oat\generis\model\OntologyRdfs;
 use oat\taoQtiItem\model\qti\metadata\MetadataGuardianResource;
 use oat\taoQtiItem\model\qti\metadata\MetadataService;
+use oat\taoQtiItem\model\qti\metadata\MetadataValue;
 use oat\taoQtiItem\model\qti\metadata\ontology\MappedMetadataInjector;
 use oat\taoQtiItem\model\qti\parser\ValidationException;
 use oat\taoQtiItem\model\event\ItemImported;
@@ -532,7 +533,12 @@ class ImportService extends ConfigurableService
                     $qtiModel = $this->createQtiItemModel($tmpQtiFile);
                     $guardian = $this->findItemByLabelInClass(
                         $itemClass,
-                        $this->extractItemLabel($qtiModel)
+                        $this->extractItemLabel(
+                            $qtiModel,
+                            $importMetadataEnabled,
+                            $resourceIdentifier,
+                            $metadataValues
+                        )
                     );
 
                     if ($guardian !== false) {
@@ -954,9 +960,25 @@ class ImportService extends ConfigurableService
 
     /**
      * @param \qtism\data\AssessmentItem $qtiModel
+     * @param array<string, array> $metadataValues
      */
-    private function extractItemLabel($qtiModel): string
-    {
+    private function extractItemLabel(
+        $qtiModel,
+        bool $importMetadataEnabled = false,
+        string $resourceIdentifier = '',
+        array $metadataValues = []
+    ): string {
+        if (
+            $importMetadataEnabled
+            && $resourceIdentifier !== ''
+            && isset($metadataValues[$resourceIdentifier])
+        ) {
+            $labelFromMetadata = $this->extractItemLabelFromMetadata($metadataValues[$resourceIdentifier]);
+            if ($labelFromMetadata !== '') {
+                return $labelFromMetadata;
+            }
+        }
+
         $label = '';
         if ($qtiModel->hasAttribute('label')) {
             $label = trim((string) $qtiModel->getAttributeValue('label'));
@@ -967,6 +989,30 @@ class ImportService extends ConfigurableService
         }
 
         return $label;
+    }
+
+    /**
+     * @param MetadataValue[] $metadataValuesForResource
+     */
+    private function extractItemLabelFromMetadata(array $metadataValuesForResource): string
+    {
+        foreach ($metadataValuesForResource as $metadataValue) {
+            if (!$metadataValue instanceof MetadataValue) {
+                continue;
+            }
+
+            $path = $metadataValue->getPath();
+            if (!isset($path[1]) || $path[1] !== OntologyRdfs::RDFS_LABEL) {
+                continue;
+            }
+
+            $value = trim((string) $metadataValue->getValue());
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/model/tasks/ImportQtiItem.php
+++ b/model/tasks/ImportQtiItem.php
@@ -44,6 +44,7 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
     public const PARAM_ITEM_MUST_EXIST = 'itemMustExist';
     public const PARAM_ITEM_MUST_BE_OVERWRITTEN = 'itemMustBeOverwritten';
     public const PARAM_ITEM_METADATA = 'importMetadata';
+    public const PARAM_OVERWRITE_BY_LABEL_IN_TARGET_CLASS = 'overwriteByLabelInTargetClass';
 
     protected $service;
 
@@ -73,7 +74,8 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
             (isset($params[self::PARAM_VALIDATORS])) ? $params[self::PARAM_VALIDATORS] : true,
             (isset($params[self::PARAM_ITEM_MUST_EXIST])) ? $params[self::PARAM_ITEM_MUST_EXIST] : false,
             $params[self::PARAM_ITEM_MUST_BE_OVERWRITTEN] ?? false,
-            $params[self::PARAM_ITEM_METADATA] ?? false
+            $params[self::PARAM_ITEM_METADATA] ?? false,
+            $params[self::PARAM_OVERWRITE_BY_LABEL_IN_TARGET_CLASS] ?? false
         );
     }
 
@@ -95,6 +97,8 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
      * @param boolean                    $enableMetadataValidators
      * @param boolean                    $itemMustExist
      * @param boolean                    $itemMustBeOverwritten
+     * @param boolean                    $itemMetadata
+     * @param boolean                    $overwriteByLabelInTargetClass
      * @return TaskInterface
      */
     public static function createTask(
@@ -105,7 +109,8 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
         $enableMetadataValidators = true,
         $itemMustExist = false,
         $itemMustBeOverwritten = false,
-        $itemMetadata = false
+        $itemMetadata = false,
+        $overwriteByLabelInTargetClass = false
     ) {
         $action = new self();
         $action->setServiceLocator($serviceManager);
@@ -124,7 +129,8 @@ class ImportQtiItem extends AbstractTaskAction implements \JsonSerializable
                 self::PARAM_VALIDATORS => $enableMetadataValidators,
                 self::PARAM_ITEM_MUST_EXIST => $itemMustExist,
                 self::PARAM_ITEM_MUST_BE_OVERWRITTEN => $itemMustBeOverwritten,
-                self::PARAM_ITEM_METADATA => $itemMetadata
+                self::PARAM_ITEM_METADATA => $itemMetadata,
+                self::PARAM_OVERWRITE_BY_LABEL_IN_TARGET_CLASS => $overwriteByLabelInTargetClass,
             ],
             __('Import QTI ITEM into "%s"', $class->getLabel())
         );

--- a/test/unit/model/qti/ImportServiceMetadataGuardTest.php
+++ b/test/unit/model/qti/ImportServiceMetadataGuardTest.php
@@ -79,14 +79,14 @@ class ImportServiceMetadataGuardTest extends TestCase
             ->method('setMetadataValues')
             ->with($metadataValues);
 
+        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
+        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
+        $itemClass = $this->createMock(RdfClass::class);
+
         $metadataImporterMock->expects($this->once())
             ->method('guard')
             ->with($resourceIdentifier)
             ->willReturn($existingResource);
-
-        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
-        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
-        $itemClass = $this->createMock(RdfClass::class);
 
         $sharedFiles = [];
         $createdClasses = [];
@@ -150,14 +150,14 @@ class ImportServiceMetadataGuardTest extends TestCase
             ->method('setMetadataValues')
             ->with($metadataValues);
 
+        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
+        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
+        $itemClass = $this->createMock(RdfClass::class);
+
         $metadataImporterMock->expects($this->once())
             ->method('guard')
             ->with($resourceIdentifier)
             ->willReturn(false);
-
-        $importService = $this->createImportServiceWithMetadataImporter($metadataImporterMock);
-        $qtiResource = $this->createQtiResourceMock($resourceIdentifier);
-        $itemClass = $this->createMock(RdfClass::class);
 
         $sharedFiles = [];
         $createdClasses = [];


### PR DESCRIPTION
Adds an optional import mode to overwrite existing items by label within the target class (class-uri / class-label), without changing the existing metadata guardian behavior.

- New API/query parameter: overwriteByLabelInTargetClass (default: false)
- Label-based overwrite runs only when both are true:
      - itemMustBeOverwritten=true
      - overwriteByLabelInTargetClass=true
- In that mode, import looks up an item in the destination class by the QTI item’s label (or title if label is empty) and overwrites it if found; otherwise it creates a new item in that class
- Metadata guardians (ItemMetadataGuardian) are not used for this lookup, so items in other classes with the same label are not affected
- When overwriteByLabelInTargetClass is false or omitted, behavior is unchanged: itemMustBeOverwritten still drives overwrite via metadata guardians (global LOM identifier match)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional overwriteByLabelInTargetClass option for QTI item import (sync and async) to allow overwriting items by matching labels in the target class; defaults to false and validated as a boolean.
  * Import flows and background import tasks now honor this option.

* **Documentation**
  * REST API spec updated to document the new optional form parameter.

* **Tests**
  * Adjusted unit tests for import service metadata guard setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/extension-tao-itemqti/pull/3003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->