### PR TITLE
feature: extend test suite to validate slider orientation and reverse…

### DIFF
--- a/test/integration/QtiOutputTest.php
+++ b/test/integration/QtiOutputTest.php
@@ -113,6 +113,86 @@ class QtiOutputTest extends TaoPhpUnitTestRunner
     }
 
     /**
+     * Test slider orientation and reverse import/export persistence.
+     *
+     * @return void
+     */
+    public function testSliderOrientationReversePersistence(): void
+    {
+        $file = dirname(__FILE__)
+            . '/samples/xml/qtiv2p1/slider-orientation-reverse-persistence.xml';
+        $qtiParser = new Parser($file);
+        $item = $qtiParser->load();
+
+        $this->assertTrue($qtiParser->isValid());
+
+        $interactions = array_values($item->getInteractions());
+        $expected = [
+            'RESPONSE' => ['orientation' => null, 'reverse' => false],
+            'RESPONSE_1' => ['orientation' => 'horizontal', 'reverse' => false],
+            'RESPONSE_2' => ['orientation' => 'vertical', 'reverse' => false],
+            'RESPONSE_3' => ['orientation' => null, 'reverse' => true],
+            'RESPONSE_4' => ['orientation' => 'horizontal', 'reverse' => true],
+            'RESPONSE_5' => ['orientation' => 'vertical', 'reverse' => true],
+        ];
+
+        $this->assertCount(count($expected), $interactions);
+
+        foreach ($interactions as $interaction) {
+            $responseIdentifier = $interaction->getResponse()->getIdentifier();
+
+            $this->assertArrayHasKey($responseIdentifier, $expected);
+            $this->assertSame(
+                $expected[$responseIdentifier]['orientation'] ?? 'horizontal',
+                $interaction->getAttributeValue('orientation')
+            );
+            $this->assertSame(
+                $expected[$responseIdentifier]['reverse'],
+                $interaction->getAttributeValue('reverse')
+            );
+        }
+
+        $qti = $item->toXML();
+        $doc = new DOMDocument();
+        $doc->loadXML($qti);
+        $exportedSliders = $doc->getElementsByTagName('sliderInteraction');
+
+        $this->assertSame(count($expected), $exportedSliders->length);
+
+        foreach ($exportedSliders as $slider) {
+            $responseIdentifier = $slider->getAttribute('responseIdentifier');
+
+            $this->assertArrayHasKey($responseIdentifier, $expected);
+            $expectation = $expected[$responseIdentifier];
+
+            if ($expectation['orientation'] === 'vertical') {
+                $this->assertSame('vertical', $slider->getAttribute('orientation'));
+            } elseif ($expectation['orientation'] === 'horizontal') {
+                $this->assertSame(
+                    'horizontal',
+                    $slider->getAttribute('orientation')
+                );
+            } else {
+                $this->assertTrue(
+                    !$slider->hasAttribute('orientation')
+                        || $slider->getAttribute('orientation') === 'horizontal'
+                );
+            }
+
+            if ($expectation['reverse'] === true) {
+                $this->assertSame('true', $slider->getAttribute('reverse'));
+            } elseif ($expectation['reverse'] === false) {
+                $this->assertSame('false', $slider->getAttribute('reverse'));
+            } else {
+                $this->assertTrue(
+                    !$slider->hasAttribute('reverse')
+                        || $slider->getAttribute('reverse') === 'false'
+                );
+            }
+        }
+    }
+
+    /**
      * test the building and exporting out the items
      * @dataProvider itemProvider
      */

--- a/test/integration/samples/xml/qtiv2p1/slider-orientation-reverse-persistence.xml
+++ b/test/integration/samples/xml/qtiv2p1/slider-orientation-reverse-persistence.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+    identifier="slider-orientation-reverse-persistence"
+    title="Slider orientation reverse persistence"
+    label=""
+    adaptive="false"
+    timeDependent="false">
+    <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="integer"/>
+    <responseDeclaration identifier="RESPONSE_1" cardinality="single" baseType="integer"/>
+    <responseDeclaration identifier="RESPONSE_2" cardinality="single" baseType="integer"/>
+    <responseDeclaration identifier="RESPONSE_3" cardinality="single" baseType="integer"/>
+    <responseDeclaration identifier="RESPONSE_4" cardinality="single" baseType="integer"/>
+    <responseDeclaration identifier="RESPONSE_5" cardinality="single" baseType="integer"/>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <itemBody>
+        <p>Slider default orientation</p>
+        <sliderInteraction responseIdentifier="RESPONSE" lowerBound="0" upperBound="100" step="1" stepLabel="false" reverse="false"/>
+        <p>Slider horizontal</p>
+        <sliderInteraction responseIdentifier="RESPONSE_1" lowerBound="0" upperBound="100" step="1" stepLabel="false" orientation="horizontal" reverse="false"/>
+        <p>Slider vertical</p>
+        <sliderInteraction responseIdentifier="RESPONSE_2" lowerBound="0" upperBound="100" step="1" stepLabel="false" orientation="vertical" reverse="false"/>
+        <p>Slider default orientation, reversed</p>
+        <sliderInteraction responseIdentifier="RESPONSE_3" lowerBound="0" upperBound="100" step="1" stepLabel="false" reverse="true"/>
+        <p>Slider horizontal, reversed</p>
+        <sliderInteraction responseIdentifier="RESPONSE_4" lowerBound="0" upperBound="100" step="1" stepLabel="false" orientation="horizontal" reverse="true"/>
+        <p>Slider vertical, reversed</p>
+        <sliderInteraction responseIdentifier="RESPONSE_5" lowerBound="0" upperBound="100" step="1" stepLabel="false" orientation="vertical" reverse="true"/>
+    </itemBody>
+</assessmentItem>

--- a/views/js/test/qtiXmlRenderer/test.js
+++ b/views/js/test/qtiXmlRenderer/test.js
@@ -72,6 +72,228 @@ define([
         }
     ];
 
+    var sliderPersistenceItem = {
+        identifier: 'slider-orientation-reverse-persistence',
+        serial: 'item_slider_orientation_reverse_persistence',
+        qtiClass: 'assessmentItem',
+        attributes: {
+            identifier: 'slider-orientation-reverse-persistence',
+            title: 'Slider orientation reverse persistence',
+            label: '',
+            adaptive: false,
+            timeDependent: false,
+            toolName: 'TAO',
+            toolVersion: '3.0'
+        },
+        body: {
+            serial: 'container_slider_orientation_reverse_body',
+            body: '<p>Slider default orientation</p>{{interaction_slider_persistence_a}}' +
+                '<p>Slider horizontal</p>{{interaction_slider_persistence_b}}' +
+                '<p>Slider vertical</p>{{interaction_slider_persistence_c}}' +
+                '<p>Slider default orientation, reversed</p>{{interaction_slider_persistence_d}}' +
+                '<p>Slider horizontal, reversed</p>{{interaction_slider_persistence_e}}' +
+                '<p>Slider vertical, reversed</p>{{interaction_slider_persistence_f}}',
+            elements: {
+                interaction_slider_persistence_a: {
+                    serial: 'interaction_slider_persistence_a',
+                    qtiClass: 'sliderInteraction',
+                    attributes: {
+                        responseIdentifier: 'RESPONSE',
+                        lowerBound: 0,
+                        upperBound: 100,
+                        step: 1,
+                        stepLabel: false,
+                        reverse: false
+                    },
+                    choices: []
+                },
+                interaction_slider_persistence_b: {
+                    serial: 'interaction_slider_persistence_b',
+                    qtiClass: 'sliderInteraction',
+                    attributes: {
+                        responseIdentifier: 'RESPONSE_1',
+                        lowerBound: 0,
+                        upperBound: 100,
+                        step: 1,
+                        stepLabel: false,
+                        orientation: 'horizontal',
+                        reverse: false
+                    },
+                    choices: []
+                },
+                interaction_slider_persistence_c: {
+                    serial: 'interaction_slider_persistence_c',
+                    qtiClass: 'sliderInteraction',
+                    attributes: {
+                        responseIdentifier: 'RESPONSE_2',
+                        lowerBound: 0,
+                        upperBound: 100,
+                        step: 1,
+                        stepLabel: false,
+                        orientation: 'vertical',
+                        reverse: false
+                    },
+                    choices: []
+                },
+                interaction_slider_persistence_d: {
+                    serial: 'interaction_slider_persistence_d',
+                    qtiClass: 'sliderInteraction',
+                    attributes: {
+                        responseIdentifier: 'RESPONSE_3',
+                        lowerBound: 0,
+                        upperBound: 100,
+                        step: 1,
+                        stepLabel: false,
+                        reverse: true
+                    },
+                    choices: []
+                },
+                interaction_slider_persistence_e: {
+                    serial: 'interaction_slider_persistence_e',
+                    qtiClass: 'sliderInteraction',
+                    attributes: {
+                        responseIdentifier: 'RESPONSE_4',
+                        lowerBound: 0,
+                        upperBound: 100,
+                        step: 1,
+                        stepLabel: false,
+                        orientation: 'horizontal',
+                        reverse: true
+                    },
+                    choices: []
+                },
+                interaction_slider_persistence_f: {
+                    serial: 'interaction_slider_persistence_f',
+                    qtiClass: 'sliderInteraction',
+                    attributes: {
+                        responseIdentifier: 'RESPONSE_5',
+                        lowerBound: 0,
+                        upperBound: 100,
+                        step: 1,
+                        stepLabel: false,
+                        orientation: 'vertical',
+                        reverse: true
+                    },
+                    choices: []
+                }
+            }
+        },
+        namespaces: {
+            xml: 'http://www.w3.org/XML/1998/namespace',
+            xsi: 'http://www.w3.org/2001/XMLSchema-instance',
+            '': 'http://www.imsglobal.org/xsd/imsqti_v2p1'
+        },
+        outcomes: {
+            outcomedeclaration_slider_persistence_score: {
+                identifier: 'SCORE',
+                serial: 'outcomedeclaration_slider_persistence_score',
+                qtiClass: 'outcomeDeclaration',
+                attributes: {
+                    identifier: 'SCORE',
+                    cardinality: 'single',
+                    baseType: 'float'
+                },
+                defaultValue: null
+            }
+        },
+        responses: {
+            responsedeclaration_slider_persistence_response: {
+                identifier: 'RESPONSE',
+                serial: 'responsedeclaration_slider_persistence_response',
+                qtiClass: 'responseDeclaration',
+                attributes: {
+                    identifier: 'RESPONSE',
+                    cardinality: 'single',
+                    baseType: 'integer'
+                },
+                correctResponses: [],
+                mapping: [],
+                areaMapping: [],
+                feedbackRules: []
+            },
+            responsedeclaration_slider_persistence_response_1: {
+                identifier: 'RESPONSE_1',
+                serial: 'responsedeclaration_slider_persistence_response_1',
+                qtiClass: 'responseDeclaration',
+                attributes: {
+                    identifier: 'RESPONSE_1',
+                    cardinality: 'single',
+                    baseType: 'integer'
+                },
+                correctResponses: [],
+                mapping: [],
+                areaMapping: [],
+                feedbackRules: []
+            },
+            responsedeclaration_slider_persistence_response_2: {
+                identifier: 'RESPONSE_2',
+                serial: 'responsedeclaration_slider_persistence_response_2',
+                qtiClass: 'responseDeclaration',
+                attributes: {
+                    identifier: 'RESPONSE_2',
+                    cardinality: 'single',
+                    baseType: 'integer'
+                },
+                correctResponses: [],
+                mapping: [],
+                areaMapping: [],
+                feedbackRules: []
+            },
+            responsedeclaration_slider_persistence_response_3: {
+                identifier: 'RESPONSE_3',
+                serial: 'responsedeclaration_slider_persistence_response_3',
+                qtiClass: 'responseDeclaration',
+                attributes: {
+                    identifier: 'RESPONSE_3',
+                    cardinality: 'single',
+                    baseType: 'integer'
+                },
+                correctResponses: [],
+                mapping: [],
+                areaMapping: [],
+                feedbackRules: []
+            },
+            responsedeclaration_slider_persistence_response_4: {
+                identifier: 'RESPONSE_4',
+                serial: 'responsedeclaration_slider_persistence_response_4',
+                qtiClass: 'responseDeclaration',
+                attributes: {
+                    identifier: 'RESPONSE_4',
+                    cardinality: 'single',
+                    baseType: 'integer'
+                },
+                correctResponses: [],
+                mapping: [],
+                areaMapping: [],
+                feedbackRules: []
+            },
+            responsedeclaration_slider_persistence_response_5: {
+                identifier: 'RESPONSE_5',
+                serial: 'responsedeclaration_slider_persistence_response_5',
+                qtiClass: 'responseDeclaration',
+                attributes: {
+                    identifier: 'RESPONSE_5',
+                    cardinality: 'single',
+                    baseType: 'integer'
+                },
+                correctResponses: [],
+                mapping: [],
+                areaMapping: [],
+                feedbackRules: []
+            }
+        },
+        feedbacks: []
+    };
+
+    var expectedSliderAttributes = {
+        RESPONSE: { orientation: null, reverse: 'false' },
+        RESPONSE_1: { orientation: 'horizontal', reverse: 'false' },
+        RESPONSE_2: { orientation: 'vertical', reverse: 'false' },
+        RESPONSE_3: { orientation: null, reverse: 'true' },
+        RESPONSE_4: { orientation: 'horizontal', reverse: 'true' },
+        RESPONSE_5: { orientation: 'vertical', reverse: 'true' }
+    };
+
     QUnit
         .cases.init(items)
         .test('xml rendering', function(sample, assert) {
@@ -104,5 +326,69 @@ define([
             });
 
         });
+
+    QUnit.test('slider orientation and reverse attributes are persisted in exported XML', function(assert) {
+        var ready = assert.async();
+        var loader = new Loader();
+        var renderer = new Renderer({
+            shuffleChoices: false,
+            runtimeContext: {
+                runtime_base_www: '/taoQtiItem/test/samples/test_base_www/',
+                root_url: '',
+                debug: true
+            }
+        });
+
+        loader.loadItemData(sliderPersistenceItem, function(item) {
+            assert.ok(Element.isA(item, 'assessmentItem'), 'slider persistence fixture item loaded');
+
+            renderer.load(function() {
+                var xml;
+                var doc;
+                var sliders;
+                var slider;
+                var expected;
+                var responseIdentifier;
+                var i;
+
+                item.setRenderer(renderer);
+                xml = item.render();
+                doc = new DOMParser().parseFromString(xml, 'application/xml');
+                sliders = doc.getElementsByTagName('sliderInteraction');
+
+                assert.equal(sliders.length, 6, 'six slider interactions are exported');
+
+                for (i = 0; i < sliders.length; i++) {
+                    slider = sliders[i];
+                    responseIdentifier = slider.getAttribute('responseIdentifier');
+                    expected = expectedSliderAttributes[responseIdentifier];
+
+                    assert.ok(expected, responseIdentifier + ' is part of the slider persistence fixture');
+
+                    if (expected.orientation) {
+                        assert.equal(
+                            slider.getAttribute('orientation'),
+                            expected.orientation,
+                            responseIdentifier + ' orientation is exported'
+                        );
+                    } else {
+                        assert.ok(
+                            !slider.hasAttribute('orientation') ||
+                                slider.getAttribute('orientation') === 'horizontal',
+                            responseIdentifier + ' keeps horizontal default orientation'
+                        );
+                    }
+
+                    assert.equal(
+                        slider.getAttribute('reverse'),
+                        expected.reverse,
+                        responseIdentifier + ' reverse is exported'
+                    );
+                }
+
+                ready();
+            }, this.getLoadedClasses());
+        });
+    });
 
 });


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4605

## What's Changed

- extend test suite to validate slider orientation and reverse

## How to test
- Run unit tests

## Video

https://github.com/user-attachments/assets/7239d5c7-036f-4bee-baa5-2aa87611485d




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration and client-side tests to confirm slider interactions retain orientation and reverse settings through item load, render, and QTI XML export.
  * Asserts the exported XML contains the expected number of slider elements and that each element’s reverse attribute and orientation are preserved or correctly defaulted/omitted when not explicitly set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->