### PR TITLE
feature: add slider orientation and reverse options

### DIFF
--- a/views/js/qtiCreator/tpl/forms/interactions/slider.tpl
+++ b/views/js/qtiCreator/tpl/forms/interactions/slider.tpl
@@ -20,3 +20,36 @@
     <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
     <span class="tooltip-content">{{__ "The number of units corresponding to a step on the slider"}}</span>
 </div>
+
+<div class="panel">
+    <h3>{{__ 'Orientation'}}</h3>
+    <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
+    <span class="tooltip-content">
+        {{__ 'Displays the slider bar either horizontally or vertically'}}
+    </span>
+    <div>
+        <label class="smaller-prompt">
+            <input type="radio" name="orientation" value="vertical" {{#unless horizontal}}checked{{/unless}} />
+            <span class="icon-radio"></span>
+            {{__ 'Vertical'}}
+        </label>
+        <br>
+        <label class="smaller-prompt">
+            <input type="radio" name="orientation" value="horizontal" {{#if horizontal}}checked{{/if}} />
+            <span class="icon-radio"></span>
+            {{__ 'Horizontal'}}
+        </label>
+    </div>
+</div>
+
+<div class="panel">
+    <label>
+        <input name="reverse" type="checkbox" {{#if reverse}}checked="checked"{{/if}}/>
+        <span class="icon-checkbox"></span>
+        {{__ "Reverse direction"}}
+    </label>
+    <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+    <span class="tooltip-content">
+        {{__ "Reverse the slider bar boundaries"}}
+    </span>
+</div>

--- a/views/js/qtiCreator/widgets/interactions/sliderInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/sliderInteraction/Widget.js
@@ -23,6 +23,19 @@ define([
 ], function (Widget, states, SliderInteraction) {
     const SliderInteractionWidget = Widget.clone();
 
+    SliderInteractionWidget.rerenderSlider = function rerenderSlider(interaction) {
+        interaction = interaction || this.element;
+
+        interaction
+            .getContainer()
+            .removeClass('qti-slider-horizontal qti-slider-vertical')
+            .find('.qti-slider,.qti-slider-values,.qti-slider-cur-value,.qti-slider-value')
+            .remove();
+
+        SliderInteraction.render(interaction);
+        interaction.getContainer().find('.qti-slider').attr('disabled', 'disabled');
+    };
+
     SliderInteractionWidget.initCreator = function () {
         this.registerStates(states);
         Widget.initCreator.call(this);
@@ -30,15 +43,10 @@ define([
         // Disable slider until response edition.
         this.$container.find('.qti-slider').attr('disabled', 'disabled');
 
-        // rerender Slider after dir is changed, because support of rtl/ltr is done by js code, not css
+        // rerender slider after dir/writing-mode changes because layout support is computed by js
         const $itemBody = this.$container.closest('.qti-itemBody');
-        $itemBody.on('item-dir-changed', () => {
-            const interaction = this.element;
-            interaction
-                .getContainer()
-                .find('.qti-slider,.qti-slider-values,.qti-slider-cur-value,.qti-slider-value')
-                .remove();
-            SliderInteraction.render(interaction);
+        $itemBody.on('item-dir-changed item-writing-mode-changed', () => {
+            this.rerenderSlider(this.element);
         });
     };
 

--- a/views/js/qtiCreator/widgets/interactions/sliderInteraction/Widget.js
+++ b/views/js/qtiCreator/widgets/interactions/sliderInteraction/Widget.js
@@ -22,6 +22,7 @@ define([
     'taoQtiItem/qtiCommonRenderer/renderers/interactions/SliderInteraction'
 ], function (Widget, states, SliderInteraction) {
     const SliderInteractionWidget = Widget.clone();
+    const itemLayoutChangeEvents = 'item-dir-changed item-writing-mode-changed';
 
     SliderInteractionWidget.rerenderSlider = function rerenderSlider(interaction) {
         interaction = interaction || this.element;
@@ -44,10 +45,22 @@ define([
         this.$container.find('.qti-slider').attr('disabled', 'disabled');
 
         // rerender slider after dir/writing-mode changes because layout support is computed by js
-        const $itemBody = this.$container.closest('.qti-itemBody');
-        $itemBody.on('item-dir-changed item-writing-mode-changed', () => {
+        this._itemBody = this.$container.closest('.qti-itemBody');
+        this._onItemDirOrWritingModeChanged = () => {
             this.rerenderSlider(this.element);
-        });
+        };
+        this._itemBody.on(itemLayoutChangeEvents, this._onItemDirOrWritingModeChanged);
+    };
+
+    SliderInteractionWidget.destroy = function destroy() {
+        if (this._itemBody && this._onItemDirOrWritingModeChanged) {
+            this._itemBody.off(itemLayoutChangeEvents, this._onItemDirOrWritingModeChanged);
+        }
+
+        this._itemBody = null;
+        this._onItemDirOrWritingModeChanged = null;
+
+        Widget.destroy.call(this);
     };
 
     return SliderInteractionWidget;

--- a/views/js/qtiCreator/widgets/interactions/sliderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/sliderInteraction/states/Question.js
@@ -44,12 +44,14 @@ define([
         const _widget = this.widget;
         const $form = _widget.$form;
         const interaction = _widget.element;
+        const orientation = interaction.attr('orientation') || 'horizontal';
 
         $form.html(formTpl({
             // tpl data for the interaction
             lowerBound : parseFloat(interaction.attr('lowerBound')),
             upperBound : parseFloat(interaction.attr('upperBound')),
-            orientation : interaction.attr('orientation'),
+            orientation : orientation,
+            horizontal : orientation !== 'vertical',
             reverse : !!interaction.attr('reverse'),
             step : parseInt(interaction.attr('step')),
             stepLabel : !!interaction.attr('stepLabel')
@@ -148,39 +150,18 @@ define([
                 .noUiSlider(
                     { range: { min: lowerBound, max: upperBound } },
                     true
-                );
+            );
         };
 
-        // TODO clean old logic after UX review, tech debt
-        // TODO orientation in Item runner tao-item-runner-qti-fe/src/qtiCommonRenderer/renderers/interactions/SliderInteraction.js
-        // // -- orientation Callback
-        // callbacks.orientation = function(interaction, attrValue, attrName){
-        //     interaction.attr('orientation', attrValue);
+        // -- orientation Callback
+        callbacks.orientation = (interactionParam, attrValue) => {
+            interactionParam.attr('orientation', attrValue || 'horizontal');
+        };
 
-        //     var orientation = (interaction.attr('orientation')) ? interaction.attr('orientation') : 'horizontal';
-        //     var reverse = interaction.attr('reverse');
-
-        //     _widget.$container.find('.qti-slider').noUiSlider({ 'orientation': interaction.attr('orientation') }, true);
-        // };
-
-        // TODO clean old logic after UX review, tech debt
-        // TODO reverse in Item runner tao-item-runner-qti-fe/src/qtiCommonRenderer/renderers/interactions/SliderInteraction.js
-        // // -- reverse Callback
-        // callbacks.reverse = function(interaction, attrValue, attrName){
-
-        //     interaction.attr('reverse', !!attrValue);
-
-        //     var reverse = interaction.attr('reverse');
-        //     var lowerBound = parseInt(interaction.attr('lowerBound'));
-        //     var upperBound = parseInt(interaction.attr('upperBound'));
-        //     var $sliderElt = _widget.$container.find('.qti-slider');
-        //     var start = (reverse) ? upperBound : lowerBound;
-        //     $sliderElt.noUiSlider({ start: start }, true);
-
-        //     _widget.$container.find('span.qti-slider-cur-value').text(lowerBound);
-        //     _widget.$container.find('.slider-min').text(!reverse ? lowerBound : upperBound);
-        //     _widget.$container.find('.slider-max').text(!reverse ? upperBound : lowerBound);
-        // };
+        // -- reverse Callback
+        callbacks.reverse = (interactionParam, attrValue) => {
+            interactionParam.attr('reverse', !!attrValue);
+        };
 
         // -- step Callback
         callbacks.step = (interactionParam, attrValue) => {
@@ -203,28 +184,6 @@ define([
                 $form.find('input[name="step"]').incrementer('options', { max: sliderLength });
             }
         };
-
-        // TODO clean old logic after UX review, tech debt
-        // // -- stepLabel Callback
-        // callbacks.stepLabel = function(interaction, attrValue, attrName){
-
-        //     interaction.attr('stepLabel', !!attrValue);
-
-        //     _widget.$container.find('span.slider-middle').remove();
-
-        //     if (interaction.attr('stepLabel')) {
-        //         var upperBound = interaction.attr('upperBound');
-        //         var lowerBound = interaction.attr('lowerBound');
-        //         var step = interaction.attr('step');
-        //         var reverse = interaction.attr('reverse');
-
-        //         var steps = parseInt((upperBound - lowerBound) / step);
-        //         var middleStep = parseInt(steps / 2);
-        //         var leftOffset = (100 / steps) * middleStep;
-        //         var middleValue = (reverse) ? upperBound - middleStep * step : lowerBound + middleStep * step;
-        //         _widget.$container.find('.slider-min').after('<span class="slider-middle" style="left:' + leftOffset + '%">' + middleValue + '</span>');
-        //     }
-        // };
 
         formElement.setChangeCallbacks($form, interaction, callbacks);
     };

--- a/views/js/qtiCreator/widgets/interactions/sliderInteraction/states/Question.js
+++ b/views/js/qtiCreator/widgets/interactions/sliderInteraction/states/Question.js
@@ -155,12 +155,16 @@ define([
 
         // -- orientation Callback
         callbacks.orientation = (interactionParam, attrValue) => {
-            interactionParam.attr('orientation', attrValue || 'horizontal');
+            const orientation = ['horizontal', 'vertical'].includes(attrValue) ? attrValue : 'horizontal';
+
+            interactionParam.attr('orientation', orientation);
+            _widget.rerenderSlider(interactionParam);
         };
 
         // -- reverse Callback
         callbacks.reverse = (interactionParam, attrValue) => {
             interactionParam.attr('reverse', !!attrValue);
+            _widget.rerenderSlider(interactionParam);
         };
 
         // -- step Callback

--- a/views/js/test/qtiCreator/widgets/interactions/sliderInteraction/states/Question/test.html
+++ b/views/js/test/qtiCreator/widgets/interactions/sliderInteraction/states/Question/test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test - Slider Interaction Question State</title>
+        <base href="../../../../../../../../../../../tao/views/"/>
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+
+            require(['/tao/ClientConfig/config'], function () {
+                require([
+                    'taoQtiItem/test/qtiCreator/widgets/interactions/sliderInteraction/states/Question/test'
+                ], function () {
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/qtiCreator/widgets/interactions/sliderInteraction/states/Question/test.js
+++ b/views/js/test/qtiCreator/widgets/interactions/sliderInteraction/states/Question/test.js
@@ -1,0 +1,447 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+define([
+    'jquery',
+    'taoQtiItem/qtiCreator/widgets/interactions/sliderInteraction/states/Question',
+    'taoQtiItem/qtiCreator/widgets/interactions/sliderInteraction/Widget'
+], function ($, SliderQuestionState, SliderInteractionWidget) {
+    'use strict';
+
+    const defaults = {
+        responseIdentifier: 'RESPONSE',
+        lowerBound: 0,
+        upperBound: 100,
+        step: 1,
+        stepLabel: false
+    };
+
+    function createInteraction(attrs) {
+        const values = $.extend({}, defaults, attrs || {});
+
+        return {
+            attr(name, value) {
+                if (typeof value !== 'undefined') {
+                    values[name] = value;
+                    return this;
+                }
+
+                return values[name];
+            },
+            getAttributes() {
+                return values;
+            },
+            getContainer() {
+                return this.$container;
+            },
+            getSerial() {
+                return 'slider-interaction-serial';
+            }
+        };
+    }
+
+    function createWidget(attrs) {
+        const $fixture = $('#qunit-fixture');
+        const $itemBody = $('<div class="qti-itemBody" />').appendTo($fixture);
+        const $container = $(
+            '<div class="qti-interaction qti-slider-horizontal" data-serial="slider-interaction-serial">' +
+                '<div class="qti-slider"></div>' +
+                '<div class="qti-slider-values">' +
+                    '<span class="slider-min"></span>' +
+                    '<span class="slider-max"></span>' +
+                '</div>' +
+                '<div class="qti-slider-cur-value">' +
+                    '<span class="qti-slider-cur-value"></span>' +
+                '</div>' +
+                '<input type="hidden" class="qti-slider-value" />' +
+            '</div>'
+        ).appendTo($itemBody);
+        const interaction = createInteraction(attrs);
+        const widget = {
+            $form: $('<form />').appendTo($fixture),
+            $itemBody,
+            $container,
+            element: interaction,
+            renderCount: 0,
+            rerenderSlider(interactionParam) {
+                this.renderCount++;
+                SliderInteractionWidget.rerenderSlider.call(this, interactionParam);
+            },
+            registerStates() {},
+            createToolbar() {},
+            createOkButton() {},
+            listenToChoiceStates() {},
+            listenToIncludeStates() {}
+        };
+
+        interaction.$container = $container;
+        $container.find('.slider-min').text(interaction.attr('lowerBound'));
+        $container.find('.slider-max').text(interaction.attr('upperBound'));
+        $container.find('span.qti-slider-cur-value').text(interaction.attr('lowerBound'));
+        $container.find('.qti-slider-value').val(interaction.attr('lowerBound'));
+
+        return widget;
+    }
+
+    function initForm(attrs) {
+        const widget = createWidget(attrs);
+        const state = new SliderQuestionState(widget);
+
+        state.initForm();
+
+        return widget;
+    }
+
+    function panelText($panel) {
+        return $panel.text().replace(/\s+/g, ' ').trim();
+    }
+
+    function getGeneratedSliderCounts(widget) {
+        return {
+            slider: widget.$container.children('.qti-slider').length,
+            values: widget.$container.children('.qti-slider-values').length,
+            currentValue: widget.$container.children('.qti-slider-cur-value').length,
+            value: widget.$container.children('.qti-slider-value').length
+        };
+    }
+
+    function assertSingleSlider(assert, widget) {
+        const counts = getGeneratedSliderCounts(widget);
+
+        assert.strictEqual(counts.slider, 1, 'has one slider element');
+        assert.strictEqual(counts.values, 1, 'has one label group');
+        assert.strictEqual(counts.currentValue, 1, 'has one current-value group');
+        assert.strictEqual(counts.value, 1, 'has one hidden value input');
+    }
+
+    function assertSliderLabels(assert, widget, expectedMin, expectedMax) {
+        assert.strictEqual(widget.$container.find('.slider-min').text(), String(expectedMin), 'min position label matches');
+        assert.strictEqual(widget.$container.find('.slider-max').text(), String(expectedMax), 'max position label matches');
+    }
+
+    QUnit.module('qtiCreator/widgets/interactions/sliderInteraction/states/Question', {
+        beforeEach() {
+            const originalVal = $.fn.val;
+
+            $.fn.noUiSlider = function (options) {
+                if (options) {
+                    this.data('noUiSliderOptions', options);
+                }
+                return this;
+            };
+            $.fn.val = function (value) {
+                if (this.hasClass('qti-slider')) {
+                    if (typeof value !== 'undefined') {
+                        this.data('noUiSliderValue', value);
+                        return this;
+                    }
+
+                    return this.data('noUiSliderValue');
+                }
+
+                return originalVal.apply(this, arguments);
+            };
+            this.originalVal = originalVal;
+        },
+        afterEach() {
+            $.fn.val = this.originalVal;
+        }
+    });
+
+    QUnit.test('renders panels in the expected order', assert => {
+        assert.expect(4);
+
+        const widget = initForm();
+        const $panels = widget.$form.find('.panel');
+
+        assert.ok(panelText($panels.eq(0)).includes('Lower Bound'), 'bounds panel is first');
+        assert.ok(panelText($panels.eq(1)).includes('Step'), 'step panel is second');
+        assert.ok(panelText($panels.eq(2)).includes('Orientation'), 'orientation panel is third');
+        assert.ok(panelText($panels.eq(3)).includes('Reverse direction'), 'reverse panel is fourth');
+    });
+
+    QUnit.test('defaults to horizontal orientation and unchecked reverse', assert => {
+        assert.expect(4);
+
+        const widget = initForm();
+
+        assert.strictEqual(
+            widget.$form.find('input[name="orientation"][value="horizontal"]').prop('checked'),
+            true,
+            'horizontal is checked by default'
+        );
+        assert.strictEqual(
+            widget.$form.find('input[name="orientation"][value="vertical"]').prop('checked'),
+            false,
+            'vertical is unchecked by default'
+        );
+        assert.strictEqual(
+            widget.$form.find('input[name="reverse"]').prop('checked'),
+            false,
+            'reverse is unchecked by default'
+        );
+        assert.strictEqual(
+            widget.$form.find('input[name="orientation"]').first().val(),
+            'vertical',
+            'vertical option is rendered above horizontal'
+        );
+    });
+
+    QUnit.test('loads existing vertical orientation', assert => {
+        assert.expect(2);
+
+        const widget = initForm({ orientation: 'vertical' });
+
+        assert.strictEqual(
+            widget.$form.find('input[name="orientation"][value="vertical"]').prop('checked'),
+            true,
+            'vertical is checked'
+        );
+        assert.strictEqual(
+            widget.$form.find('input[name="orientation"][value="horizontal"]').prop('checked'),
+            false,
+            'horizontal is unchecked'
+        );
+    });
+
+    QUnit.test('loads existing reversed setting', assert => {
+        assert.expect(1);
+
+        const widget = initForm({ reverse: true });
+
+        assert.strictEqual(widget.$form.find('input[name="reverse"]').prop('checked'), true, 'reverse is checked');
+    });
+
+    QUnit.test('changing orientation persists after form reinitialization', assert => {
+        assert.expect(5);
+
+        const widget = initForm();
+
+        widget.$form
+            .find('input[name="orientation"][value="vertical"]')
+            .prop('checked', true)
+            .trigger('change');
+
+        assert.strictEqual(widget.element.attr('orientation'), 'vertical', 'orientation attribute is updated');
+        assert.strictEqual(widget.renderCount, 1, 'slider is re-rendered after orientation changes');
+        assert.strictEqual(widget.$container.find('.qti-slider').attr('disabled'), 'disabled', 'slider remains disabled');
+
+        const state = new SliderQuestionState(widget);
+        state.initForm();
+
+        assert.strictEqual(
+            widget.$form.find('input[name="orientation"][value="vertical"]').prop('checked'),
+            true,
+            'vertical remains selected after reinitialization'
+        );
+        assert.strictEqual(
+            widget.$form.find('input[name="orientation"][value="horizontal"]').prop('checked'),
+            false,
+            'horizontal remains unselected after reinitialization'
+        );
+    });
+
+    QUnit.test('invalid orientation falls back to horizontal', assert => {
+        assert.expect(2);
+
+        const widget = initForm();
+
+        widget.$form
+            .find('input[name="orientation"][value="vertical"]')
+            .val('diagonal')
+            .prop('checked', true)
+            .trigger('change');
+
+        assert.strictEqual(widget.element.attr('orientation'), 'horizontal', 'invalid orientation falls back');
+        assert.strictEqual(widget.renderCount, 1, 'slider is re-rendered after invalid orientation changes');
+    });
+
+    QUnit.test('changing reverse persists after form reinitialization', assert => {
+        assert.expect(4);
+
+        const widget = initForm();
+
+        widget.$form.find('input[name="reverse"]').prop('checked', true).trigger('change');
+
+        assert.strictEqual(widget.element.attr('reverse'), true, 'reverse attribute is updated');
+        assert.strictEqual(widget.renderCount, 1, 'slider is re-rendered after reverse changes');
+        assert.strictEqual(widget.$container.find('.qti-slider').attr('disabled'), 'disabled', 'slider remains disabled');
+
+        const state = new SliderQuestionState(widget);
+        state.initForm();
+
+        assert.strictEqual(
+            widget.$form.find('input[name="reverse"]').prop('checked'),
+            true,
+            'reverse remains checked after reinitialization'
+        );
+    });
+
+    QUnit.test('repeated orientation and reverse changes do not duplicate generated slider parts', assert => {
+        assert.expect(10);
+
+        const widget = initForm();
+
+        widget.$form.find('input[name="orientation"][value="vertical"]').prop('checked', true).trigger('change');
+        widget.$form.find('input[name="orientation"][value="horizontal"]').prop('checked', true).trigger('change');
+        widget.$form.find('input[name="reverse"]').prop('checked', true).trigger('change');
+        widget.$form.find('input[name="reverse"]').prop('checked', false).trigger('change');
+
+        assert.strictEqual(widget.renderCount, 4, 'slider is re-rendered after each rendering option change');
+        assertSingleSlider(assert, widget);
+        assert.strictEqual(widget.$container.find('.qti-slider').attr('disabled'), 'disabled', 'slider remains disabled');
+        assert.strictEqual(widget.$container.hasClass('qti-slider-horizontal'), true, 'horizontal class is present');
+        assert.strictEqual(widget.$container.hasClass('qti-slider-vertical'), false, 'stale vertical class is removed');
+        assertSliderLabels(assert, widget, 0, 100);
+    });
+
+    QUnit.test('item direction and writing-mode events re-render through the widget helper', assert => {
+        assert.expect(8);
+
+        const widget = createWidget();
+
+        SliderInteractionWidget.initCreator.call(widget);
+
+        widget.$itemBody.trigger('item-dir-changed');
+
+        assert.strictEqual(widget.renderCount, 1, 'direction event re-renders the slider');
+        assertSingleSlider(assert, widget);
+        assert.strictEqual(widget.$container.find('.qti-slider').attr('disabled'), 'disabled', 'slider remains disabled');
+
+        widget.$itemBody.addClass('writing-mode-vertical-rl').trigger('item-writing-mode-changed');
+
+        assert.strictEqual(widget.renderCount, 2, 'writing-mode event re-renders the slider');
+        assert.strictEqual(widget.$container.find('.qti-slider').attr('disabled'), 'disabled', 'slider remains disabled again');
+    });
+
+    QUnit.test('horizontal LTR and RTL positioning follows effective direction', assert => {
+        assert.expect(6);
+
+        const ltrWidget = createWidget({
+            lowerBound: 10,
+            upperBound: 90,
+            orientation: 'horizontal',
+            reverse: false
+        });
+        ltrWidget.$container.css('direction', 'ltr');
+        ltrWidget.rerenderSlider(ltrWidget.element);
+
+        assert.strictEqual(ltrWidget.$container.hasClass('qti-slider-horizontal'), true, 'LTR slider is horizontal');
+        assertSliderLabels(assert, ltrWidget, 10, 90);
+
+        const rtlWidget = createWidget({
+            lowerBound: 10,
+            upperBound: 90,
+            orientation: 'horizontal',
+            reverse: false
+        });
+        rtlWidget.$container.css('direction', 'rtl');
+        rtlWidget.rerenderSlider(rtlWidget.element);
+
+        assert.strictEqual(rtlWidget.$container.hasClass('qti-slider-horizontal'), true, 'RTL slider is horizontal');
+        assertSliderLabels(assert, rtlWidget, 90, 10);
+    });
+
+    QUnit.test('vertical positioning follows reverse without changing bounds', assert => {
+        assert.expect(8);
+
+        const widget = createWidget({
+            lowerBound: 5,
+            upperBound: 25,
+            orientation: 'vertical',
+            reverse: false
+        });
+        widget.rerenderSlider(widget.element);
+
+        assert.strictEqual(widget.$container.hasClass('qti-slider-vertical'), true, 'slider is vertical');
+        assert.strictEqual(widget.$container.hasClass('qti-slider-horizontal'), false, 'stale horizontal class is removed');
+        assertSliderLabels(assert, widget, 5, 25);
+
+        widget.element.attr('reverse', true);
+        widget.rerenderSlider(widget.element);
+
+        assertSliderLabels(assert, widget, 25, 5);
+        assert.strictEqual(widget.element.attr('lowerBound'), 5, 'lower bound attribute is unchanged');
+        assert.strictEqual(widget.element.attr('upperBound'), 25, 'upper bound attribute is unchanged');
+    });
+
+    QUnit.test('existing numeric controls still render and lower bound callback updates the attribute', assert => {
+        assert.expect(6);
+
+        const widget = initForm();
+
+        assert.strictEqual(widget.$form.find('input[name="lowerBound"]').length, 1, 'lower bound input renders');
+        assert.strictEqual(widget.$form.find('input[name="upperBound"]').length, 1, 'upper bound input renders');
+        assert.strictEqual(widget.$form.find('input[name="step"]').length, 1, 'step input renders');
+
+        widget.$form.find('input[name="lowerBound"]').val('7').trigger('change');
+
+        assert.strictEqual(widget.element.attr('lowerBound'), 7, 'lower bound attribute is updated');
+        assert.strictEqual(widget.element.attr('step'), 1, 'step callback path still keeps step attribute valid');
+        assert.strictEqual(widget.$container.find('.qti-slider').val(), 7, 'slider value is updated');
+    });
+
+    QUnit.test('lower and upper bound validation still clamps as before', assert => {
+        assert.expect(6);
+
+        const invalidLowerWidget = initForm({ lowerBound: 5, upperBound: 10, step: 2 });
+
+        invalidLowerWidget.$form.find('input[name="lowerBound"]').val('-4').trigger('change');
+
+        assert.strictEqual(invalidLowerWidget.element.attr('lowerBound'), 0, 'invalid lower bound clamps to zero');
+        assertSliderLabels(assert, invalidLowerWidget, 0, 10);
+
+        const upperBelowLowerWidget = initForm({ lowerBound: 10, upperBound: 20, step: 5 });
+
+        upperBelowLowerWidget.$form.find('input[name="upperBound"]').val('7').trigger('change');
+
+        assert.strictEqual(upperBelowLowerWidget.element.attr('upperBound'), 7, 'upper bound is updated');
+        assert.strictEqual(upperBelowLowerWidget.element.attr('lowerBound'), 7, 'lower bound is clamped down to upper bound');
+        assert.strictEqual(
+            upperBelowLowerWidget.$form.find('input[name="lowerBound"]').val(),
+            '7',
+            'lower bound input is clamped'
+        );
+    });
+
+    QUnit.test('step validation still clamps to slider length', assert => {
+        assert.expect(2);
+
+        const widget = initForm({ lowerBound: 0, upperBound: 10, step: 20 });
+
+        widget.$form.find('input[name="upperBound"]').val('5').trigger('change');
+
+        assert.strictEqual(widget.element.attr('step'), 5, 'step is clamped to the slider length');
+        assert.strictEqual(widget.$form.find('input[name="step"]').val(), '5', 'step input is clamped');
+    });
+
+    QUnit.test('tooltip source strings are present', assert => {
+        assert.expect(2);
+
+        const widget = initForm();
+        const formText = widget.$form.text();
+
+        assert.ok(
+            formText.includes('Displays the slider bar either horizontally or vertically'),
+            'orientation tooltip source string is rendered'
+        );
+        assert.ok(
+            formText.includes('Reverse the slider bar boundaries'),
+            'reverse tooltip source string is rendered'
+        );
+    });
+});

--- a/views/js/test/qtiCreator/widgets/interactions/sliderInteraction/states/Question/test.js
+++ b/views/js/test/qtiCreator/widgets/interactions/sliderInteraction/states/Question/test.js
@@ -77,10 +77,13 @@ define([
             $container,
             element: interaction,
             renderCount: 0,
+            serial: 'slider-interaction-serial',
             rerenderSlider(interactionParam) {
                 this.renderCount++;
                 SliderInteractionWidget.rerenderSlider.call(this, interactionParam);
             },
+            changeState() {},
+            offEvents() {},
             registerStates() {},
             createToolbar() {},
             createOkButton() {},
@@ -310,7 +313,7 @@ define([
     });
 
     QUnit.test('item direction and writing-mode events re-render through the widget helper', assert => {
-        assert.expect(8);
+        assert.expect(9);
 
         const widget = createWidget();
 
@@ -326,6 +329,11 @@ define([
 
         assert.strictEqual(widget.renderCount, 2, 'writing-mode event re-renders the slider');
         assert.strictEqual(widget.$container.find('.qti-slider').attr('disabled'), 'disabled', 'slider remains disabled again');
+
+        SliderInteractionWidget.destroy.call(widget);
+        widget.$itemBody.trigger('item-dir-changed');
+
+        assert.strictEqual(widget.renderCount, 2, 'direction event is unregistered on destroy');
     });
 
     QUnit.test('horizontal LTR and RTL positioning follows effective direction', assert => {


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4603

## What's Changed

- add slider orientation and reverse options

## Dependencies PRs

- https://github.com/oat-sa/tao-core/


## How to test
- Go to item authoring
- Add Slider interaction to the desk
- The slider orientation options are in the interactions settings tab

## Video

https://github.com/user-attachments/assets/783c2811-dec3-497a-89a2-6fad54992aa9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Orientation option (vertical/horizontal) and Reverse Direction toggle for slider interactions, with help tooltips.
* **Bug Fixes**
  * Slider re-rendering improved when direction or writing mode change; re-render preserves disabled state and cleans up event handlers.
* **Tests**
  * Added comprehensive UI tests and a test page covering orientation, reverse behavior, persistence, bounds/step validation, and re-rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->