### PR TITLE
fix/INV-1203: regenerate text reader images when asset updated

### DIFF
--- a/helpers/QtiXmlLoader.php
+++ b/helpers/QtiXmlLoader.php
@@ -49,7 +49,9 @@ class QtiXmlLoader
         $dom = new DOMDocument('1.0', 'UTF-8');
         $this->configDomParser($dom);
         try {
-            $dom->loadXML($xml);
+            if ($dom->loadXML($xml) === false) {
+                throw new QtiModelException('Invalid QTI XML');
+            }
         } catch (Exception $e) {
             throw new QtiModelException('Invalid QTI XML', 0, $e);
         }

--- a/model/qti/ElementReferences.php
+++ b/model/qti/ElementReferences.php
@@ -33,11 +33,19 @@ class ElementReferences
     /** @var string[] */
     private $imgReferences;
 
-    public function __construct(array $xIncludeReferences, array $objectReferences, array $imgReferences)
-    {
+    /** @var string[] */
+    private $textReaderReferences;
+
+    public function __construct(
+        array $xIncludeReferences,
+        array $objectReferences,
+        array $imgReferences,
+        array $textReaderReferences = []
+    ) {
         $this->xIncludeReferences = $xIncludeReferences;
         $this->objectReferences = $objectReferences;
         $this->imgReferences = $imgReferences;
+        $this->textReaderReferences = $textReaderReferences;
     }
 
     public function getXIncludeReferences(): array
@@ -55,12 +63,18 @@ class ElementReferences
         return $this->imgReferences;
     }
 
+    public function getTextReaderReferences(): array
+    {
+        return $this->textReaderReferences;
+    }
+
     public function getAllReferences(): array
     {
         return array_merge(
             $this->xIncludeReferences,
             $this->objectReferences,
-            $this->imgReferences
+            $this->imgReferences,
+            $this->textReaderReferences
         );
     }
 }

--- a/model/qti/ServiceProvider/QtiServiceProvider.php
+++ b/model/qti/ServiceProvider/QtiServiceProvider.php
@@ -35,6 +35,9 @@ use oat\taoQtiItem\model\qti\converter\ItemConverter;
 use oat\taoQtiItem\model\qti\converter\ManifestConverter;
 use oat\taoQtiItem\model\qti\Identifier\Service\QtiIdentifierSetter;
 use oat\taoQtiItem\model\qti\ItemMaxScoreService;
+use oat\taoQtiItem\model\qti\parser\ElementReferencesExtractor;
+use oat\taoQtiItem\model\qti\parser\TextReaderReferencesExtractor;
+use oat\taoQtiItem\model\qti\parser\TextReaderReferencesExtractorInterface;
 use oat\taoQtiItem\model\qti\Service;
 use oat\taoQtiItem\model\QtiCreator\Scales\RemoteScaleListService;
 use oat\taoQtiItem\model\ValidationService;
@@ -98,6 +101,18 @@ class QtiServiceProvider implements ContainerServiceProviderInterface
             ->public();
 
         $services->set(ItemMaxScoreService::class, ItemMaxScoreService::class)
+            ->public();
+
+        $services->set(TextReaderReferencesExtractor::class, TextReaderReferencesExtractor::class)
+            ->public();
+
+        $services->set(TextReaderReferencesExtractorInterface::class, TextReaderReferencesExtractor::class)
+            ->public();
+
+        $services->set(ElementReferencesExtractor::class, ElementReferencesExtractor::class)
+            ->args([
+                service(TextReaderReferencesExtractorInterface::class),
+            ])
             ->public();
     }
 }

--- a/model/qti/event/UpdatedItemEventDispatcher.php
+++ b/model/qti/event/UpdatedItemEventDispatcher.php
@@ -37,6 +37,7 @@ class UpdatedItemEventDispatcher extends ConfigurableService
     private const INCLUDE_ELEMENT_REFERENCES_KEY = 'includeElementReferences';
     private const OBJECT_ELEMENT_REFERENCES_KEY = 'objectElementReferences';
     private const IMG_ELEMENT_REFERENCES_KEY = 'imgElementReferences';
+    private const TEXT_READER_ELEMENT_REFERENCES_KEY = 'textReaderElementReferences';
 
     public function dispatch(Item $qtiItem, core_kernel_classes_Resource $rdfItem): void
     {
@@ -46,6 +47,7 @@ class UpdatedItemEventDispatcher extends ConfigurableService
             self::INCLUDE_ELEMENT_REFERENCES_KEY => $extractor->extract($qtiItem, XInclude::class, 'href'),
             self::OBJECT_ELEMENT_REFERENCES_KEY => $extractor->extract($qtiItem, QtiObject::class, 'data'),
             self::IMG_ELEMENT_REFERENCES_KEY => $extractor->extract($qtiItem, Img::class, 'src'),
+            self::TEXT_READER_ELEMENT_REFERENCES_KEY => $extractor->extractTextReaderReferences($qtiItem),
         ];
 
         $this->getEventManager()

--- a/model/qti/parser/ElementReferencesExtractor.php
+++ b/model/qti/parser/ElementReferencesExtractor.php
@@ -22,21 +22,24 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\model\qti\parser;
 
+use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiItem\model\qti\Element;
 use oat\taoQtiItem\model\qti\ElementReferences;
 use oat\taoQtiItem\model\qti\Img;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\QtiObject;
 use oat\taoQtiItem\model\qti\XInclude;
-
-class ElementReferencesExtractor
+class ElementReferencesExtractor extends ConfigurableService
 {
     /** @var string[] */
     private $elementReferences;
 
+    private ?TextReaderReferencesExtractorInterface $textReaderReferencesExtractor;
+
     public function __construct(
-        private readonly TextReaderReferencesExtractorInterface $textReaderReferencesExtractor
+        ?TextReaderReferencesExtractorInterface $textReaderReferencesExtractor = null
     ) {
+        $this->textReaderReferencesExtractor = $textReaderReferencesExtractor;
     }
 
     public function extract(Item $qtiItem, string $elementClass, string $attributeName): array
@@ -63,6 +66,15 @@ class ElementReferencesExtractor
 
     public function extractTextReaderReferences(Item $qtiItem): array
     {
-        return $this->textReaderReferencesExtractor->extract($qtiItem);
+        return $this->getTextReaderReferencesExtractor()->extract($qtiItem);
+    }
+
+    private function getTextReaderReferencesExtractor(): TextReaderReferencesExtractorInterface
+    {
+        if ($this->textReaderReferencesExtractor !== null) {
+            return $this->textReaderReferencesExtractor;
+        }
+
+        return new TextReaderReferencesExtractor();
     }
 }

--- a/model/qti/parser/ElementReferencesExtractor.php
+++ b/model/qti/parser/ElementReferencesExtractor.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\model\qti\parser;
 
-use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiItem\model\qti\Element;
 use oat\taoQtiItem\model\qti\ElementReferences;
 use oat\taoQtiItem\model\qti\Img;
@@ -30,10 +29,15 @@ use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\QtiObject;
 use oat\taoQtiItem\model\qti\XInclude;
 
-class ElementReferencesExtractor extends ConfigurableService
+class ElementReferencesExtractor
 {
     /** @var string[] */
     private $elementReferences;
+
+    public function __construct(
+        private readonly TextReaderReferencesExtractorInterface $textReaderReferencesExtractor
+    ) {
+    }
 
     public function extract(Item $qtiItem, string $elementClass, string $attributeName): array
     {
@@ -59,11 +63,6 @@ class ElementReferencesExtractor extends ConfigurableService
 
     public function extractTextReaderReferences(Item $qtiItem): array
     {
-        return $this->getTextReaderReferencesExtractor()->extract($qtiItem);
-    }
-
-    private function getTextReaderReferencesExtractor(): TextReaderReferencesExtractor
-    {
-        return new TextReaderReferencesExtractor();
+        return $this->textReaderReferencesExtractor->extract($qtiItem);
     }
 }

--- a/model/qti/parser/ElementReferencesExtractor.php
+++ b/model/qti/parser/ElementReferencesExtractor.php
@@ -29,6 +29,7 @@ use oat\taoQtiItem\model\qti\Img;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\QtiObject;
 use oat\taoQtiItem\model\qti\XInclude;
+
 class ElementReferencesExtractor extends ConfigurableService
 {
     /** @var string[] */

--- a/model/qti/parser/ElementReferencesExtractor.php
+++ b/model/qti/parser/ElementReferencesExtractor.php
@@ -25,10 +25,10 @@ namespace oat\taoQtiItem\model\qti\parser;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiItem\model\qti\Element;
 use oat\taoQtiItem\model\qti\ElementReferences;
+use oat\taoQtiItem\model\qti\Img;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\QtiObject;
 use oat\taoQtiItem\model\qti\XInclude;
-use oat\taoQtiItem\model\qti\Img;
 
 class ElementReferencesExtractor extends ConfigurableService
 {
@@ -52,7 +52,18 @@ class ElementReferencesExtractor extends ConfigurableService
         return new ElementReferences(
             $this->extract($qtiItem, XInclude::class, 'href'),
             $this->extract($qtiItem, QtiObject::class, 'data'),
-            $this->extract($qtiItem, Img::class, 'src')
+            $this->extract($qtiItem, Img::class, 'src'),
+            $this->extractTextReaderReferences($qtiItem)
         );
+    }
+
+    public function extractTextReaderReferences(Item $qtiItem): array
+    {
+        return $this->getTextReaderReferencesExtractor()->extract($qtiItem);
+    }
+
+    private function getTextReaderReferencesExtractor(): TextReaderReferencesExtractor
+    {
+        return new TextReaderReferencesExtractor();
     }
 }

--- a/model/qti/parser/TextReaderReferencesExtractor.php
+++ b/model/qti/parser/TextReaderReferencesExtractor.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\parser;
+
+use DOMDocument;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoQtiItem\model\qti\Item;
+use oat\taoQtiItem\model\qti\interaction\ImsPortableCustomInteraction;
+use oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction;
+
+class TextReaderReferencesExtractor extends ConfigurableService
+{
+    private const TEXT_READER_TYPE_IDENTIFIER = 'textReaderInteraction';
+
+    public function extract(Item $qtiItem): array
+    {
+        $references = [];
+
+        foreach ($this->getTextReaderInteractions($qtiItem) as $interaction) {
+            $references = array_merge($references, $this->extractFromInteraction($interaction));
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    /**
+     * @return array<int, PortableCustomInteraction|ImsPortableCustomInteraction>
+     */
+    public function getTextReaderInteractions(Item $qtiItem): array
+    {
+        $interactions = array_merge(
+            $qtiItem->getComposingElements(PortableCustomInteraction::class),
+            $qtiItem->getComposingElements(ImsPortableCustomInteraction::class)
+        );
+
+        return array_values(
+            array_filter(
+                $interactions,
+                static fn ($interaction): bool => (
+                    ($interaction instanceof PortableCustomInteraction
+                        || $interaction instanceof ImsPortableCustomInteraction)
+                    && $interaction->getTypeIdentifier() === self::TEXT_READER_TYPE_IDENTIFIER
+                )
+            )
+        );
+    }
+
+    public function extractFromInteraction(
+        PortableCustomInteraction|ImsPortableCustomInteraction $interaction
+    ): array {
+        $properties = $interaction->getProperties();
+        $pages = $this->normalizePagesProperty($properties['pages'] ?? null);
+        if ($pages === []) {
+            return [];
+        }
+
+        $references = [];
+
+        foreach ($pages as $page) {
+            if (!isset($page['content']) || !is_array($page['content'])) {
+                continue;
+            }
+
+            $references = array_merge($references, $this->extractImageSourcesFromContent($page['content']));
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    private function extractImageSourcesFromContent(array $content): array
+    {
+        $references = [];
+        $previousState = libxml_use_internal_errors(true);
+
+        try {
+            foreach ($content as $element) {
+                if (!is_string($element) || $element === '') {
+                    continue;
+                }
+
+                $dom = new DOMDocument();
+                $dom->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $element);
+                libxml_clear_errors();
+
+                foreach ($dom->getElementsByTagName('img') as $image) {
+                    $src = $image->getAttribute('src');
+                    if ($src !== '') {
+                        $references[] = $src;
+                    }
+                }
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousState);
+        }
+
+        return $references;
+    }
+
+    private function normalizePagesProperty($pages): array
+    {
+        if (is_array($pages)) {
+            return $pages;
+        }
+
+        if (!is_string($pages) || $pages === '') {
+            return [];
+        }
+
+        $decoded = json_decode($pages, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/model/qti/parser/TextReaderReferencesExtractor.php
+++ b/model/qti/parser/TextReaderReferencesExtractor.php
@@ -68,7 +68,7 @@ class TextReaderReferencesExtractor implements TextReaderReferencesExtractorInte
         PortableCustomInteraction|ImsPortableCustomInteraction $interaction
     ): array {
         $properties = $interaction->getProperties();
-        $pages = $this->normalizePagesProperty($properties['pages'] ?? null);
+        $pages = $this->normalizePages($properties['pages'] ?? null);
         if ($pages === []) {
             return [];
         }
@@ -116,18 +116,19 @@ class TextReaderReferencesExtractor implements TextReaderReferencesExtractorInte
         return $references;
     }
 
-    private function normalizePagesProperty($pages): array
+    private function normalizePages($pages): array
     {
         if (is_array($pages)) {
             return $pages;
         }
-
-        if (!is_string($pages) || $pages === '') {
+        if (!is_string($pages)) {
             return [];
         }
-
-        $decoded = json_decode($pages, true);
-
-        return is_array($decoded) ? $decoded : [];
+        try {
+            $decoded = json_decode($pages, true, 512, JSON_THROW_ON_ERROR);
+            return is_array($decoded) ? $decoded : [];
+        } catch (\JsonException $_) {
+            return [];
+        }
     }
 }

--- a/model/qti/parser/TextReaderReferencesExtractor.php
+++ b/model/qti/parser/TextReaderReferencesExtractor.php
@@ -23,12 +23,11 @@ declare(strict_types=1);
 namespace oat\taoQtiItem\model\qti\parser;
 
 use DOMDocument;
-use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\interaction\ImsPortableCustomInteraction;
 use oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction;
 
-class TextReaderReferencesExtractor extends ConfigurableService
+class TextReaderReferencesExtractor implements TextReaderReferencesExtractorInterface
 {
     private const TEXT_READER_TYPE_IDENTIFIER = 'textReaderInteraction';
 

--- a/model/qti/parser/TextReaderReferencesExtractorInterface.php
+++ b/model/qti/parser/TextReaderReferencesExtractorInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\model\qti\parser;
+
+use oat\taoQtiItem\model\qti\interaction\ImsPortableCustomInteraction;
+use oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction;
+use oat\taoQtiItem\model\qti\Item;
+
+interface TextReaderReferencesExtractorInterface
+{
+    public function extract(Item $qtiItem): array;
+
+    /**
+     * @return array<int, PortableCustomInteraction|ImsPortableCustomInteraction>
+     */
+    public function getTextReaderInteractions(Item $qtiItem): array;
+
+    public function extractFromInteraction(
+        PortableCustomInteraction|ImsPortableCustomInteraction $interaction
+    ): array;
+}

--- a/test/unit/model/event/UpdatedItemEventDispatcherTest.php
+++ b/test/unit/model/event/UpdatedItemEventDispatcherTest.php
@@ -80,6 +80,7 @@ class UpdatedItemEventDispatcherTest extends TestCase
                         'includeElementReferences' => $ids,
                         'objectElementReferences' => $ids,
                         'imgElementReferences' => $ids,
+                        'textReaderElementReferences' => [],
                     ]
                 )
             );
@@ -92,6 +93,11 @@ class UpdatedItemEventDispatcherTest extends TestCase
                 [$item, QtiObject::class, 'data', $ids],
                 [$item, Img::class, 'src', $ids],
             ]);
+        $this->referencesExtractor
+            ->expects($this->once())
+            ->method('extractTextReaderReferences')
+            ->with($item)
+            ->willReturn([]);
 
         $this->assertNull($this->subject->dispatch($item, $rdfItem));
     }

--- a/test/unit/model/qti/ElementReferencesTest.php
+++ b/test/unit/model/qti/ElementReferencesTest.php
@@ -33,6 +33,8 @@ class ElementReferencesTest extends TestCase
         . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d5';
     private const MEDIA_LINK_3 = 'taomedia://mediamanager/https_2_test-tao-deploy_0_docker_0_localhost_1_ontologies_1_'
         . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d3';
+    private const MEDIA_LINK_4 = 'taomedia://mediamanager/https_2_test-tao-deploy_0_docker_0_localhost_1_ontologies_1_'
+        . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d7';
 
     /** @var ElementReferences */
     private $subject;
@@ -42,7 +44,8 @@ class ElementReferencesTest extends TestCase
         $this->subject = new ElementReferences(
             [self::MEDIA_LINK_1],
             [self::MEDIA_LINK_2],
-            [self::MEDIA_LINK_3]
+            [self::MEDIA_LINK_3],
+            [self::MEDIA_LINK_4]
         );
     }
 
@@ -51,12 +54,14 @@ class ElementReferencesTest extends TestCase
         $this->assertSame($this->subject->getXIncludeReferences(), [self::MEDIA_LINK_1]);
         $this->assertSame($this->subject->getObjectReferences(), [self::MEDIA_LINK_2]);
         $this->assertSame($this->subject->getImgReferences(), [self::MEDIA_LINK_3]);
+        $this->assertSame($this->subject->getTextReaderReferences(), [self::MEDIA_LINK_4]);
         $this->assertSame(
             $this->subject->getAllReferences(),
             [
                 self::MEDIA_LINK_1,
                 self::MEDIA_LINK_2,
                 self::MEDIA_LINK_3,
+                self::MEDIA_LINK_4,
             ]
         );
     }

--- a/test/unit/model/qti/event/UpdatedItemEventDispatcherTest.php
+++ b/test/unit/model/qti/event/UpdatedItemEventDispatcherTest.php
@@ -79,6 +79,7 @@ class UpdatedItemEventDispatcherTest extends TestCase
         $hrefValue = ['href-value 1', 'href-value 2', 'href-value 3'];
         $dataValue = ['data-value 1', 'data-value 2'];
         $srcValue = ['src-value 1', 'src-value 2'];
+        $textReaderValue = ['text-reader-value 1', 'text-reader-value 2'];
 
         $this->referencesExtractor
             ->expects($this->exactly(3))
@@ -90,6 +91,11 @@ class UpdatedItemEventDispatcherTest extends TestCase
                     [$this->qtiItem, Img::class, 'src', $srcValue],
                 ]
             );
+        $this->referencesExtractor
+            ->expects($this->once())
+            ->method('extractTextReaderReferences')
+            ->with($this->qtiItem)
+            ->willReturn($textReaderValue);
 
         $this->eventManager
             ->expects($this->once())
@@ -100,7 +106,8 @@ class UpdatedItemEventDispatcherTest extends TestCase
                     [
                         'includeElementReferences' => $hrefValue,
                         'objectElementReferences' => $dataValue,
-                        'imgElementReferences' => $srcValue
+                        'imgElementReferences' => $srcValue,
+                        'textReaderElementReferences' => $textReaderValue,
                     ]
                 )
             );

--- a/test/unit/model/qti/parser/ElementReferencesExtractorTest.php
+++ b/test/unit/model/qti/parser/ElementReferencesExtractorTest.php
@@ -26,9 +26,12 @@ use oat\taoQtiItem\model\qti\ElementReferences;
 use oat\taoQtiItem\model\qti\Img;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\parser\ElementReferencesExtractor;
+use oat\taoQtiItem\model\qti\parser\TextReaderReferencesExtractor;
 use oat\generis\test\TestCase;
 use oat\taoQtiItem\model\qti\QtiObject;
 use oat\taoQtiItem\model\qti\XInclude;
+use oat\taoQtiItem\model\qti\interaction\ImsPortableCustomInteraction;
+use oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ElementReferencesExtractorTest extends TestCase
@@ -39,6 +42,8 @@ class ElementReferencesExtractorTest extends TestCase
         . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d5';
     private const MEDIA_LINK_3 = 'taomedia://mediamanager/https_2_test-tao-deploy_0_docker_0_localhost_1_ontologies_1_'
         . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d3';
+    private const MEDIA_LINK_4 = 'taomedia://mediamanager/https_2_test-tao-deploy_0_docker_0_localhost_1_ontologies_1_'
+        . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d7';
 
     /** @var ElementReferencesExtractor */
     private $subject;
@@ -46,6 +51,11 @@ class ElementReferencesExtractorTest extends TestCase
     protected function setUp(): void
     {
         $this->subject = new ElementReferencesExtractor();
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock([
+                TextReaderReferencesExtractor::class => new TextReaderReferencesExtractor(),
+            ])
+        );
     }
 
     public function testExtract(): void
@@ -99,6 +109,25 @@ class ElementReferencesExtractorTest extends TestCase
         $element3->method('attr')
             ->willReturn(self::MEDIA_LINK_3);
 
+        $textReaderInteraction = $this->createMock(PortableCustomInteraction::class);
+        $textReaderInteraction->method('getTypeIdentifier')
+            ->willReturn('textReaderInteraction');
+        $textReaderInteraction->method('getProperties')
+            ->willReturn(
+                [
+                    'pages' => json_encode(
+                        [
+                            [
+                                'content' => [
+                                    '<p><img src="' . self::MEDIA_LINK_4 . '"/></p>',
+                                    '<p><img src="' . self::MEDIA_LINK_4 . '"/></p>',
+                                ],
+                            ],
+                        ]
+                    ),
+                ]
+            );
+
         /** @var Item|MockObject $item */
         $item = $this->createMock(Item::class);
         $item->method('getComposingElements')
@@ -106,7 +135,9 @@ class ElementReferencesExtractorTest extends TestCase
                 ...[
                     [$element1],
                     [$element2],
-                    [$element3]
+                    [$element3],
+                    [$textReaderInteraction],
+                    [],
                 ]
             );
 
@@ -114,9 +145,55 @@ class ElementReferencesExtractorTest extends TestCase
             new ElementReferences(
                 [self::MEDIA_LINK_1],
                 [self::MEDIA_LINK_2],
-                [self::MEDIA_LINK_3]
+                [self::MEDIA_LINK_3],
+                [self::MEDIA_LINK_4]
             ),
             $this->subject->extractAll($item)
+        );
+    }
+
+    public function testExtractTextReaderReferences(): void
+    {
+        $textReaderInteraction = $this->createMock(PortableCustomInteraction::class);
+        $textReaderInteraction->method('getTypeIdentifier')
+            ->willReturn('textReaderInteraction');
+        $textReaderInteraction->method('getProperties')
+            ->willReturn(
+                [
+                    'pages' => json_encode(
+                        [
+                            [
+                                'content' => [
+                                    '<p><img src="' . self::MEDIA_LINK_4 . '"/></p>',
+                                    '<p><img src="' . self::MEDIA_LINK_2 . '"/></p>',
+                                ],
+                            ],
+                        ]
+                    ),
+                ]
+            );
+
+        $otherInteraction = $this->createMock(PortableCustomInteraction::class);
+        $otherInteraction->method('getTypeIdentifier')
+            ->willReturn('someOtherInteraction');
+
+        /** @var Item|MockObject $item */
+        $item = $this->createMock(Item::class);
+        $item->expects($this->exactly(2))
+            ->method('getComposingElements')
+            ->willReturnMap(
+                [
+                    [PortableCustomInteraction::class, [$textReaderInteraction, $otherInteraction]],
+                    [ImsPortableCustomInteraction::class, []],
+                ]
+            );
+
+        $this->assertSame(
+            [
+                self::MEDIA_LINK_4,
+                self::MEDIA_LINK_2,
+            ],
+            $this->subject->extractTextReaderReferences($item)
         );
     }
 }

--- a/test/unit/model/qti/parser/ElementReferencesExtractorTest.php
+++ b/test/unit/model/qti/parser/ElementReferencesExtractorTest.php
@@ -191,4 +191,40 @@ class ElementReferencesExtractorTest extends TestCase
             $this->subject->extractTextReaderReferences($item)
         );
     }
+
+    public function testExtractTextReaderReferencesWithoutInjectedDependency(): void
+    {
+        $textReaderInteraction = $this->createMock(PortableCustomInteraction::class);
+        $textReaderInteraction->method('getTypeIdentifier')
+            ->willReturn('textReaderInteraction');
+        $textReaderInteraction->method('getProperties')
+            ->willReturn(
+                [
+                    'pages' => json_encode(
+                        [
+                            [
+                                'content' => [
+                                    '<p><img src="' . self::MEDIA_LINK_4 . '"/></p>',
+                                ],
+                            ],
+                        ]
+                    ),
+                ]
+            );
+
+        /** @var Item|MockObject $item */
+        $item = $this->createMock(Item::class);
+        $item->expects($this->exactly(2))
+            ->method('getComposingElements')
+            ->willReturnMap(
+                [
+                    [PortableCustomInteraction::class, [$textReaderInteraction]],
+                    [ImsPortableCustomInteraction::class, []],
+                ]
+            );
+
+        $subject = new ElementReferencesExtractor();
+
+        $this->assertSame([self::MEDIA_LINK_4], $subject->extractTextReaderReferences($item));
+    }
 }

--- a/test/unit/model/qti/parser/ElementReferencesExtractorTest.php
+++ b/test/unit/model/qti/parser/ElementReferencesExtractorTest.php
@@ -22,12 +22,12 @@ declare(strict_types=1);
 
 namespace oat\taoQtiItem\test\unit\model\qti\parser;
 
+use PHPUnit\Framework\TestCase;
 use oat\taoQtiItem\model\qti\ElementReferences;
 use oat\taoQtiItem\model\qti\Img;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\parser\ElementReferencesExtractor;
 use oat\taoQtiItem\model\qti\parser\TextReaderReferencesExtractor;
-use oat\generis\test\TestCase;
 use oat\taoQtiItem\model\qti\QtiObject;
 use oat\taoQtiItem\model\qti\XInclude;
 use oat\taoQtiItem\model\qti\interaction\ImsPortableCustomInteraction;
@@ -50,12 +50,7 @@ class ElementReferencesExtractorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new ElementReferencesExtractor();
-        $this->subject->setServiceLocator(
-            $this->getServiceLocatorMock([
-                TextReaderReferencesExtractor::class => new TextReaderReferencesExtractor(),
-            ])
-        );
+        $this->subject = new ElementReferencesExtractor(new TextReaderReferencesExtractor());
     }
 
     public function testExtract(): void

--- a/test/unit/model/qti/parser/TextReaderReferencesExtractorTest.php
+++ b/test/unit/model/qti/parser/TextReaderReferencesExtractorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\qti\parser;
+
+use oat\generis\test\TestCase;
+use oat\taoQtiItem\model\qti\Item;
+use oat\taoQtiItem\model\qti\interaction\ImsPortableCustomInteraction;
+use oat\taoQtiItem\model\qti\interaction\PortableCustomInteraction;
+use oat\taoQtiItem\model\qti\parser\TextReaderReferencesExtractor;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class TextReaderReferencesExtractorTest extends TestCase
+{
+    private const MEDIA_LINK_1 = 'taomedia://mediamanager/https_2_test-tao-deploy_0_docker_0_localhost_1_ontologies_1_'
+        . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d4';
+    private const MEDIA_LINK_2 = 'taomedia://mediamanager/https_2_test-tao-deploy_0_docker_0_localhost_1_ontologies_1_'
+        . 'tao_0_rdf_3_i5ec293a38ebe623833180e3b0a547a6d5';
+
+    private TextReaderReferencesExtractor $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new TextReaderReferencesExtractor();
+    }
+
+    public function testExtract(): void
+    {
+        $portableInteraction = $this->createTextReaderInteraction(
+            [
+                [
+                    'content' => [
+                        '<p><img src="' . self::MEDIA_LINK_1 . '"/></p>',
+                    ],
+                ],
+            ]
+        );
+        $imsInteraction = $this->createImsTextReaderInteraction(
+            [
+                [
+                    'content' => [
+                        '<p><img src="' . self::MEDIA_LINK_1 . '"/></p>',
+                        '<p><img src="' . self::MEDIA_LINK_2 . '"/></p>',
+                    ],
+                ],
+            ]
+        );
+
+        /** @var Item|MockObject $item */
+        $item = $this->createMock(Item::class);
+        $item->expects($this->exactly(2))
+            ->method('getComposingElements')
+            ->willReturnMap(
+                [
+                    [PortableCustomInteraction::class, [$portableInteraction]],
+                    [ImsPortableCustomInteraction::class, [$imsInteraction]],
+                ]
+            );
+
+        $this->assertSame(
+            [
+                self::MEDIA_LINK_1,
+                self::MEDIA_LINK_2,
+            ],
+            $this->subject->extract($item)
+        );
+    }
+
+    public function testExtractFromInteraction(): void
+    {
+        $interaction = $this->createTextReaderInteraction(
+            [
+                [
+                    'content' => [
+                        '<p><img src="' . self::MEDIA_LINK_1 . '"/></p>',
+                        '<p><img src="' . self::MEDIA_LINK_2 . '"/></p>',
+                        '<p><img src="' . self::MEDIA_LINK_1 . '"/></p>',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertSame(
+            [
+                self::MEDIA_LINK_1,
+                self::MEDIA_LINK_2,
+            ],
+            $this->subject->extractFromInteraction($interaction)
+        );
+    }
+
+    public function testGetTextReaderInteractions(): void
+    {
+        $textReaderInteraction = $this->createTextReaderInteraction([]);
+        $otherInteraction = $this->createMock(PortableCustomInteraction::class);
+        $otherInteraction->method('getTypeIdentifier')
+            ->willReturn('someOtherInteraction');
+
+        /** @var Item|MockObject $item */
+        $item = $this->createMock(Item::class);
+        $item->expects($this->exactly(2))
+            ->method('getComposingElements')
+            ->willReturnMap(
+                [
+                    [PortableCustomInteraction::class, [$textReaderInteraction, $otherInteraction]],
+                    [ImsPortableCustomInteraction::class, []],
+                ]
+            );
+
+        $this->assertSame(
+            [$textReaderInteraction],
+            $this->subject->getTextReaderInteractions($item)
+        );
+    }
+
+    private function createTextReaderInteraction(array $pages): PortableCustomInteraction|MockObject
+    {
+        $interaction = $this->createMock(PortableCustomInteraction::class);
+        $interaction->method('getTypeIdentifier')
+            ->willReturn('textReaderInteraction');
+        $interaction->method('getProperties')
+            ->willReturn(['pages' => json_encode($pages)]);
+
+        return $interaction;
+    }
+
+    private function createImsTextReaderInteraction(array $pages): ImsPortableCustomInteraction|MockObject
+    {
+        $interaction = $this->createMock(ImsPortableCustomInteraction::class);
+        $interaction->method('getTypeIdentifier')
+            ->willReturn('textReaderInteraction');
+        $interaction->method('getProperties')
+            ->willReturn(['pages' => json_encode($pages)]);
+
+        return $interaction;
+    }
+}


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INV-1203

## What's Changed
Fixes an issue where text reader images wouldn't update after their corresponding assets were changed.

## Dependencies PRs
- https://github.com/oat-sa/tao-deliver-be/pull/1689
- https://github.com/oat-sa/extension-tao-testqti/pull/2786
- https://github.com/oat-sa/extension-tao-mediamanager/pull/567

## How to test
1. Upload an image to the Assets section in backoffice.
2. Create a Text Reader interaction from Custom Interactions and insert this image asset from the toolbar.
3. Create a test with this item, and publish the test.
4. Click Replace Asset and upload a different image for this image in Assets.
5. The image should now be replaced in item and test previews, and in deliveries after republishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text‑reader support that discovers image references in interaction pages and includes them in item update payloads.

* **Bug Fixes**
  * Improved QTI XML parsing to reliably detect and report invalid XML input.

* **Tests**
  * Expanded unit tests covering text‑reader reference extraction and the updated event payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->