### PR TITLE
fix: INF-477 backport to v32.5.13.1

### DIFF
--- a/model/QtiJsonItemCompiler.php
+++ b/model/QtiJsonItemCompiler.php
@@ -105,7 +105,12 @@ class QtiJsonItemCompiler extends QtiItemCompiler
             $publicLangDirectory = $publicDirectory->getDirectory($language);
 
             // retrieve the media assets
-            $packedAssets = $this->parseAndReplaceAssetByPlaceholder($qtiItem, $resolver, $publicLangDirectory);
+            $this->parseAndReplaceAssetByPlaceholder(
+                $qtiItem,
+                $resolver,
+                $publicLangDirectory,
+                $publicDirectory->getId()
+            );
 
             $this->compileItemIndex($item->getUri(), $qtiItem, $language);
 
@@ -177,12 +182,14 @@ class QtiJsonItemCompiler extends QtiItemCompiler
     private function parseAndReplaceAssetByPlaceholder(
         Item &$qtiItem,
         ItemMediaResolver $resolver,
-        Directory $publicLangDirectory
+        Directory $publicLangDirectory,
+        string $deliveryCompilationId
     ) {
         $packedAssets = $this->getQtiItemAssetCompiler()->extractAndCopyAssetFiles(
             $qtiItem,
             $publicLangDirectory,
-            $resolver
+            $resolver,
+            $deliveryCompilationId
         );
 
         $dom = new DOMDocument('1.0', 'UTF-8');

--- a/model/compile/QtiAssetCompiler/QtiItemAssetCompiler.php
+++ b/model/compile/QtiAssetCompiler/QtiItemAssetCompiler.php
@@ -50,7 +50,8 @@ class QtiItemAssetCompiler extends ConfigurationService
     public function extractAndCopyAssetFiles(
         Item $qtiItem,
         Directory $publicDirectory,
-        ItemMediaResolver $resolver
+        ItemMediaResolver $resolver,
+        string $deliveryCompilationId = ''
     ): array {
         $assetParser = new AssetParser($qtiItem, $publicDirectory);
         $assetParser->setGetSharedLibraries(false);
@@ -80,7 +81,11 @@ class QtiItemAssetCompiler extends ConfigurationService
 
                 if ($type != 'xinclude') {
                     if ($this->getQtiItemAssetReplacer()->shouldBeReplaced($packedAsset)) {
-                        $packedAsset = $this->replaceWithExternalSource($packedAsset, $qtiItem);
+                        $packedAsset = $this->replaceWithExternalSource(
+                            $packedAsset,
+                            $qtiItem,
+                            $deliveryCompilationId
+                        );
                     } else {
                         $this->copyAssetFileToPublicDirectory($publicDirectory, $packedAsset);
                     }
@@ -92,12 +97,17 @@ class QtiItemAssetCompiler extends ConfigurationService
         return $packedAssets;
     }
 
-    private function replaceWithExternalSource(PackedAsset $packedAsset, Item $qtiItem): PackedAsset
+    private function replaceWithExternalSource(
+        PackedAsset $packedAsset,
+        Item $qtiItem,
+        string $deliveryCompilationId
+    ): PackedAsset
     {
         $qtiItemAssetReplacer = $this->getQtiItemAssetReplacer();
         return $qtiItemAssetReplacer->replace(
             $packedAsset,
-            $qtiItem->getIdentifier()
+            (string) $qtiItem->getIdentifier(),
+            $deliveryCompilationId
         );
     }
 

--- a/model/compile/QtiAssetReplacer/NullQtiItemAssetReplacer.php
+++ b/model/compile/QtiAssetReplacer/NullQtiItemAssetReplacer.php
@@ -33,7 +33,11 @@ class NullQtiItemAssetReplacer extends ConfigurableService implements QtiItemAss
         return false;
     }
 
-    public function replace(PackedAsset $packetAsset, $itemId): PackedAsset
+    public function replace(
+        PackedAsset $packetAsset,
+        string $itemId,
+        string $deliveryCompilationId = ''
+    ): PackedAsset
     {
         return $packetAsset;
     }

--- a/model/compile/QtiAssetReplacer/QtiItemAssetReplacer.php
+++ b/model/compile/QtiAssetReplacer/QtiItemAssetReplacer.php
@@ -102,7 +102,12 @@ interface QtiItemAssetReplacer
      * Replace the current asset with the external
      * @param PackedAsset $packetAsset
      * @param string $itemId
+     * @param string $deliveryCompilationId
      * @return PackedAsset
      */
-    public function replace(PackedAsset $packetAsset, string $itemId): PackedAsset;
+    public function replace(
+        PackedAsset $packetAsset,
+        string $itemId,
+        string $deliveryCompilationId = ''
+    ): PackedAsset;
 }


### PR DESCRIPTION
## Summary

Backport of **INF-477** to **v32.5.13.1**.

- pass `deliveryCompilationId` from `QtiJsonItemCompiler` into `QtiItemAssetCompiler`
- extend `QtiItemAssetReplacer` contract with optional `deliveryCompilationId`
- forward the new argument through replacer call sites for CloudFront key scoping

## Problem

Assets published with the same item identifier and filename could collide because the replacement flow had no publish-specific segment.

## Validation

- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoQtiItem/test/unit/model/compile/QtiItemAssetCompilerTest.php`
- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoQtiItem/test/unit/model/QtiJsonItemCompilerTest.php`

## Notes

- this PR is a backport-only change for release branch `release/2026.07-v32.5.13.1`
- paired with `lib-generis-aws` changes from the same ticket
