### PR TITLE
fix(NIV-253): refresh translations after multi-field scoring

### DIFF
--- a/locales/ar-SA/messages.po
+++ b/locales/ar-SA/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:24\n"
+"PO-Revision-Date: 2026-07-31T12:35:02\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ar-SA\n"

--- a/locales/ar-SA/qtiItemRunner.rdf.po
+++ b/locales/ar-SA/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:24\n"
+"PO-Revision-Date: 2026-07-31T12:35:02\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ar-SA\n"

--- a/locales/ar-SA/taoQti.rdf.po
+++ b/locales/ar-SA/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:24\n"
+"PO-Revision-Date: 2026-07-31T12:35:02\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ar-SA\n"

--- a/locales/ar-arb/messages.po
+++ b/locales/ar-arb/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:26\n"
+"PO-Revision-Date: 2026-07-31T12:35:05\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ar-arb\n"

--- a/locales/ar-arb/qtiItemRunner.rdf.po
+++ b/locales/ar-arb/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:27\n"
+"PO-Revision-Date: 2026-07-31T12:35:05\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ar-arb\n"

--- a/locales/ar-arb/taoQti.rdf.po
+++ b/locales/ar-arb/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:26\n"
+"PO-Revision-Date: 2026-07-31T12:35:05\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ar-arb\n"

--- a/locales/da-DK/messages.po
+++ b/locales/da-DK/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:29\n"
+"PO-Revision-Date: 2026-07-31T12:35:07\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: da-DK\n"

--- a/locales/da-DK/qtiItemRunner.rdf.po
+++ b/locales/da-DK/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:29\n"
+"PO-Revision-Date: 2026-07-31T12:35:07\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: da-DK\n"

--- a/locales/da-DK/taoQti.rdf.po
+++ b/locales/da-DK/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:29\n"
+"PO-Revision-Date: 2026-07-31T12:35:07\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: da-DK\n"

--- a/locales/de-AT/messages.po
+++ b/locales/de-AT/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:31\n"
+"PO-Revision-Date: 2026-07-31T12:35:09\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-AT\n"

--- a/locales/de-AT/qtiItemRunner.rdf.po
+++ b/locales/de-AT/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:31\n"
+"PO-Revision-Date: 2026-07-31T12:35:09\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-AT\n"

--- a/locales/de-AT/taoQti.rdf.po
+++ b/locales/de-AT/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:31\n"
+"PO-Revision-Date: 2026-07-31T12:35:09\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-AT\n"

--- a/locales/de-BE/messages.po
+++ b/locales/de-BE/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:33\n"
+"PO-Revision-Date: 2026-07-31T12:35:11\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-BE\n"

--- a/locales/de-BE/qtiItemRunner.rdf.po
+++ b/locales/de-BE/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:33\n"
+"PO-Revision-Date: 2026-07-31T12:35:11\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-BE\n"

--- a/locales/de-BE/taoQti.rdf.po
+++ b/locales/de-BE/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:33\n"
+"PO-Revision-Date: 2026-07-31T12:35:11\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-BE\n"

--- a/locales/de-CH/messages.po
+++ b/locales/de-CH/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:35\n"
+"PO-Revision-Date: 2026-07-31T12:35:13\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-CH\n"

--- a/locales/de-CH/qtiItemRunner.rdf.po
+++ b/locales/de-CH/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:35\n"
+"PO-Revision-Date: 2026-07-31T12:35:13\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-CH\n"

--- a/locales/de-CH/taoQti.rdf.po
+++ b/locales/de-CH/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:35\n"
+"PO-Revision-Date: 2026-07-31T12:35:13\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-CH\n"

--- a/locales/de-DE/messages.po
+++ b/locales/de-DE/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:37\n"
+"PO-Revision-Date: 2026-07-31T12:35:15\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-DE\n"

--- a/locales/de-DE/qtiItemRunner.rdf.po
+++ b/locales/de-DE/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:37\n"
+"PO-Revision-Date: 2026-07-31T12:35:15\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-DE\n"

--- a/locales/de-DE/taoQti.rdf.po
+++ b/locales/de-DE/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:37\n"
+"PO-Revision-Date: 2026-07-31T12:35:15\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-DE\n"

--- a/locales/de-LI/messages.po
+++ b/locales/de-LI/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:39\n"
+"PO-Revision-Date: 2026-07-31T12:35:17\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-LI\n"

--- a/locales/de-LI/qtiItemRunner.rdf.po
+++ b/locales/de-LI/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:39\n"
+"PO-Revision-Date: 2026-07-31T12:35:17\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-LI\n"

--- a/locales/de-LI/taoQti.rdf.po
+++ b/locales/de-LI/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:39\n"
+"PO-Revision-Date: 2026-07-31T12:35:17\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-LI\n"

--- a/locales/de-LU/messages.po
+++ b/locales/de-LU/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:41\n"
+"PO-Revision-Date: 2026-07-31T12:35:19\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-LU\n"

--- a/locales/de-LU/qtiItemRunner.rdf.po
+++ b/locales/de-LU/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:41\n"
+"PO-Revision-Date: 2026-07-31T12:35:19\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-LU\n"

--- a/locales/de-LU/taoQti.rdf.po
+++ b/locales/de-LU/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:41\n"
+"PO-Revision-Date: 2026-07-31T12:35:19\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: de-LU\n"

--- a/locales/el-GR/messages.po
+++ b/locales/el-GR/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:43\n"
+"PO-Revision-Date: 2026-07-31T12:35:21\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: el-GR\n"

--- a/locales/el-GR/qtiItemRunner.rdf.po
+++ b/locales/el-GR/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:43\n"
+"PO-Revision-Date: 2026-07-31T12:35:21\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: el-GR\n"

--- a/locales/el-GR/taoQti.rdf.po
+++ b/locales/el-GR/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:43\n"
+"PO-Revision-Date: 2026-07-31T12:35:21\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: el-GR\n"

--- a/locales/en-GB/messages.po
+++ b/locales/en-GB/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:45\n"
+"PO-Revision-Date: 2026-07-31T12:35:23\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-GB\n"

--- a/locales/en-GB/qtiItemRunner.rdf.po
+++ b/locales/en-GB/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:45\n"
+"PO-Revision-Date: 2026-07-31T12:35:23\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-GB\n"

--- a/locales/en-GB/taoQti.rdf.po
+++ b/locales/en-GB/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:45\n"
+"PO-Revision-Date: 2026-07-31T12:35:23\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-GB\n"

--- a/locales/en-US/messages.po
+++ b/locales/en-US/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:49\n"
+"PO-Revision-Date: 2026-07-31T12:35:25\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-US\n"

--- a/locales/en-US/qtiItemRunner.rdf.po
+++ b/locales/en-US/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:49\n"
+"PO-Revision-Date: 2026-07-31T12:35:25\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-US\n"

--- a/locales/en-US/taoQti.rdf.po
+++ b/locales/en-US/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:49\n"
+"PO-Revision-Date: 2026-07-31T12:35:25\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-US\n"

--- a/locales/es-CR/messages.po
+++ b/locales/es-CR/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:52\n"
+"PO-Revision-Date: 2026-07-31T12:35:27\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-CR\n"

--- a/locales/es-CR/qtiItemRunner.rdf.po
+++ b/locales/es-CR/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:52\n"
+"PO-Revision-Date: 2026-07-31T12:35:27\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-CR\n"

--- a/locales/es-CR/taoQti.rdf.po
+++ b/locales/es-CR/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:52\n"
+"PO-Revision-Date: 2026-07-31T12:35:27\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-CR\n"

--- a/locales/es-ES/messages.po
+++ b/locales/es-ES/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:54\n"
+"PO-Revision-Date: 2026-07-31T12:35:29\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-ES\n"

--- a/locales/es-ES/qtiItemRunner.rdf.po
+++ b/locales/es-ES/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:54\n"
+"PO-Revision-Date: 2026-07-31T12:35:29\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-ES\n"

--- a/locales/es-ES/taoQti.rdf.po
+++ b/locales/es-ES/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:54\n"
+"PO-Revision-Date: 2026-07-31T12:35:29\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-ES\n"

--- a/locales/es-MX/messages.po
+++ b/locales/es-MX/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:56\n"
+"PO-Revision-Date: 2026-07-31T12:35:31\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-MX\n"

--- a/locales/es-MX/qtiItemRunner.rdf.po
+++ b/locales/es-MX/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:56\n"
+"PO-Revision-Date: 2026-07-31T12:35:31\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-MX\n"

--- a/locales/es-MX/taoQti.rdf.po
+++ b/locales/es-MX/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:56\n"
+"PO-Revision-Date: 2026-07-31T12:35:31\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: es-MX\n"

--- a/locales/fa-IR/messages.po
+++ b/locales/fa-IR/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:58\n"
+"PO-Revision-Date: 2026-07-31T12:35:33\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fa-IR\n"

--- a/locales/fa-IR/qtiItemRunner.rdf.po
+++ b/locales/fa-IR/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:58\n"
+"PO-Revision-Date: 2026-07-31T12:35:33\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fa-IR\n"

--- a/locales/fa-IR/taoQti.rdf.po
+++ b/locales/fa-IR/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:45:58\n"
+"PO-Revision-Date: 2026-07-31T12:35:33\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fa-IR\n"

--- a/locales/fi-FI/messages.po
+++ b/locales/fi-FI/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:00\n"
+"PO-Revision-Date: 2026-07-31T12:35:35\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fi-FI\n"

--- a/locales/fi-FI/qtiItemRunner.rdf.po
+++ b/locales/fi-FI/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:00\n"
+"PO-Revision-Date: 2026-07-31T12:35:35\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fi-FI\n"

--- a/locales/fi-FI/taoQti.rdf.po
+++ b/locales/fi-FI/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:00\n"
+"PO-Revision-Date: 2026-07-31T12:35:35\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fi-FI\n"

--- a/locales/fr-BE/messages.po
+++ b/locales/fr-BE/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:03\n"
+"PO-Revision-Date: 2026-07-31T12:35:37\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-BE\n"

--- a/locales/fr-BE/qtiItemRunner.rdf.po
+++ b/locales/fr-BE/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:03\n"
+"PO-Revision-Date: 2026-07-31T12:35:37\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-BE\n"

--- a/locales/fr-BE/taoQti.rdf.po
+++ b/locales/fr-BE/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:03\n"
+"PO-Revision-Date: 2026-07-31T12:35:37\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-BE\n"

--- a/locales/fr-CA/messages.po
+++ b/locales/fr-CA/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:05\n"
+"PO-Revision-Date: 2026-07-31T12:35:40\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-CA\n"

--- a/locales/fr-CA/qtiItemRunner.rdf.po
+++ b/locales/fr-CA/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:05\n"
+"PO-Revision-Date: 2026-07-31T12:35:40\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-CA\n"

--- a/locales/fr-CA/taoQti.rdf.po
+++ b/locales/fr-CA/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:05\n"
+"PO-Revision-Date: 2026-07-31T12:35:40\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-CA\n"

--- a/locales/fr-CH/messages.po
+++ b/locales/fr-CH/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:07\n"
+"PO-Revision-Date: 2026-07-31T12:35:42\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-CH\n"

--- a/locales/fr-CH/qtiItemRunner.rdf.po
+++ b/locales/fr-CH/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:07\n"
+"PO-Revision-Date: 2026-07-31T12:35:42\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-CH\n"

--- a/locales/fr-CH/taoQti.rdf.po
+++ b/locales/fr-CH/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:07\n"
+"PO-Revision-Date: 2026-07-31T12:35:42\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-CH\n"

--- a/locales/fr-FR/messages.po
+++ b/locales/fr-FR/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:09\n"
+"PO-Revision-Date: 2026-07-31T12:35:44\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-FR\n"

--- a/locales/fr-FR/qtiItemRunner.rdf.po
+++ b/locales/fr-FR/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:09\n"
+"PO-Revision-Date: 2026-07-31T12:35:44\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-FR\n"

--- a/locales/fr-FR/taoQti.rdf.po
+++ b/locales/fr-FR/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:09\n"
+"PO-Revision-Date: 2026-07-31T12:35:44\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-FR\n"

--- a/locales/fr-LU/messages.po
+++ b/locales/fr-LU/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:12\n"
+"PO-Revision-Date: 2026-07-31T12:35:46\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-LU\n"

--- a/locales/fr-LU/qtiItemRunner.rdf.po
+++ b/locales/fr-LU/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:12\n"
+"PO-Revision-Date: 2026-07-31T12:35:46\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-LU\n"

--- a/locales/fr-LU/taoQti.rdf.po
+++ b/locales/fr-LU/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:12\n"
+"PO-Revision-Date: 2026-07-31T12:35:46\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-LU\n"

--- a/locales/fr-QC/messages.po
+++ b/locales/fr-QC/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:14\n"
+"PO-Revision-Date: 2026-07-31T12:35:48\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-QC\n"

--- a/locales/fr-QC/qtiItemRunner.rdf.po
+++ b/locales/fr-QC/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:14\n"
+"PO-Revision-Date: 2026-07-31T12:35:48\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-QC\n"

--- a/locales/fr-QC/taoQti.rdf.po
+++ b/locales/fr-QC/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:14\n"
+"PO-Revision-Date: 2026-07-31T12:35:48\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: fr-QC\n"

--- a/locales/gl-ES/messages.po
+++ b/locales/gl-ES/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:16\n"
+"PO-Revision-Date: 2026-07-31T12:35:50\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: gl-ES\n"

--- a/locales/gl-ES/qtiItemRunner.rdf.po
+++ b/locales/gl-ES/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:16\n"
+"PO-Revision-Date: 2026-07-31T12:35:50\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: gl-ES\n"

--- a/locales/gl-ES/taoQti.rdf.po
+++ b/locales/gl-ES/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:16\n"
+"PO-Revision-Date: 2026-07-31T12:35:50\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: gl-ES\n"

--- a/locales/he-IL/messages.po
+++ b/locales/he-IL/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:18\n"
+"PO-Revision-Date: 2026-07-31T12:35:52\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: he-IL\n"

--- a/locales/he-IL/qtiItemRunner.rdf.po
+++ b/locales/he-IL/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:18\n"
+"PO-Revision-Date: 2026-07-31T12:35:52\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: he-IL\n"

--- a/locales/he-IL/taoQti.rdf.po
+++ b/locales/he-IL/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:18\n"
+"PO-Revision-Date: 2026-07-31T12:35:52\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: he-IL\n"

--- a/locales/hu-HU/messages.po
+++ b/locales/hu-HU/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:20\n"
+"PO-Revision-Date: 2026-07-31T12:35:54\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: hu-HU\n"

--- a/locales/hu-HU/qtiItemRunner.rdf.po
+++ b/locales/hu-HU/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:20\n"
+"PO-Revision-Date: 2026-07-31T12:35:54\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: hu-HU\n"

--- a/locales/hu-HU/taoQti.rdf.po
+++ b/locales/hu-HU/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:20\n"
+"PO-Revision-Date: 2026-07-31T12:35:54\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: hu-HU\n"

--- a/locales/id-ID/messages.po
+++ b/locales/id-ID/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:22\n"
+"PO-Revision-Date: 2026-07-31T12:35:56\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: id-ID\n"

--- a/locales/id-ID/qtiItemRunner.rdf.po
+++ b/locales/id-ID/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:22\n"
+"PO-Revision-Date: 2026-07-31T12:35:56\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: id-ID\n"

--- a/locales/id-ID/taoQti.rdf.po
+++ b/locales/id-ID/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:22\n"
+"PO-Revision-Date: 2026-07-31T12:35:56\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: id-ID\n"

--- a/locales/is-IS/messages.po
+++ b/locales/is-IS/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:24\n"
+"PO-Revision-Date: 2026-07-31T12:35:58\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: is-IS\n"

--- a/locales/is-IS/qtiItemRunner.rdf.po
+++ b/locales/is-IS/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:24\n"
+"PO-Revision-Date: 2026-07-31T12:35:58\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: is-IS\n"

--- a/locales/is-IS/taoQti.rdf.po
+++ b/locales/is-IS/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:24\n"
+"PO-Revision-Date: 2026-07-31T12:35:58\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: is-IS\n"

--- a/locales/it-IT/messages.po
+++ b/locales/it-IT/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:26\n"
+"PO-Revision-Date: 2026-07-31T12:36:00\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: it-IT\n"

--- a/locales/it-IT/qtiItemRunner.rdf.po
+++ b/locales/it-IT/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:26\n"
+"PO-Revision-Date: 2026-07-31T12:36:00\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: it-IT\n"

--- a/locales/it-IT/taoQti.rdf.po
+++ b/locales/it-IT/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:26\n"
+"PO-Revision-Date: 2026-07-31T12:36:00\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: it-IT\n"

--- a/locales/ja-HS/messages.po
+++ b/locales/ja-HS/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:29\n"
+"PO-Revision-Date: 2026-07-31T12:36:02\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-HS\n"

--- a/locales/ja-HS/qtiItemRunner.rdf.po
+++ b/locales/ja-HS/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:29\n"
+"PO-Revision-Date: 2026-07-31T12:36:02\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-HS\n"

--- a/locales/ja-HS/taoQti.rdf.po
+++ b/locales/ja-HS/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:29\n"
+"PO-Revision-Date: 2026-07-31T12:36:02\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-HS\n"

--- a/locales/ja-JP/messages.po
+++ b/locales/ja-JP/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:31\n"
+"PO-Revision-Date: 2026-07-31T12:36:04\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-JP\n"

--- a/locales/ja-JP/qtiItemRunner.rdf.po
+++ b/locales/ja-JP/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:31\n"
+"PO-Revision-Date: 2026-07-31T12:36:04\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-JP\n"

--- a/locales/ja-JP/taoQti.rdf.po
+++ b/locales/ja-JP/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:31\n"
+"PO-Revision-Date: 2026-07-31T12:36:04\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-JP\n"

--- a/locales/ja-LE/messages.po
+++ b/locales/ja-LE/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:33\n"
+"PO-Revision-Date: 2026-07-31T12:36:06\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-LE\n"

--- a/locales/ja-LE/qtiItemRunner.rdf.po
+++ b/locales/ja-LE/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:33\n"
+"PO-Revision-Date: 2026-07-31T12:36:06\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-LE\n"

--- a/locales/ja-LE/taoQti.rdf.po
+++ b/locales/ja-LE/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:33\n"
+"PO-Revision-Date: 2026-07-31T12:36:06\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-LE\n"

--- a/locales/ja-UE/messages.po
+++ b/locales/ja-UE/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:35\n"
+"PO-Revision-Date: 2026-07-31T12:36:08\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-UE\n"

--- a/locales/ja-UE/qtiItemRunner.rdf.po
+++ b/locales/ja-UE/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:35\n"
+"PO-Revision-Date: 2026-07-31T12:36:08\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-UE\n"

--- a/locales/ja-UE/taoQti.rdf.po
+++ b/locales/ja-UE/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:35\n"
+"PO-Revision-Date: 2026-07-31T12:36:08\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ja-UE\n"

--- a/locales/lb-LU/messages.po
+++ b/locales/lb-LU/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:37\n"
+"PO-Revision-Date: 2026-07-31T12:36:10\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: lb-LU\n"

--- a/locales/lb-LU/qtiItemRunner.rdf.po
+++ b/locales/lb-LU/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:37\n"
+"PO-Revision-Date: 2026-07-31T12:36:10\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: lb-LU\n"

--- a/locales/lb-LU/taoQti.rdf.po
+++ b/locales/lb-LU/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:37\n"
+"PO-Revision-Date: 2026-07-31T12:36:10\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: lb-LU\n"

--- a/locales/lt-LT/messages.po
+++ b/locales/lt-LT/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:39\n"
+"PO-Revision-Date: 2026-07-31T12:36:12\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: lt-LT\n"

--- a/locales/lt-LT/qtiItemRunner.rdf.po
+++ b/locales/lt-LT/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:39\n"
+"PO-Revision-Date: 2026-07-31T12:36:12\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: lt-LT\n"

--- a/locales/lt-LT/taoQti.rdf.po
+++ b/locales/lt-LT/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:39\n"
+"PO-Revision-Date: 2026-07-31T12:36:12\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: lt-LT\n"

--- a/locales/nb-NO/messages.po
+++ b/locales/nb-NO/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:41\n"
+"PO-Revision-Date: 2026-07-31T12:36:14\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nb-NO\n"

--- a/locales/nb-NO/qtiItemRunner.rdf.po
+++ b/locales/nb-NO/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:41\n"
+"PO-Revision-Date: 2026-07-31T12:36:14\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nb-NO\n"

--- a/locales/nb-NO/taoQti.rdf.po
+++ b/locales/nb-NO/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:41\n"
+"PO-Revision-Date: 2026-07-31T12:36:14\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nb-NO\n"

--- a/locales/ne-NP/messages.po
+++ b/locales/ne-NP/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:44\n"
+"PO-Revision-Date: 2026-07-31T12:36:17\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ne-NP\n"

--- a/locales/ne-NP/qtiItemRunner.rdf.po
+++ b/locales/ne-NP/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:44\n"
+"PO-Revision-Date: 2026-07-31T12:36:17\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ne-NP\n"

--- a/locales/ne-NP/taoQti.rdf.po
+++ b/locales/ne-NP/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:44\n"
+"PO-Revision-Date: 2026-07-31T12:36:17\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ne-NP\n"

--- a/locales/nl-BE/messages.po
+++ b/locales/nl-BE/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:46\n"
+"PO-Revision-Date: 2026-07-31T12:36:19\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-BE\n"

--- a/locales/nl-BE/qtiItemRunner.rdf.po
+++ b/locales/nl-BE/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:46\n"
+"PO-Revision-Date: 2026-07-31T12:36:19\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-BE\n"

--- a/locales/nl-BE/taoQti.rdf.po
+++ b/locales/nl-BE/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:46\n"
+"PO-Revision-Date: 2026-07-31T12:36:19\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-BE\n"

--- a/locales/nl-NL/messages.po
+++ b/locales/nl-NL/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:48\n"
+"PO-Revision-Date: 2026-07-31T12:36:21\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-NL\n"

--- a/locales/nl-NL/qtiItemRunner.rdf.po
+++ b/locales/nl-NL/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:48\n"
+"PO-Revision-Date: 2026-07-31T12:36:21\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-NL\n"

--- a/locales/nl-NL/taoQti.rdf.po
+++ b/locales/nl-NL/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:48\n"
+"PO-Revision-Date: 2026-07-31T12:36:21\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-NL\n"

--- a/locales/nl-SR/messages.po
+++ b/locales/nl-SR/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:50\n"
+"PO-Revision-Date: 2026-07-31T12:36:23\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-SR\n"

--- a/locales/nl-SR/qtiItemRunner.rdf.po
+++ b/locales/nl-SR/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:50\n"
+"PO-Revision-Date: 2026-07-31T12:36:23\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-SR\n"

--- a/locales/nl-SR/taoQti.rdf.po
+++ b/locales/nl-SR/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:50\n"
+"PO-Revision-Date: 2026-07-31T12:36:23\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nl-SR\n"

--- a/locales/nn-NO/messages.po
+++ b/locales/nn-NO/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:52\n"
+"PO-Revision-Date: 2026-07-31T12:36:25\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nn-NO\n"

--- a/locales/nn-NO/qtiItemRunner.rdf.po
+++ b/locales/nn-NO/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:52\n"
+"PO-Revision-Date: 2026-07-31T12:36:25\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nn-NO\n"

--- a/locales/nn-NO/taoQti.rdf.po
+++ b/locales/nn-NO/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:52\n"
+"PO-Revision-Date: 2026-07-31T12:36:25\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: nn-NO\n"

--- a/locales/no-NO/messages.po
+++ b/locales/no-NO/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:54\n"
+"PO-Revision-Date: 2026-07-31T12:36:27\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: no-NO\n"

--- a/locales/no-NO/qtiItemRunner.rdf.po
+++ b/locales/no-NO/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:54\n"
+"PO-Revision-Date: 2026-07-31T12:36:27\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: no-NO\n"

--- a/locales/no-NO/taoQti.rdf.po
+++ b/locales/no-NO/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:54\n"
+"PO-Revision-Date: 2026-07-31T12:36:27\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: no-NO\n"

--- a/locales/pl-PL/messages.po
+++ b/locales/pl-PL/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:56\n"
+"PO-Revision-Date: 2026-07-31T12:36:29\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pl-PL\n"

--- a/locales/pl-PL/qtiItemRunner.rdf.po
+++ b/locales/pl-PL/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:56\n"
+"PO-Revision-Date: 2026-07-31T12:36:29\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pl-PL\n"

--- a/locales/pl-PL/taoQti.rdf.po
+++ b/locales/pl-PL/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:56\n"
+"PO-Revision-Date: 2026-07-31T12:36:29\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pl-PL\n"

--- a/locales/pt-BR/messages.po
+++ b/locales/pt-BR/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:58\n"
+"PO-Revision-Date: 2026-07-31T12:36:31\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pt-BR\n"

--- a/locales/pt-BR/qtiItemRunner.rdf.po
+++ b/locales/pt-BR/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:58\n"
+"PO-Revision-Date: 2026-07-31T12:36:31\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pt-BR\n"

--- a/locales/pt-BR/taoQti.rdf.po
+++ b/locales/pt-BR/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:46:58\n"
+"PO-Revision-Date: 2026-07-31T12:36:31\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pt-BR\n"

--- a/locales/pt-PT/messages.po
+++ b/locales/pt-PT/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:01\n"
+"PO-Revision-Date: 2026-07-31T12:36:33\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pt-PT\n"

--- a/locales/pt-PT/qtiItemRunner.rdf.po
+++ b/locales/pt-PT/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:01\n"
+"PO-Revision-Date: 2026-07-31T12:36:33\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pt-PT\n"

--- a/locales/pt-PT/taoQti.rdf.po
+++ b/locales/pt-PT/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:01\n"
+"PO-Revision-Date: 2026-07-31T12:36:33\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: pt-PT\n"

--- a/locales/ro-RO/messages.po
+++ b/locales/ro-RO/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:03\n"
+"PO-Revision-Date: 2026-07-31T12:36:35\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ro-RO\n"

--- a/locales/ro-RO/qtiItemRunner.rdf.po
+++ b/locales/ro-RO/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:03\n"
+"PO-Revision-Date: 2026-07-31T12:36:35\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ro-RO\n"

--- a/locales/ro-RO/taoQti.rdf.po
+++ b/locales/ro-RO/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:03\n"
+"PO-Revision-Date: 2026-07-31T12:36:35\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ro-RO\n"

--- a/locales/ru-RU/messages.po
+++ b/locales/ru-RU/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:05\n"
+"PO-Revision-Date: 2026-07-31T12:36:37\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ru-RU\n"

--- a/locales/ru-RU/qtiItemRunner.rdf.po
+++ b/locales/ru-RU/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:05\n"
+"PO-Revision-Date: 2026-07-31T12:36:37\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ru-RU\n"

--- a/locales/ru-RU/taoQti.rdf.po
+++ b/locales/ru-RU/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:05\n"
+"PO-Revision-Date: 2026-07-31T12:36:37\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: ru-RU\n"

--- a/locales/sk-SK/messages.po
+++ b/locales/sk-SK/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:07\n"
+"PO-Revision-Date: 2026-07-31T12:36:39\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: sk-SK\n"

--- a/locales/sk-SK/qtiItemRunner.rdf.po
+++ b/locales/sk-SK/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:07\n"
+"PO-Revision-Date: 2026-07-31T12:36:39\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: sk-SK\n"

--- a/locales/sk-SK/taoQti.rdf.po
+++ b/locales/sk-SK/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:07\n"
+"PO-Revision-Date: 2026-07-31T12:36:39\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: sk-SK\n"

--- a/locales/sv-SE/messages.po
+++ b/locales/sv-SE/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:09\n"
+"PO-Revision-Date: 2026-07-31T12:36:41\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: sv-SE\n"

--- a/locales/sv-SE/qtiItemRunner.rdf.po
+++ b/locales/sv-SE/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:09\n"
+"PO-Revision-Date: 2026-07-31T12:36:41\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: sv-SE\n"

--- a/locales/sv-SE/taoQti.rdf.po
+++ b/locales/sv-SE/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:09\n"
+"PO-Revision-Date: 2026-07-31T12:36:41\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: sv-SE\n"

--- a/locales/uk-UA/messages.po
+++ b/locales/uk-UA/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:11\n"
+"PO-Revision-Date: 2026-07-31T12:36:43\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: uk-UA\n"

--- a/locales/uk-UA/qtiItemRunner.rdf.po
+++ b/locales/uk-UA/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:11\n"
+"PO-Revision-Date: 2026-07-31T12:36:43\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: uk-UA\n"

--- a/locales/uk-UA/taoQti.rdf.po
+++ b/locales/uk-UA/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:11\n"
+"PO-Revision-Date: 2026-07-31T12:36:43\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: uk-UA\n"

--- a/locales/zh-CN/messages.po
+++ b/locales/zh-CN/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:13\n"
+"PO-Revision-Date: 2026-07-31T12:36:45\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-CN\n"

--- a/locales/zh-CN/qtiItemRunner.rdf.po
+++ b/locales/zh-CN/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:13\n"
+"PO-Revision-Date: 2026-07-31T12:36:45\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-CN\n"

--- a/locales/zh-CN/taoQti.rdf.po
+++ b/locales/zh-CN/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:13\n"
+"PO-Revision-Date: 2026-07-31T12:36:45\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-CN\n"

--- a/locales/zh-SG/messages.po
+++ b/locales/zh-SG/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:15\n"
+"PO-Revision-Date: 2026-07-31T12:36:47\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-SG\n"

--- a/locales/zh-SG/qtiItemRunner.rdf.po
+++ b/locales/zh-SG/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:15\n"
+"PO-Revision-Date: 2026-07-31T12:36:47\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-SG\n"

--- a/locales/zh-SG/taoQti.rdf.po
+++ b/locales/zh-SG/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:15\n"
+"PO-Revision-Date: 2026-07-31T12:36:47\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-SG\n"

--- a/locales/zh-TW/messages.po
+++ b/locales/zh-TW/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:17\n"
+"PO-Revision-Date: 2026-07-31T12:36:49\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-TW\n"

--- a/locales/zh-TW/qtiItemRunner.rdf.po
+++ b/locales/zh-TW/qtiItemRunner.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:17\n"
+"PO-Revision-Date: 2026-07-31T12:36:49\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-TW\n"

--- a/locales/zh-TW/taoQti.rdf.po
+++ b/locales/zh-TW/taoQti.rdf.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 2026.08 LTS\n"
-"PO-Revision-Date: 2026-07-31T09:47:17\n"
+"PO-Revision-Date: 2026-07-31T12:36:49\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: zh-TW\n"


### PR DESCRIPTION
## Summary
- Regenerates locale PO files via `taoTranslate` for NIV-253 after the multi-field scoring strategy landed on `develop`.
- Updates `PO-Revision-Date` across 159 locale files under `locales/`.

## Context
Follow-up translation refresh for [NIV-253](https://oat-sa.atlassian.net/browse/NIV-253) on top of the merged multi-field scoring strategy work.

## Test plan
- [ ] Confirm only locale PO metadata/date updates are present (no unintended string churn)
- [ ] Spot-check a few locales load correctly in authoring/runner
- [ ] No functional code changes expected in this PR

[NIV-253]: https://oat-sa.atlassian.net/browse/NIV-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ