### PR TITLE
fix: make release locale build input optional (NIV-253)

### DIFF
--- a/.github/workflows/release_tao_extension.yml
+++ b/.github/workflows/release_tao_extension.yml
@@ -27,7 +27,7 @@ on:
         default: auto
       build_locale:
         description: 'Locale build'
-        required: true
+        required: false
         type: choice
         options: [auto, yes, no]
         default: auto


### PR DESCRIPTION
# NIV-253 — Disable locale build requirement for release workflow

## Summary
- Makes the `build_locale` workflow_dispatch input optional in `release_tao_extension.yml`.
- Unblocks releasing after the failed `v32.10.0` locale compile (`tao` core missing locales like `de-AT` during `taoTranslate -a compile`).

## Context
Post-merge release for [#3081](https://github.com/oat-sa/extension-tao-itemqti/pull/3081) failed at **Compile translation JS bundles**:
`PO file '.../tao/locales/de-AT/messages.po' for extension 'tao' ... cannot be read`.

Root cause is in `tao-core` `TaoTranslate::actionCompile` dependency fallback when compiling extension-only locales.

## Test plan
- [ ] Confirm workflow YAML validates in GitHub Actions UI
- [ ] After merge, dispatch **Release Tao extension** with `build_locale=no` to publish the blocked release
- [ ] Confirm FE build still runs as expected (`build_fe=auto`)
- [ ] Follow-up: restore locale compile once `tao-core` compile fallback is fixed

## Risk
Temporary workaround — locale JS bundles will not be regenerated by release until locale build is re-enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Made the locale selection optional when manually starting a release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->