### PR TITLE
fix: AUT-4172 backport minMax enableField config sync for v31.0.19

### DIFF
--- a/views/js/qtiCreator/widgets/component/minMax/minMax.js
+++ b/views/js/qtiCreator/widgets/component/minMax/minMax.js
@@ -341,6 +341,9 @@ define([
                             valueToSet = initialValue > 1 ? initialValue : 1;
                         }
 
+                        // Keep config in sync before input 'change' so convertToNumber and isFieldEnabled see enabled state
+                        config[field].value = valueToSet;
+
                         controls[field].input
                             .val(valueToSet)
                             .incrementer('enable')


### PR DESCRIPTION
**Backport:**
- [fix] [AUT-4172](https://oat-sa.atlassian.net/browse/AUT-4172) Sync minMax config before enableField change ([0c5430657](https://github.com/oat-sa/extension-tao-itemqti/commit/0c543065718795a7027d0fad1652086e96e29fa8))

Related community CI failure: [tao-community#770](https://github.com/oat-sa/tao-community/pull/770)

Target release branch: `release-31.0.19`
Target release tag: `v31.0.19`


[AUT-4172]: https://oat-sa.atlassian.net/browse/AUT-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ