### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+## Cursor Cloud specific instructions
+
+This is a TAO platform extension (`extension-tao-itemqti` / `taoQtiItem`) for creating and managing QTI assessment items. It is **not a standalone application** — it runs as part of the [TAO](https://www.taotesting.com) platform ecosystem.
+
+### Project structure
+
+- **PHP backend**: Controllers, models, services under `controller/`, `model/`, `helpers/`, `scripts/`
+- **JavaScript frontend**: AMD/RequireJS modules under `views/js/`
+- **PHP tests**: `test/unit/` (PHPUnit unit tests), `test/integration/` (integration tests requiring TAO platform)
+- **Frontend E2E tests**: `views/cypress/tests/` (Cypress, requires a running TAO instance)
+- **Frontend JS test fixtures**: `views/js/test/` (QUnit-style, run via Grunt)
+
+### Running PHP unit tests
+
+```bash
+cd /workspace
+./vendor/bin/phpunit --bootstrap generis/test/bootstrap.php test/unit/ --no-configuration
+```
+
+To run a specific test file or directory:
+
+```bash
+./vendor/bin/phpunit --bootstrap generis/test/bootstrap.php test/unit/model/qti/ImportServiceTest.php --no-configuration
+```
+
+The integration tests (`test/integration/`) require a fully installed TAO platform with database and are not runnable in this environment.
+
+### Running JavaScript linting
+
+The JS linting tools live in `tao/views/build/`. A symlink `taoQtiItem -> /workspace` is needed so the Grunt tasks can locate the extension by name.
+
+```bash
+ln -sf /workspace /workspace/taoQtiItem
+cd /workspace/tao/views/build
+npx grunt eslint:extension --extension=taoQtiItem --no-color --force
+```
+
+### Key caveats
+
+- The `composer.json` does not include `phpunit` in `require-dev`; it must be installed separately (`composer require --dev phpunit/phpunit:"^10.0"`). The CI action `oat-sa/tao-extension-ci-action@v1` provides it in CI.
+- Composer plugins `oat-sa/oatbox-extension-installer` and `oat-sa/composer-npm-bridge` must be allowed. Run `composer config --no-plugins allow-plugins.oat-sa/oatbox-extension-installer true` and `composer config --no-plugins allow-plugins.oat-sa/composer-npm-bridge true` before `composer install` if not already configured.
+- The npm-bridge plugin automatically installs npm dependencies for all extensions (including `views/` for this extension) during `composer install`.
+- The `taoQtiItem` symlink (`ln -sf /workspace /workspace/taoQtiItem`) is necessary for the Grunt-based lint/build/test tasks to resolve extension paths correctly.
+- PHP 8.1, 8.2, and 8.3 are supported (per CI matrix). PHP 8.3 is recommended.
+- Pre-existing ESLint errors (1800+) exist in the JS codebase; these are not regressions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket:
N/A - Development environment setup

## What's Changed
- Added `AGENTS.md` with Cursor Cloud-specific development instructions for the TAO QTI Item extension.

The file includes:
- Project structure overview
- PHPUnit test commands (unit tests with generis bootstrap)
- JavaScript linting instructions (via Grunt/ESLint)
- Key caveats for environment setup (Composer plugin allowlisting, npm-bridge behavior, taoQtiItem symlink requirement)

> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## TODO 
- [x] Documentation file (AGENTS.md)

## How to test
This is a documentation-only change. No functional testing needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40d3446a-d027-4d92-9141-02827e7947c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40d3446a-d027-4d92-9141-02827e7947c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

